### PR TITLE
Theme playground + shiki-highlighted code blocks

### DIFF
--- a/app/(showcase)/[component]/page.tsx
+++ b/app/(showcase)/[component]/page.tsx
@@ -4,6 +4,8 @@ import { notFound } from "next/navigation"
 import type { Metadata } from "next"
 
 import { ComponentPage } from "@/components/showcase/component-page"
+import type { SourceFile } from "@/components/showcase/component-page"
+import { highlightCode, langFromPath } from "@/lib/highlight"
 import { REGISTRY, REGISTRY_BY_NAME } from "@/registry/sabk/registry-meta"
 
 export const dynamicParams = false
@@ -26,16 +28,22 @@ export async function generateMetadata({
   }
 }
 
-async function loadSource(files: string[] | undefined) {
-  const out: Record<string, string> = {}
+async function loadSource(
+  files: string[] | undefined
+): Promise<Record<string, SourceFile>> {
+  const out: Record<string, SourceFile> = {}
   if (!files) return out
   await Promise.all(
     files.map(async (f) => {
+      let code: string
       try {
-        out[f] = await fs.readFile(path.join(process.cwd(), f), "utf8")
+        code = await fs.readFile(path.join(process.cwd(), f), "utf8")
       } catch {
-        out[f] = "// (unable to read source)"
+        code = "// (unable to read source)"
       }
+      const lang = langFromPath(f)
+      const html = await highlightCode(code, lang)
+      out[f] = { code, html, lang }
     })
   )
   return out

--- a/app/(showcase)/blocks/[block]/page.tsx
+++ b/app/(showcase)/blocks/[block]/page.tsx
@@ -11,21 +11,21 @@ import { REGISTRY, REGISTRY_BY_NAME } from "@/registry/sabk/registry-meta"
 export const dynamicParams = false
 
 export function generateStaticParams() {
-  return REGISTRY.filter((entry) => entry.category !== "blocks").map(
-    (entry) => ({ component: entry.name })
+  return REGISTRY.filter((entry) => entry.category === "blocks").map(
+    (entry) => ({ block: entry.name })
   )
 }
 
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ component: string }>
+  params: Promise<{ block: string }>
 }): Promise<Metadata> {
-  const { component } = await params
-  const entry = REGISTRY_BY_NAME[component]
-  if (!entry || entry.category === "blocks") return {}
+  const { block } = await params
+  const entry = REGISTRY_BY_NAME[block]
+  if (!entry || entry.category !== "blocks") return {}
   return {
-    title: `${entry.title} — Sabk`,
+    title: `${entry.title} — Sabk blocks`,
     description: entry.description,
   }
 }
@@ -51,14 +51,14 @@ async function loadSource(
   return out
 }
 
-export default async function ComponentRoute({
+export default async function BlockRoute({
   params,
 }: {
-  params: Promise<{ component: string }>
+  params: Promise<{ block: string }>
 }) {
-  const { component } = await params
-  const entry = REGISTRY_BY_NAME[component]
-  if (!entry || entry.category === "blocks") notFound()
+  const { block } = await params
+  const entry = REGISTRY_BY_NAME[block]
+  if (!entry || entry.category !== "blocks") notFound()
   const source = await loadSource(entry.sourceFiles)
   return <ComponentPage entry={entry} source={source} />
 }

--- a/app/(showcase)/blocks/page.tsx
+++ b/app/(showcase)/blocks/page.tsx
@@ -1,0 +1,138 @@
+import Link from "next/link"
+import type { Metadata } from "next"
+import { ArrowRight } from "lucide-react"
+
+import {
+  BLOCK_KIND_LABELS,
+  BLOCK_KIND_ORDER,
+  BLOCKS_BY_KIND,
+  REGISTRY,
+} from "@/registry/sabk/registry-meta"
+
+export const metadata: Metadata = {
+  title: "Blocks — Sabk",
+  description:
+    "Top-tier, copy-into-your-repo section blocks — heroes, FAQs, CTAs and login screens that share the Sabk forge aesthetic.",
+}
+
+export default function BlocksIndex() {
+  const blockCount = REGISTRY.filter((r) => r.category === "blocks").length
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-6 py-12 md:px-10 md:py-16">
+      <header className="flex flex-col gap-5 border-b-2 border-border pb-10">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-forge">
+            ◆ blocks
+          </span>
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            section-level compositions
+          </span>
+        </div>
+        <h1 className="text-5xl font-semibold tracking-[-0.04em] md:text-6xl">
+          Blocks that compose, not decorate.
+        </h1>
+        <p className="max-w-2xl text-base text-muted-foreground">
+          Heroes, CTAs, FAQs and auth screens — built on top of the Sabk
+          component registry and the forge aesthetic. Copy a block in one
+          command, then shape it like any other source file in your repo.
+        </p>
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          {blockCount} blocks · {BLOCK_KIND_ORDER.length} categories · MIT
+        </p>
+      </header>
+
+      <nav className="flex flex-wrap gap-2 border-b-2 border-border pb-5">
+        {BLOCK_KIND_ORDER.map((kind) => {
+          const items = BLOCKS_BY_KIND[kind]
+          return (
+            <a
+              key={kind}
+              href={`#${kind}`}
+              className="inline-flex items-center gap-2 rounded-sm border-2 border-border bg-card px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:border-forge hover:text-foreground"
+            >
+              <span className="size-1 rounded-full bg-forge" />
+              {BLOCK_KIND_LABELS[kind]}
+              <span className="tabular-nums text-muted-foreground">
+                {items.length}
+              </span>
+            </a>
+          )
+        })}
+      </nav>
+
+      <div className="flex flex-col gap-20">
+        {BLOCK_KIND_ORDER.map((kind) => {
+          const items = BLOCKS_BY_KIND[kind]
+          if (!items.length) return null
+          return (
+            <section
+              key={kind}
+              id={kind}
+              className="flex flex-col gap-6 scroll-mt-12"
+            >
+              <div className="flex items-baseline justify-between">
+                <h2 className="font-mono text-xs uppercase tracking-[0.14em] text-muted-foreground">
+                  {BLOCK_KIND_LABELS[kind]}
+                </h2>
+                <span className="font-mono text-[10px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
+                  {items.length} variant{items.length === 1 ? "" : "s"}
+                </span>
+              </div>
+
+              <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
+                {items.map((entry) => {
+                  const Demo = entry.Demo
+                  return (
+                    <Link
+                      key={entry.name}
+                      href={`/blocks/${entry.name}`}
+                      className="group flex flex-col overflow-hidden rounded-sm border-2 border-border bg-background transition-colors hover:border-forge"
+                    >
+                      <div className="relative h-64 overflow-hidden border-b-2 border-border bg-card/40">
+                        {Demo && (
+                          <div
+                            className="pointer-events-none origin-top-left"
+                            style={{
+                              width: "200%",
+                              transform: "scale(0.5)",
+                            }}
+                          >
+                            <Demo />
+                          </div>
+                        )}
+                        <span
+                          aria-hidden
+                          className="pointer-events-none absolute inset-0 bg-gradient-to-t from-background/60 via-transparent to-transparent opacity-0 transition-opacity duration-200 group-hover:opacity-100"
+                        />
+                      </div>
+
+                      <div className="flex flex-col gap-2 p-5">
+                        <div className="flex items-center justify-between gap-2">
+                          <h3 className="text-base font-medium tracking-[-0.015em]">
+                            {entry.title}
+                          </h3>
+                          <span className="size-1.5 rounded-full bg-forge" />
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                          {entry.blockTagline ?? entry.description}
+                        </p>
+                        <div className="mt-2 flex items-center justify-between border-t-2 border-border pt-2.5 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+                          <span>/blocks/{entry.name}</span>
+                          <span className="inline-flex items-center gap-1 text-muted-foreground transition-colors group-hover:text-forge">
+                            view
+                            <ArrowRight className="size-3 transition-transform duration-150 ease-[var(--ease-forge)] group-hover:translate-x-0.5" />
+                          </span>
+                        </div>
+                      </div>
+                    </Link>
+                  )
+                })}
+              </div>
+            </section>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/app/(showcase)/blocks/page.tsx
+++ b/app/(showcase)/blocks/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link"
 import type { Metadata } from "next"
 import { ArrowRight } from "lucide-react"
 
+import { BlockPreview } from "@/components/showcase/block-preview"
 import {
   BLOCK_KIND_LABELS,
   BLOCK_KIND_ORDER,
@@ -19,8 +20,8 @@ export default function BlocksIndex() {
   const blockCount = REGISTRY.filter((r) => r.category === "blocks").length
 
   return (
-    <div className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-6 py-12 md:px-10 md:py-16">
-      <header className="flex flex-col gap-5 border-b-2 border-border pb-10">
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 py-10 sm:gap-12 sm:px-6 sm:py-12 md:px-10 md:py-16">
+      <header className="flex flex-col gap-5 border-b-2 border-border pb-8 sm:pb-10">
         <div className="flex flex-wrap items-center gap-2">
           <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-forge">
             ◆ blocks
@@ -29,7 +30,7 @@ export default function BlocksIndex() {
             section-level compositions
           </span>
         </div>
-        <h1 className="text-5xl font-semibold tracking-[-0.04em] md:text-6xl">
+        <h1 className="text-balance text-4xl font-semibold leading-[1.05] tracking-[-0.04em] sm:text-5xl md:text-6xl">
           Blocks that compose, not decorate.
         </h1>
         <p className="max-w-2xl text-base text-muted-foreground">
@@ -80,54 +81,37 @@ export default function BlocksIndex() {
                 </span>
               </div>
 
-              <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
-                {items.map((entry) => {
-                  const Demo = entry.Demo
-                  return (
-                    <Link
-                      key={entry.name}
-                      href={`/blocks/${entry.name}`}
-                      className="group flex flex-col overflow-hidden rounded-sm border-2 border-border bg-background transition-colors hover:border-forge"
-                    >
-                      <div className="relative h-64 overflow-hidden border-b-2 border-border bg-card/40">
-                        {Demo && (
-                          <div
-                            className="pointer-events-none origin-top-left"
-                            style={{
-                              width: "200%",
-                              transform: "scale(0.5)",
-                            }}
-                          >
-                            <Demo />
-                          </div>
-                        )}
-                        <span
-                          aria-hidden
-                          className="pointer-events-none absolute inset-0 bg-gradient-to-t from-background/60 via-transparent to-transparent opacity-0 transition-opacity duration-200 group-hover:opacity-100"
-                        />
-                      </div>
+              <div className="grid grid-cols-1 gap-6 sm:gap-8 lg:grid-cols-2">
+                {items.map((entry) => (
+                  <Link
+                    key={entry.name}
+                    href={`/blocks/${entry.name}`}
+                    className="group flex flex-col overflow-hidden rounded-sm border-2 border-border bg-background transition-colors hover:border-forge focus-visible:border-forge focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    <BlockPreview name={entry.name} title={entry.title} />
 
-                      <div className="flex flex-col gap-2 p-5">
-                        <div className="flex items-center justify-between gap-2">
-                          <h3 className="text-base font-medium tracking-[-0.015em]">
-                            {entry.title}
-                          </h3>
-                          <span className="size-1.5 rounded-full bg-forge" />
-                        </div>
-                        <p className="text-xs text-muted-foreground">
-                          {entry.blockTagline ?? entry.description}
-                        </p>
-                        <div className="mt-2 flex items-center justify-between border-t-2 border-border pt-2.5 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
-                          <span>/blocks/{entry.name}</span>
-                          <span className="inline-flex items-center gap-1 text-muted-foreground transition-colors group-hover:text-forge">
-                            view
-                            <ArrowRight className="size-3 transition-transform duration-150 ease-[var(--ease-forge)] group-hover:translate-x-0.5" />
-                          </span>
-                        </div>
+                    <div className="flex flex-col gap-2 p-4 sm:p-5">
+                      <div className="flex items-center justify-between gap-2">
+                        <h3 className="text-base font-medium tracking-[-0.015em]">
+                          {entry.title}
+                        </h3>
+                        <span className="size-1.5 shrink-0 rounded-full bg-forge" />
                       </div>
-                    </Link>
-                  )
-                })}
+                      <p className="text-xs text-muted-foreground">
+                        {entry.blockTagline ?? entry.description}
+                      </p>
+                      <div className="mt-2 flex items-center justify-between gap-2 border-t-2 border-border pt-2.5 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+                        <span className="truncate">
+                          /blocks/{entry.name}
+                        </span>
+                        <span className="inline-flex shrink-0 items-center gap-1 text-muted-foreground transition-colors group-hover:text-forge">
+                          view
+                          <ArrowRight className="size-3 transition-transform duration-150 ease-[var(--ease-forge)] group-hover:translate-x-0.5" />
+                        </span>
+                      </div>
+                    </div>
+                  </Link>
+                ))}
               </div>
             </section>
           )

--- a/app/(showcase)/layout.tsx
+++ b/app/(showcase)/layout.tsx
@@ -1,3 +1,4 @@
+import { MobileTopBar } from "@/components/showcase/mobile-nav"
 import { ShowcaseSidebar } from "@/components/showcase/sidebar"
 
 export default function ShowcaseLayout({
@@ -8,7 +9,10 @@ export default function ShowcaseLayout({
   return (
     <div className="flex min-h-svh">
       <ShowcaseSidebar />
-      <main className="flex-1 min-w-0">{children}</main>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <MobileTopBar />
+        <main className="min-w-0 flex-1">{children}</main>
+      </div>
     </div>
   )
 }

--- a/app/(showcase)/page.tsx
+++ b/app/(showcase)/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link"
 
+import { InlineCodeBlock } from "@/components/showcase/code-block"
 import { InstallBlock } from "@/components/showcase/install-block"
+import { highlightCode } from "@/lib/highlight"
 import {
   CATEGORY_LABELS,
   REGISTRY,
@@ -10,8 +12,18 @@ import {
 
 const ORDER: ComponentCategory[] = ["inputs", "pickers", "files"]
 
-export default function ShowcaseHome() {
+const DUAL_API_SNIPPET = `// Compound
+<MultiSelect.Root value={value} onValueChange={setValue} options={options}>
+  <MultiSelect.Trigger placeholder="Pick…" />
+  <MultiSelect.Content searchPlaceholder="Filter…" />
+</MultiSelect.Root>
+
+// Single-prop
+<MultiSelect options={options} value={value} onChange={setValue} />`
+
+export default async function ShowcaseHome() {
   const stableCount = REGISTRY.filter((r) => r.status === "stable").length
+  const dualApiHtml = await highlightCode(DUAL_API_SNIPPET, "tsx")
 
   return (
     <div className="mx-auto flex w-full max-w-4xl flex-col gap-12 px-6 py-12 md:px-10 md:py-16">
@@ -101,16 +113,7 @@ export default function ShowcaseHome() {
           composition, layout, or rendering. Single-prop is the convenience
           wrapper; ninety percent of usage looks like this.
         </p>
-        <pre className="overflow-x-auto rounded-sm border-2 border-border bg-card p-4 font-mono text-xs leading-relaxed">
-{`// Compound
-<MultiSelect.Root value={value} onValueChange={setValue} options={options}>
-  <MultiSelect.Trigger placeholder="Pick…" />
-  <MultiSelect.Content searchPlaceholder="Filter…" />
-</MultiSelect.Root>
-
-// Single-prop
-<MultiSelect options={options} value={value} onChange={setValue} />`}
-        </pre>
+        <InlineCodeBlock code={DUAL_API_SNIPPET} html={dualApiHtml} />
       </section>
     </div>
   )

--- a/app/(showcase)/page.tsx
+++ b/app/(showcase)/page.tsx
@@ -1,9 +1,12 @@
 import Link from "next/link"
+import { ArrowRight, LayoutTemplate } from "lucide-react"
 
 import { InlineCodeBlock } from "@/components/showcase/code-block"
 import { InstallBlock } from "@/components/showcase/install-block"
 import { highlightCode } from "@/lib/highlight"
 import {
+  BLOCK_KIND_LABELS,
+  BLOCK_KIND_ORDER,
   CATEGORY_LABELS,
   REGISTRY,
   REGISTRY_BY_CATEGORY,
@@ -101,6 +104,51 @@ export default async function ShowcaseHome() {
             </div>
           )
         })}
+      </section>
+
+      <section className="grid gap-4 border-t-2 border-border pt-8">
+        <div className="flex items-baseline justify-between">
+          <h2 className="font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground">
+            Blocks
+          </h2>
+          <Link
+            href="/blocks"
+            className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground transition-colors hover:text-forge"
+          >
+            view all
+            <ArrowRight className="size-3" />
+          </Link>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Section-level compositions built on top of the registry —
+          heroes, CTAs, FAQs and auth screens, in the same forge
+          aesthetic. Copy a block into your repo in one command.
+        </p>
+        <Link
+          href="/blocks"
+          className="group flex items-center justify-between gap-4 rounded-sm border-2 border-border bg-card p-4 transition-colors hover:border-forge"
+        >
+          <div className="flex items-center gap-4">
+            <span className="inline-flex size-10 items-center justify-center rounded-sm border-2 border-border bg-background">
+              <LayoutTemplate className="size-4 text-forge" />
+            </span>
+            <div className="flex flex-col gap-0.5">
+              <span className="text-sm font-medium">
+                {REGISTRY_BY_CATEGORY.blocks.length} top-tier blocks ·{" "}
+                {BLOCK_KIND_ORDER.length} categories
+              </span>
+              <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+                {BLOCK_KIND_ORDER.map(
+                  (k) => `${BLOCK_KIND_LABELS[k].toLowerCase()}`
+                ).join(" · ")}
+              </span>
+            </div>
+          </div>
+          <span className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground transition-colors group-hover:text-forge">
+            /blocks
+            <ArrowRight className="size-3 transition-transform duration-150 ease-[var(--ease-forge)] group-hover:translate-x-0.5" />
+          </span>
+        </Link>
       </section>
 
       <section className="grid gap-3 border-t-2 border-border pt-8">

--- a/app/(showcase)/page.tsx
+++ b/app/(showcase)/page.tsx
@@ -29,9 +29,9 @@ export default async function ShowcaseHome() {
   const dualApiHtml = await highlightCode(DUAL_API_SNIPPET, "tsx")
 
   return (
-    <div className="mx-auto flex w-full max-w-4xl flex-col gap-12 px-6 py-12 md:px-10 md:py-16">
-      <header className="flex flex-col gap-5 border-b-2 border-border pb-10">
-        <div className="flex items-center gap-2">
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-10 px-4 py-10 sm:gap-12 sm:px-6 sm:py-12 md:px-10 md:py-16">
+      <header className="flex flex-col gap-5 border-b-2 border-border pb-8 sm:pb-10">
+        <div className="flex flex-wrap items-center gap-2">
           <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-forge">
             ◆ sabk · v0.1
           </span>
@@ -39,7 +39,7 @@ export default async function ShowcaseHome() {
             peer of shadcn, not a replacement
           </span>
         </div>
-        <h1 className="text-5xl font-semibold tracking-[-0.04em] md:text-6xl">
+        <h1 className="text-balance text-4xl font-semibold leading-[1.05] tracking-[-0.04em] sm:text-5xl md:text-6xl">
           shadcn&apos;s missing pieces.
         </h1>
         <p className="max-w-2xl text-base text-muted-foreground">

--- a/app/(showcase)/theme/page.tsx
+++ b/app/(showcase)/theme/page.tsx
@@ -1,0 +1,11 @@
+import { ThemePlayground } from "./playground"
+
+export const metadata = {
+  title: "Theme playground — Sabk",
+  description:
+    "Preview every Sabk component against your own theme. Paste CSS variables, pick a preset, and see the registry render live.",
+}
+
+export default function ThemePage() {
+  return <ThemePlayground />
+}

--- a/app/(showcase)/theme/playground.tsx
+++ b/app/(showcase)/theme/playground.tsx
@@ -17,9 +17,9 @@ export function ThemePlayground() {
   const stable = REGISTRY.filter((r) => r.status === "stable")
 
   return (
-    <div className="mx-auto flex w-full max-w-5xl flex-col gap-10 px-6 py-12 md:px-10 md:py-14">
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 py-10 sm:gap-10 sm:px-6 sm:py-12 md:px-10 md:py-14">
       <header className="flex flex-col gap-5 border-b-2 border-border pb-8">
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-forge">
             ◆ playground
           </span>
@@ -27,7 +27,7 @@ export function ThemePlayground() {
             live theme preview
           </span>
         </div>
-        <h1 className="text-4xl font-semibold tracking-[-0.035em] md:text-5xl">
+        <h1 className="text-balance text-3xl font-semibold leading-[1.05] tracking-[-0.035em] sm:text-4xl md:text-5xl">
           Your theme, every component.
         </h1>
         <p className="max-w-2xl text-sm text-muted-foreground">

--- a/app/(showcase)/theme/playground.tsx
+++ b/app/(showcase)/theme/playground.tsx
@@ -1,0 +1,199 @@
+"use client"
+
+import * as React from "react"
+
+import { Button } from "@/registry/sabk/ui/button"
+import { Badge } from "@/registry/sabk/ui/badge"
+import { Input } from "@/registry/sabk/ui/input"
+import { Label } from "@/registry/sabk/ui/label"
+import { ThemeSheetTrigger } from "@/components/showcase/theme-sheet"
+import { useTheme } from "@/components/showcase/theme-provider"
+import { REGISTRY } from "@/registry/sabk/registry-meta"
+
+export function ThemePlayground() {
+  const { mode, theme } = useTheme()
+  const overrideCount =
+    Object.keys(theme.dark).length + Object.keys(theme.light).length
+  const stable = REGISTRY.filter((r) => r.status === "stable")
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-10 px-6 py-12 md:px-10 md:py-14">
+      <header className="flex flex-col gap-5 border-b-2 border-border pb-8">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-forge">
+            ◆ playground
+          </span>
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            live theme preview
+          </span>
+        </div>
+        <h1 className="text-4xl font-semibold tracking-[-0.035em] md:text-5xl">
+          Your theme, every component.
+        </h1>
+        <p className="max-w-2xl text-sm text-muted-foreground">
+          Paste a CSS variable block from your own app — or any shadcn theme
+          generator — and watch the entire Sabk registry re-skin. The active
+          theme is persisted in your browser; reset any time.
+        </p>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <ThemeSheetTrigger />
+          <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+            mode · {mode}
+          </span>
+          <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+            ·
+          </span>
+          <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+            {overrideCount} override{overrideCount === 1 ? "" : "s"} active
+          </span>
+        </div>
+      </header>
+
+      <Section
+        eyebrow="Surfaces"
+        title="Backgrounds & cards"
+        description="The three surface layers components stack on — background, card, popover. Borders read against each."
+      >
+        <div className="grid grid-cols-1 gap-px overflow-hidden rounded-sm border-2 border-border bg-border sm:grid-cols-3">
+          <Surface label="background" className="bg-background text-foreground" />
+          <Surface label="card" className="bg-card text-card-foreground" />
+          <Surface label="popover" className="bg-popover text-popover-foreground" />
+        </div>
+      </Section>
+
+      <Section
+        eyebrow="Primitives"
+        title="Buttons, badges, inputs"
+        description="The base shadcn primitives Sabk components compose on top of."
+      >
+        <div className="grid gap-6 rounded-sm border-2 border-border bg-card/40 p-6">
+          <div className="flex flex-wrap items-center gap-2">
+            <Button>Default</Button>
+            <Button variant="forge">Forge</Button>
+            <Button variant="secondary">Secondary</Button>
+            <Button variant="outline">Outline</Button>
+            <Button variant="ghost">Ghost</Button>
+            <Button variant="destructive">Destructive</Button>
+            <Button variant="link">Link</Button>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge>Default</Badge>
+            <Badge variant="forge">Forge</Badge>
+            <Badge variant="outline">Outline</Badge>
+            <Badge variant="destructive">Destructive</Badge>
+          </div>
+          <div className="grid max-w-md gap-2">
+            <Label htmlFor="theme-preview-input">Email</Label>
+            <Input
+              id="theme-preview-input"
+              placeholder="you@example.com"
+              defaultValue="hello@sabk.dev"
+            />
+            <p className="text-xs text-muted-foreground">
+              Muted foreground reads against background.
+            </p>
+          </div>
+        </div>
+      </Section>
+
+      <Section
+        eyebrow="Registry"
+        title="Sabk components"
+        description="Every stable component re-renders against the active theme. Edit it and watch them all update at once."
+      >
+        <div className="grid grid-cols-1 gap-px overflow-hidden rounded-sm border-2 border-border bg-border lg:grid-cols-2">
+          {stable.map((entry) => {
+            const Demo = entry.Demo
+            if (!Demo) return null
+            return (
+              <article
+                key={entry.name}
+                className="flex flex-col gap-4 bg-card p-6"
+              >
+                <div className="flex items-baseline justify-between gap-3">
+                  <h3 className="text-sm font-medium tracking-[-0.01em]">
+                    {entry.title}
+                  </h3>
+                  <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground">
+                    /{entry.name}
+                  </span>
+                </div>
+                <div className="flex min-h-[160px] items-center justify-center rounded-sm border-2 border-dashed border-border bg-background/60 p-4">
+                  <Demo />
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      </Section>
+
+      <Section
+        eyebrow="Accent"
+        title="Forge, ring, destructive"
+        description="The accents that should only ever appear when something is important. They borrow the ring color for focus states."
+      >
+        <div className="flex flex-wrap items-center gap-3 rounded-sm border-2 border-border bg-card/40 p-6">
+          <Swatch label="forge" varName="--forge" />
+          <Swatch label="ring" varName="--ring" />
+          <Swatch label="destructive" varName="--destructive" />
+          <Swatch label="primary" varName="--primary" />
+          <Swatch label="muted" varName="--muted" />
+          <Swatch label="border" varName="--border" />
+        </div>
+      </Section>
+    </div>
+  )
+}
+
+function Section({
+  eyebrow,
+  title,
+  description,
+  children,
+}: {
+  eyebrow: string
+  title: string
+  description: string
+  children: React.ReactNode
+}) {
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+          {eyebrow}
+        </span>
+        <h2 className="text-xl font-semibold tracking-[-0.02em]">{title}</h2>
+        <p className="max-w-2xl text-xs text-muted-foreground">{description}</p>
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function Surface({ label, className }: { label: string; className: string }) {
+  return (
+    <div className={`flex flex-col gap-1 p-5 ${className}`}>
+      <span className="font-mono text-[10px] uppercase tracking-[0.1em] opacity-70">
+        --{label}
+      </span>
+      <span className="text-sm">Aa · the quick brown fox</span>
+      <span className="text-xs opacity-60">Muted line of secondary copy.</span>
+    </div>
+  )
+}
+
+function Swatch({ label, varName }: { label: string; varName: string }) {
+  return (
+    <div className="inline-flex items-center gap-2 rounded-sm border-2 border-border bg-background px-2.5 py-1.5">
+      <span
+        aria-hidden
+        className="size-4 rounded-sm border-2 border-border"
+        style={{ background: `var(${varName})` }}
+      />
+      <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+        {label}
+      </span>
+    </div>
+  )
+}

--- a/app/embed/blocks/[block]/page.tsx
+++ b/app/embed/blocks/[block]/page.tsx
@@ -1,0 +1,30 @@
+import { notFound } from "next/navigation"
+import type { Metadata } from "next"
+
+import { REGISTRY, REGISTRY_BY_NAME } from "@/registry/sabk/registry-meta"
+
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return REGISTRY.filter((entry) => entry.category === "blocks").map(
+    (entry) => ({ block: entry.name })
+  )
+}
+
+export const metadata: Metadata = { robots: { index: false } }
+
+export default async function BlockEmbedRoute({
+  params,
+}: {
+  params: Promise<{ block: string }>
+}) {
+  const { block } = await params
+  const entry = REGISTRY_BY_NAME[block]
+  if (!entry || entry.category !== "blocks" || !entry.Demo) notFound()
+  const Demo = entry.Demo
+  return (
+    <div className="min-h-svh bg-background">
+      <Demo />
+    </div>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -122,6 +122,37 @@
   --sidebar-accent-foreground: oklch(0.20 0.006 60);
 }
 
+/* shiki dual-theme: defaultColor=dark means the inline color/bg are dark
+   values; --shiki-light + --shiki-light-bg are CSS vars. Override them in
+   .light to swap. */
+.shiki {
+  background-color: var(--card) !important;
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+  font-size: 12px;
+  line-height: 1.65;
+  padding: 14px 16px;
+  tab-size: 2;
+}
+.shiki code {
+  display: block;
+  background: transparent !important;
+  counter-reset: line;
+}
+.shiki .line {
+  display: block;
+  min-height: 1lh;
+}
+html.light .shiki {
+  background-color: var(--shiki-light-bg) !important;
+  color: var(--shiki-light) !important;
+}
+html.light .shiki span {
+  color: var(--shiki-light) !important;
+  font-style: var(--shiki-light-font-style, inherit) !important;
+  font-weight: var(--shiki-light-font-weight, inherit) !important;
+  text-decoration: var(--shiki-light-text-decoration, inherit) !important;
+}
+
 @layer base {
   * {
     border-color: var(--border);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,9 @@ import type { Metadata } from "next"
 import { Geist, Geist_Mono } from "next/font/google"
 import "./globals.css"
 
+import { ThemeProvider } from "@/components/showcase/theme-provider"
+import { themePrehydrationScript } from "@/lib/theme"
+
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
@@ -25,10 +28,15 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{ __html: themePrehydrationScript() }}
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <ThemeProvider>{children}</ThemeProvider>
       </body>
     </html>
   )

--- a/components/showcase/block-preview.tsx
+++ b/components/showcase/block-preview.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import * as React from "react"
+
+/**
+ * Renders a block in an iframe sized to a fixed simulated viewport,
+ * then scale-transforms it to fit the parent card. A ResizeObserver
+ * keeps the scale in sync with the container so the preview reads as
+ * a faithful, in-card miniature of the desktop layout.
+ */
+export function BlockPreview({
+  name,
+  title,
+  /** Simulated viewport the iframe should render at. */
+  simWidth = 1280,
+  /** Iframe height — chosen with simWidth to fix the preview aspect ratio. */
+  simHeight = 720,
+}: {
+  name: string
+  title: string
+  simWidth?: number
+  simHeight?: number
+}) {
+  const ref = React.useRef<HTMLDivElement>(null)
+  const [scale, setScale] = React.useState(0.5)
+
+  React.useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width ?? 0
+      if (w > 0) setScale(w / simWidth)
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [simWidth])
+
+  return (
+    <div
+      ref={ref}
+      className="relative w-full overflow-hidden border-b-2 border-border bg-card/30"
+      style={{ aspectRatio: `${simWidth} / ${simHeight}` }}
+    >
+      <iframe
+        src={`/embed/blocks/${name}`}
+        title={`${title} preview`}
+        loading="lazy"
+        tabIndex={-1}
+        aria-hidden
+        className="pointer-events-none absolute left-0 top-0 origin-top-left border-0"
+        style={{
+          width: `${simWidth}px`,
+          height: `${simHeight}px`,
+          transform: `scale(${scale})`,
+        }}
+      />
+    </div>
+  )
+}

--- a/components/showcase/block-viewer.tsx
+++ b/components/showcase/block-viewer.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import * as React from "react"
+import { ExternalLink, Maximize2, Monitor, Smartphone, Tablet } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+type Viewport = "mobile" | "tablet" | "desktop"
+
+const SIZES: Record<Viewport, { width: number; label: string }> = {
+  mobile: { width: 380, label: "Mobile" },
+  tablet: { width: 768, label: "Tablet" },
+  desktop: { width: 0, label: "Desktop" },
+}
+
+const ICONS: Record<Viewport, React.ComponentType<{ className?: string }>> = {
+  mobile: Smartphone,
+  tablet: Tablet,
+  desktop: Monitor,
+}
+
+const ORDER: Viewport[] = ["mobile", "tablet", "desktop"]
+
+export function BlockViewer({
+  name,
+  title,
+  minHeight = 800,
+}: {
+  name: string
+  title: string
+  minHeight?: number
+}) {
+  const [viewport, setViewport] = React.useState<Viewport>("desktop")
+  const [key, setKey] = React.useState(0)
+
+  const sizing =
+    viewport === "desktop"
+      ? { width: "100%", maxWidth: "100%" }
+      : { width: `${SIZES[viewport].width}px`, maxWidth: "100%" }
+
+  return (
+    <div
+      data-slot="block-viewer"
+      className="overflow-hidden rounded-sm border-2 border-border bg-background"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b-2 border-border bg-card/50 px-3 py-2">
+        <div
+          role="tablist"
+          aria-label="Preview viewport"
+          className="flex items-center gap-0.5 rounded-sm border-2 border-border bg-background p-0.5"
+        >
+          {ORDER.map((v) => {
+            const Icon = ICONS[v]
+            const active = viewport === v
+            return (
+              <button
+                key={v}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                aria-label={`${SIZES[v].label} viewport${
+                  v === "desktop" ? "" : ` (${SIZES[v].width}px)`
+                }`}
+                onClick={() => setViewport(v)}
+                className={cn(
+                  "inline-flex h-6 items-center gap-1.5 rounded-[2px] px-2 font-mono text-[10px] uppercase tracking-[0.1em] transition-colors",
+                  active
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                <Icon className="size-3" />
+                <span className="hidden sm:inline">{SIZES[v].label}</span>
+                {v !== "desktop" && active && (
+                  <span className="tabular-nums text-muted-foreground">
+                    {SIZES[v].width}
+                  </span>
+                )}
+              </button>
+            )
+          })}
+        </div>
+
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setKey((k) => k + 1)}
+            aria-label="Refresh preview"
+            className="inline-flex size-7 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <Maximize2 className="size-3.5 -rotate-45" />
+          </button>
+          <a
+            href={`/embed/blocks/${name}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Open preview in new tab"
+            className="inline-flex size-7 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <ExternalLink className="size-3.5" />
+          </a>
+        </div>
+      </div>
+
+      <div className="flex justify-center overflow-x-auto bg-card/20 p-3 sm:p-4">
+        <iframe
+          key={key}
+          src={`/embed/blocks/${name}`}
+          title={`${title} preview`}
+          loading="lazy"
+          className="block border-0 bg-background transition-[width,max-width] duration-300 ease-[var(--ease-forge)]"
+          style={{ ...sizing, height: minHeight }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/components/showcase/code-block.tsx
+++ b/components/showcase/code-block.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import * as React from "react"
+import { Check, Copy } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+export type CodeBlockTab = {
+  /** Tab label (e.g. filename). */
+  label: string
+  /** Raw source — used for copy + clipboard. */
+  code: string
+  /** Pre-highlighted shiki HTML for `code`. */
+  html: string
+}
+
+export function CodeBlock({
+  tabs,
+  defaultTab,
+  className,
+  maxHeight = "max-h-[640px]",
+}: {
+  tabs: CodeBlockTab[]
+  defaultTab?: string
+  className?: string
+  /** Tailwind max-h class for the scroll area. */
+  maxHeight?: string
+}) {
+  const [active, setActive] = React.useState(
+    () => defaultTab ?? tabs[0]?.label
+  )
+  const current = tabs.find((t) => t.label === active) ?? tabs[0]
+
+  if (!current) return null
+
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-sm border-2 border-border",
+        className
+      )}
+    >
+      <div className="flex items-center justify-between gap-2 border-b-2 border-border bg-card px-2 py-1.5">
+        <div className="flex items-center gap-1 overflow-x-auto">
+          {tabs.map((t) => (
+            <button
+              key={t.label}
+              type="button"
+              onClick={() => setActive(t.label)}
+              className={cn(
+                "rounded-sm px-2 py-1 font-mono text-[10px] uppercase tracking-[0.08em] transition-colors",
+                active === t.label
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {t.label.split("/").slice(-1)[0]}
+            </button>
+          ))}
+        </div>
+        <CopyButton text={current.code} />
+      </div>
+      <div
+        className={cn("shiki-scroll overflow-auto", maxHeight)}
+        dangerouslySetInnerHTML={{ __html: current.html }}
+      />
+    </div>
+  )
+}
+
+export function InlineCodeBlock({
+  html,
+  code,
+  className,
+  maxHeight = "max-h-[640px]",
+}: {
+  html: string
+  code: string
+  className?: string
+  maxHeight?: string
+}) {
+  return (
+    <div
+      className={cn(
+        "group relative overflow-hidden rounded-sm border-2 border-border",
+        className
+      )}
+    >
+      <CopyButton
+        text={code}
+        className="absolute right-2 top-2 z-10 opacity-0 transition-opacity group-hover:opacity-100"
+      />
+      <div
+        className={cn("shiki-scroll overflow-auto", maxHeight)}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </div>
+  )
+}
+
+function CopyButton({
+  text,
+  className,
+}: {
+  text: string
+  className?: string
+}) {
+  const [copied, setCopied] = React.useState(false)
+  return (
+    <button
+      type="button"
+      aria-label="Copy code"
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(text)
+          setCopied(true)
+          setTimeout(() => setCopied(false), 1400)
+        } catch {
+          // ignore
+        }
+      }}
+      className={cn(
+        "inline-flex size-7 shrink-0 items-center justify-center rounded-sm border-2 border-transparent text-muted-foreground transition-colors hover:border-border hover:text-foreground",
+        className
+      )}
+    >
+      {copied ? (
+        <Check className="size-3.5 text-forge" />
+      ) : (
+        <Copy className="size-3.5" />
+      )}
+    </button>
+  )
+}

--- a/components/showcase/component-page.tsx
+++ b/components/showcase/component-page.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
+import { BlockViewer } from "@/components/showcase/block-viewer"
 import { CodeBlock, type CodeBlockTab } from "@/components/showcase/code-block"
 import { InstallBlock } from "@/components/showcase/install-block"
 import type { RegistryEntryMeta } from "@/registry/sabk/registry-meta"
@@ -43,22 +44,32 @@ export function ComponentPage({
   return (
     <div
       className={cn(
-        "mx-auto flex w-full flex-col gap-8 px-6 py-10 md:px-10",
+        "mx-auto flex w-full flex-col gap-6 px-4 py-8 sm:gap-8 sm:px-6 sm:py-10 md:px-10",
         isBlock ? "max-w-6xl" : "max-w-4xl"
       )}
     >
       <header className="flex flex-col gap-3 border-b-2 border-border pb-6">
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
             {entry.category}
           </span>
+          {entry.blockKind && (
+            <>
+              <span className="font-mono text-[10px] text-muted-foreground">
+                ·
+              </span>
+              <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-forge">
+                {entry.blockKind}
+              </span>
+            </>
+          )}
           {entry.status === "planned" && (
             <span className="rounded-sm border-2 border-border px-1.5 py-0 font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
               planned
             </span>
           )}
         </div>
-        <h1 className="text-4xl font-semibold tracking-[-0.035em]">
+        <h1 className="text-3xl font-semibold tracking-[-0.035em] sm:text-4xl">
           {entry.title}
         </h1>
         <p className="max-w-2xl text-sm text-muted-foreground">
@@ -80,7 +91,11 @@ export function ComponentPage({
         </div>
       ) : (
         <>
-          <div className="flex items-center gap-1 border-b-2 border-border">
+          <div
+            role="tablist"
+            aria-label="View"
+            className="-mx-4 flex items-center gap-0 overflow-x-auto border-b-2 border-border px-4 sm:mx-0 sm:px-0"
+          >
             {(
               [
                 ["preview", "Preview"],
@@ -91,9 +106,11 @@ export function ComponentPage({
               <button
                 key={k}
                 type="button"
+                role="tab"
+                aria-selected={tab === k}
                 onClick={() => setTab(k)}
                 className={cn(
-                  "relative -mb-[2px] px-3 py-2 font-mono text-[11px] uppercase tracking-[0.1em] transition-colors",
+                  "relative -mb-[2px] shrink-0 px-3 py-2 font-mono text-[11px] uppercase tracking-[0.1em] transition-colors focus-visible:outline-none focus-visible:text-foreground",
                   tab === k
                     ? "text-foreground"
                     : "text-muted-foreground hover:text-foreground"
@@ -107,28 +124,15 @@ export function ComponentPage({
             ))}
           </div>
 
-          {tab === "preview" && Demo && (
-            isBlock ? (
-              <div className="overflow-hidden rounded-sm border-2 border-border bg-background">
-                <div className="flex items-center justify-between gap-3 border-b-2 border-border bg-card/50 px-4 py-2">
-                  <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-                    full-width preview
-                  </span>
-                  <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-                    <span className="size-1.5 rounded-full bg-forge" />
-                    rendered in-page
-                  </span>
-                </div>
-                <div className="relative">
-                  <Demo />
-                </div>
-              </div>
+          {tab === "preview" &&
+            Demo &&
+            (isBlock ? (
+              <BlockViewer name={entry.name} title={entry.title} />
             ) : (
-              <div className="flex min-h-[420px] items-center justify-center rounded-sm border-2 border-border bg-card/40 p-10">
+              <div className="flex min-h-[360px] items-center justify-center rounded-sm border-2 border-border bg-card/40 p-6 sm:min-h-[420px] sm:p-8 md:p-10">
                 <Demo />
               </div>
-            )
-          )}
+            ))}
 
           {tab === "code" && codeTabs.length > 0 && (
             <CodeBlock tabs={codeTabs} />

--- a/components/showcase/component-page.tsx
+++ b/components/showcase/component-page.tsx
@@ -38,9 +38,15 @@ export function ComponentPage({
   )
 
   const Demo = entry.Demo
+  const isBlock = entry.category === "blocks"
 
   return (
-    <div className="mx-auto flex w-full max-w-4xl flex-col gap-8 px-6 py-10 md:px-10">
+    <div
+      className={cn(
+        "mx-auto flex w-full flex-col gap-8 px-6 py-10 md:px-10",
+        isBlock ? "max-w-6xl" : "max-w-4xl"
+      )}
+    >
       <header className="flex flex-col gap-3 border-b-2 border-border pb-6">
         <div className="flex items-center gap-2">
           <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
@@ -102,9 +108,26 @@ export function ComponentPage({
           </div>
 
           {tab === "preview" && Demo && (
-            <div className="flex min-h-[420px] items-center justify-center rounded-sm border-2 border-border bg-card/40 p-10">
-              <Demo />
-            </div>
+            isBlock ? (
+              <div className="overflow-hidden rounded-sm border-2 border-border bg-background">
+                <div className="flex items-center justify-between gap-3 border-b-2 border-border bg-card/50 px-4 py-2">
+                  <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                    full-width preview
+                  </span>
+                  <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                    <span className="size-1.5 rounded-full bg-forge" />
+                    rendered in-page
+                  </span>
+                </div>
+                <div className="relative">
+                  <Demo />
+                </div>
+              </div>
+            ) : (
+              <div className="flex min-h-[420px] items-center justify-center rounded-sm border-2 border-border bg-card/40 p-10">
+                <Demo />
+              </div>
+            )
           )}
 
           {tab === "code" && codeTabs.length > 0 && (

--- a/components/showcase/component-page.tsx
+++ b/components/showcase/component-page.tsx
@@ -3,22 +3,38 @@
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
+import { CodeBlock, type CodeBlockTab } from "@/components/showcase/code-block"
 import { InstallBlock } from "@/components/showcase/install-block"
 import type { RegistryEntryMeta } from "@/registry/sabk/registry-meta"
 
 type Tab = "preview" | "code" | "install"
+
+export type SourceFile = {
+  code: string
+  html: string
+  lang: string
+}
 
 export function ComponentPage({
   entry,
   source,
 }: {
   entry: RegistryEntryMeta
-  /** Pre-loaded file contents (path → string) for the Code tab. */
-  source: Record<string, string>
+  /** Pre-highlighted source files keyed by repo-relative path. */
+  source: Record<string, SourceFile>
 }) {
   const [tab, setTab] = React.useState<Tab>("preview")
-  const [activeFile, setActiveFile] = React.useState<string | undefined>(
-    entry.sourceFiles?.[0]
+
+  const codeTabs: CodeBlockTab[] = React.useMemo(
+    () =>
+      (entry.sourceFiles ?? [])
+        .map((f) => {
+          const file = source[f]
+          if (!file) return null
+          return { label: f, code: file.code, html: file.html }
+        })
+        .filter((t): t is CodeBlockTab => t !== null),
+    [entry.sourceFiles, source]
   )
 
   const Demo = entry.Demo
@@ -91,31 +107,8 @@ export function ComponentPage({
             </div>
           )}
 
-          {tab === "code" && entry.sourceFiles && (
-            <div className="overflow-hidden rounded-sm border-2 border-border">
-              <div className="flex items-center gap-2 border-b-2 border-border bg-card px-3 py-1.5">
-                {entry.sourceFiles.map((f) => (
-                  <button
-                    key={f}
-                    type="button"
-                    onClick={() => setActiveFile(f)}
-                    className={cn(
-                      "rounded-sm px-2 py-1 font-mono text-[10px] uppercase tracking-[0.08em] transition-colors",
-                      activeFile === f
-                        ? "bg-accent text-foreground"
-                        : "text-muted-foreground hover:text-foreground"
-                    )}
-                  >
-                    {f.split("/").slice(-1)[0]}
-                  </button>
-                ))}
-              </div>
-              <pre className="max-h-[640px] overflow-auto bg-card p-4 text-xs leading-relaxed">
-                <code className="font-mono">
-                  {activeFile ? (source[activeFile] ?? "// (missing)") : ""}
-                </code>
-              </pre>
-            </div>
+          {tab === "code" && codeTabs.length > 0 && (
+            <CodeBlock tabs={codeTabs} />
           )}
 
           {tab === "install" && (

--- a/components/showcase/install-block.tsx
+++ b/components/showcase/install-block.tsx
@@ -23,7 +23,8 @@ export function InstallBlock({
     }
   }, [])
 
-  const command = `npx shadcn@latest add ${origin || "https://sabk.dev"}/r/${name}.json`
+  const base = origin || "https://sabk.dev"
+  const command = `npx shadcn@latest add ${base}/r/${name}.json`
 
   const onCopy = async () => {
     await navigator.clipboard.writeText(command)
@@ -42,7 +43,10 @@ export function InstallBlock({
         $
       </span>
       <code className="flex-1 overflow-x-auto whitespace-nowrap font-mono text-xs text-foreground">
-        {command}
+        <span className="text-muted-foreground">npx</span>{" "}
+        <span className="text-foreground">shadcn@latest</span>{" "}
+        <span className="text-muted-foreground">add</span>{" "}
+        <span className="text-forge">{base}/r/{name}.json</span>
       </code>
       <button
         type="button"

--- a/components/showcase/mobile-nav.tsx
+++ b/components/showcase/mobile-nav.tsx
@@ -1,0 +1,161 @@
+"use client"
+
+import * as React from "react"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { LayoutTemplate, Menu, Sparkles } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import {
+  Sheet,
+  SheetContent,
+  SheetTrigger,
+} from "@/registry/sabk/ui/sheet"
+import { ThemeSheetTrigger } from "@/components/showcase/theme-sheet"
+import {
+  CATEGORY_LABELS,
+  REGISTRY_BY_CATEGORY,
+  type ComponentCategory,
+} from "@/registry/sabk/registry-meta"
+
+const ORDER: ComponentCategory[] = ["inputs", "pickers", "files"]
+
+export function MobileTopBar() {
+  const [open, setOpen] = React.useState(false)
+  const pathname = usePathname()
+
+  React.useEffect(() => {
+    setOpen(false)
+  }, [pathname])
+
+  return (
+    <header className="sticky top-0 z-40 flex h-14 items-center justify-between gap-3 border-b-2 border-border bg-background/90 px-4 backdrop-blur-md md:hidden">
+      <Link href="/" className="flex items-baseline gap-2">
+        <span className="text-base font-semibold tracking-[-0.04em]">
+          sabk
+        </span>
+        <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-forge">
+          ◆ forge
+        </span>
+      </Link>
+
+      <div className="flex items-center gap-1.5">
+        <ThemeSheetTrigger />
+        <Sheet open={open} onOpenChange={setOpen}>
+          <SheetTrigger asChild>
+            <button
+              type="button"
+              aria-label="Open navigation"
+              className="inline-flex size-9 items-center justify-center rounded-sm border-2 border-border bg-card text-foreground transition-colors hover:border-forge hover:text-forge focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <Menu className="size-4" />
+            </button>
+          </SheetTrigger>
+          <SheetContent
+            side="left"
+            className="w-72 max-w-[85vw] p-0 sm:max-w-[85vw]"
+          >
+            <MobileNavBody />
+          </SheetContent>
+        </Sheet>
+      </div>
+    </header>
+  )
+}
+
+function MobileNavBody() {
+  const blockCount = REGISTRY_BY_CATEGORY.blocks.length
+  return (
+    <div className="flex h-full flex-col bg-sidebar text-sidebar-foreground">
+      <div className="border-b-2 border-sidebar-border px-5 py-4">
+        <div className="flex items-baseline gap-2">
+          <span className="text-lg font-semibold tracking-[-0.04em]">
+            sabk
+          </span>
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-forge">
+            ◆ forge
+          </span>
+        </div>
+        <p className="mt-0.5 font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+          shadcn&apos;s missing pieces
+        </p>
+      </div>
+
+      <nav className="flex-1 overflow-y-auto px-2 py-4">
+        <div className="mb-5">
+          <div className="px-3 pb-2 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            Workspace
+          </div>
+          <ul className="flex flex-col">
+            <li>
+              <Link
+                href="/theme"
+                className={cn(
+                  "group flex items-center justify-between rounded-sm px-3 py-2 text-sm transition-colors",
+                  "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                )}
+              >
+                <span className="inline-flex items-center gap-2 truncate">
+                  <Sparkles className="size-3.5 text-forge" />
+                  Theme playground
+                </span>
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/blocks"
+                className={cn(
+                  "group flex items-center justify-between rounded-sm px-3 py-2 text-sm transition-colors",
+                  "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                )}
+              >
+                <span className="inline-flex items-center gap-2 truncate">
+                  <LayoutTemplate className="size-3.5 text-forge" />
+                  Blocks
+                </span>
+                <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground">
+                  {blockCount}
+                </span>
+              </Link>
+            </li>
+          </ul>
+        </div>
+
+        {ORDER.map((cat) => {
+          const items = REGISTRY_BY_CATEGORY[cat]
+          if (!items.length) return null
+          return (
+            <div key={cat} className="mb-5">
+              <div className="px-3 pb-2 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                {CATEGORY_LABELS[cat]}
+              </div>
+              <ul className="flex flex-col">
+                {items.map((entry) => (
+                  <li key={entry.name}>
+                    <Link
+                      href={`/${entry.name}`}
+                      className="group flex items-center justify-between rounded-sm px-3 py-2 text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                    >
+                      <span className="truncate">{entry.title}</span>
+                      {entry.status === "planned" && (
+                        <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground">
+                          soon
+                        </span>
+                      )}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )
+        })}
+      </nav>
+
+      <div className="border-t-2 border-sidebar-border px-5 py-3">
+        <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+          v0.1 · peer of shadcn
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/components/showcase/sidebar.tsx
+++ b/components/showcase/sidebar.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link"
-import { Sparkles } from "lucide-react"
+import { Sparkles, LayoutTemplate } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { ThemeSheetTrigger } from "@/components/showcase/theme-sheet"
@@ -11,6 +11,7 @@ import {
 
 export function ShowcaseSidebar({ active }: { active?: string }) {
   const order: ComponentCategory[] = ["inputs", "pickers", "files"]
+  const blockCount = REGISTRY_BY_CATEGORY.blocks.length
 
   return (
     <aside className="sticky top-0 hidden h-svh w-60 shrink-0 flex-col border-r-2 border-sidebar-border bg-sidebar text-sidebar-foreground md:flex">
@@ -51,6 +52,25 @@ export function ShowcaseSidebar({ active }: { active?: string }) {
                 {active === "theme" && (
                   <span className="size-1.5 rounded-full bg-forge" />
                 )}
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/blocks"
+                className={cn(
+                  "group flex items-center justify-between rounded-sm px-3 py-1.5 text-sm transition-colors",
+                  "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+                  active === "blocks" &&
+                    "bg-sidebar-accent text-sidebar-accent-foreground"
+                )}
+              >
+                <span className="inline-flex items-center gap-2 truncate">
+                  <LayoutTemplate className="size-3.5 text-forge" />
+                  Blocks
+                </span>
+                <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground">
+                  {blockCount}
+                </span>
               </Link>
             </li>
           </ul>

--- a/components/showcase/sidebar.tsx
+++ b/components/showcase/sidebar.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link"
+import { Sparkles } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { ThemeSheetTrigger } from "@/components/showcase/theme-sheet"
 import {
   CATEGORY_LABELS,
   REGISTRY_BY_CATEGORY,
@@ -27,6 +29,33 @@ export function ShowcaseSidebar({ active }: { active?: string }) {
       </Link>
 
       <nav className="flex-1 overflow-y-auto px-2 py-4">
+        <div className="mb-5">
+          <div className="px-3 pb-2 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            Workspace
+          </div>
+          <ul className="flex flex-col">
+            <li>
+              <Link
+                href="/theme"
+                className={cn(
+                  "group flex items-center justify-between rounded-sm px-3 py-1.5 text-sm transition-colors",
+                  "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+                  active === "theme" &&
+                    "bg-sidebar-accent text-sidebar-accent-foreground"
+                )}
+              >
+                <span className="inline-flex items-center gap-2 truncate">
+                  <Sparkles className="size-3.5 text-forge" />
+                  Theme playground
+                </span>
+                {active === "theme" && (
+                  <span className="size-1.5 rounded-full bg-forge" />
+                )}
+              </Link>
+            </li>
+          </ul>
+        </div>
+
         {order.map((cat) => {
           const items = REGISTRY_BY_CATEGORY[cat]
           if (!items.length) return null
@@ -68,8 +97,11 @@ export function ShowcaseSidebar({ active }: { active?: string }) {
         })}
       </nav>
 
-      <div className="border-t-2 border-sidebar-border px-5 py-3 font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
-        v0.1 · peer of shadcn
+      <div className="flex items-center justify-between gap-2 border-t-2 border-sidebar-border px-3 py-3">
+        <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+          v0.1 · peer of shadcn
+        </span>
+        <ThemeSheetTrigger />
       </div>
     </aside>
   )

--- a/components/showcase/theme-provider.tsx
+++ b/components/showcase/theme-provider.tsx
@@ -1,0 +1,120 @@
+"use client"
+
+import * as React from "react"
+
+import {
+  MODE_STORAGE_KEY,
+  STORAGE_KEY,
+  type Theme,
+  type ThemeMode,
+  type ThemeTokens,
+} from "@/lib/theme"
+
+type ThemeContextValue = {
+  mode: ThemeMode
+  setMode: (mode: ThemeMode) => void
+  theme: Theme
+  setTokens: (mode: ThemeMode, tokens: ThemeTokens) => void
+  mergeTheme: (partial: Partial<Theme>) => void
+  reset: () => void
+}
+
+const EMPTY_THEME: Theme = { light: {}, dark: {} }
+
+const ThemeContext = React.createContext<ThemeContextValue | null>(null)
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  // Mode is read synchronously after mount; the pre-hydration script handles
+  // the first paint, so this just brings React state in sync.
+  const [mode, setModeState] = React.useState<ThemeMode>("dark")
+  const [theme, setTheme] = React.useState<Theme>(EMPTY_THEME)
+
+  // Sync from storage once on mount.
+  React.useEffect(() => {
+    try {
+      const storedMode = localStorage.getItem(MODE_STORAGE_KEY)
+      if (storedMode === "light" || storedMode === "dark") {
+        setModeState(storedMode)
+      } else if (document.documentElement.classList.contains("light")) {
+        setModeState("light")
+      }
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored) {
+        const parsed = JSON.parse(stored) as Theme
+        setTheme({
+          light: parsed.light ?? {},
+          dark: parsed.dark ?? {},
+        })
+      }
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  // Apply mode class.
+  React.useEffect(() => {
+    const html = document.documentElement
+    if (mode === "light") html.classList.add("light")
+    else html.classList.remove("light")
+    try {
+      localStorage.setItem(MODE_STORAGE_KEY, mode)
+    } catch {
+      // ignore
+    }
+  }, [mode])
+
+  // Apply tokens for the active mode. Clearing a token requires removeProperty.
+  const appliedKeysRef = React.useRef<Set<string>>(new Set())
+  React.useEffect(() => {
+    const html = document.documentElement
+    const active = mode === "light" ? theme.light : theme.dark
+    const next = new Set<string>()
+    for (const [k, v] of Object.entries(active)) {
+      html.style.setProperty(`--${k}`, v)
+      next.add(k)
+    }
+    // Remove anything previously applied that's now gone.
+    for (const k of appliedKeysRef.current) {
+      if (!next.has(k)) html.style.removeProperty(`--${k}`)
+    }
+    appliedKeysRef.current = next
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(theme))
+    } catch {
+      // ignore
+    }
+  }, [mode, theme])
+
+  const setMode = React.useCallback((m: ThemeMode) => setModeState(m), [])
+
+  const setTokens = React.useCallback(
+    (target: ThemeMode, tokens: ThemeTokens) => {
+      setTheme((prev) => ({ ...prev, [target]: tokens }))
+    },
+    []
+  )
+
+  const mergeTheme = React.useCallback((partial: Partial<Theme>) => {
+    setTheme((prev) => ({
+      light: { ...prev.light, ...(partial.light ?? {}) },
+      dark: { ...prev.dark, ...(partial.dark ?? {}) },
+    }))
+  }, [])
+
+  const reset = React.useCallback(() => {
+    setTheme(EMPTY_THEME)
+  }, [])
+
+  const value = React.useMemo<ThemeContextValue>(
+    () => ({ mode, setMode, theme, setTokens, mergeTheme, reset }),
+    [mode, setMode, theme, setTokens, mergeTheme, reset]
+  )
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = React.useContext(ThemeContext)
+  if (!ctx) throw new Error("useTheme must be used inside <ThemeProvider>")
+  return ctx
+}

--- a/components/showcase/theme-sheet.tsx
+++ b/components/showcase/theme-sheet.tsx
@@ -1,0 +1,304 @@
+"use client"
+
+import * as React from "react"
+import { Check, Copy, Moon, Palette, RotateCcw, Sun } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import {
+  formatThemeCss,
+  parseThemeCss,
+  THEME_PRESETS,
+  type ThemeMode,
+} from "@/lib/theme"
+import { useTheme } from "@/components/showcase/theme-provider"
+import { Button } from "@/registry/sabk/ui/button"
+import {
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/registry/sabk/ui/sheet"
+
+export function ThemeSheetTrigger({ className }: { className?: string }) {
+  const [open, setOpen] = React.useState(false)
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <button
+          type="button"
+          aria-label="Open theme settings"
+          className={cn(
+            "inline-flex items-center gap-2 rounded-sm border-2 border-sidebar-border bg-sidebar px-2.5 py-1.5 font-mono text-[10px] uppercase tracking-[0.1em] text-sidebar-foreground transition-colors hover:border-forge hover:text-forge",
+            className
+          )}
+        >
+          <Palette className="size-3.5" />
+          theme
+        </button>
+      </SheetTrigger>
+      <SheetContent>
+        <ThemeSheetBody />
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function ThemeSheetBody() {
+  const { mode, setMode, theme, mergeTheme, reset } = useTheme()
+  const [paste, setPaste] = React.useState("")
+  const [parseStatus, setParseStatus] = React.useState<
+    { kind: "idle" } | { kind: "ok"; msg: string } | { kind: "warn"; msg: string }
+  >({ kind: "idle" })
+  const [copied, setCopied] = React.useState(false)
+
+  const exportCss = React.useMemo(() => {
+    // Fall back to a helpful empty hint if no overrides set.
+    const formatted = formatThemeCss(theme)
+    return (
+      formatted ||
+      "/* No overrides yet. Paste a theme below or pick a preset to populate this. */"
+    )
+  }, [theme])
+
+  function applyPaste() {
+    const { theme: parsed, warnings } = parseThemeCss(paste, mode)
+    const lightCount = Object.keys(parsed.light ?? {}).length
+    const darkCount = Object.keys(parsed.dark ?? {}).length
+    if (!lightCount && !darkCount) {
+      setParseStatus({
+        kind: "warn",
+        msg: warnings[0] ?? "No tokens recognized.",
+      })
+      return
+    }
+    mergeTheme(parsed)
+    const parts: string[] = []
+    if (darkCount) parts.push(`${darkCount} dark`)
+    if (lightCount) parts.push(`${lightCount} light`)
+    setParseStatus({
+      kind: "ok",
+      msg: `Applied ${parts.join(" + ")} token${darkCount + lightCount === 1 ? "" : "s"}.`,
+    })
+  }
+
+  async function copyExport() {
+    try {
+      await navigator.clipboard.writeText(exportCss)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // ignore
+    }
+  }
+
+  function applyPreset(presetId: string) {
+    const preset = THEME_PRESETS.find((p) => p.id === presetId)
+    if (!preset) return
+    mergeTheme(preset.overrides)
+    setParseStatus({ kind: "ok", msg: `Applied "${preset.label}" preset.` })
+  }
+
+  const overrideCount =
+    Object.keys(theme.light).length + Object.keys(theme.dark).length
+
+  return (
+    <>
+      <SheetHeader>
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-forge">
+            ◆ theme
+          </span>
+        </div>
+        <SheetTitle>Theme settings</SheetTitle>
+        <SheetDescription>
+          Preview Sabk components against your own theme. Paste a CSS variable
+          block, pick a preset, or copy the active theme back out.
+        </SheetDescription>
+      </SheetHeader>
+
+      <SheetBody className="flex flex-col gap-7">
+        <Section title="Mode">
+          <div className="grid grid-cols-2 gap-2">
+            <ModeButton
+              active={mode === "dark"}
+              onClick={() => setMode("dark")}
+              icon={<Moon className="size-3.5" />}
+              label="Dark"
+            />
+            <ModeButton
+              active={mode === "light"}
+              onClick={() => setMode("light")}
+              icon={<Sun className="size-3.5" />}
+              label="Light"
+            />
+          </div>
+        </Section>
+
+        <Section title="Presets">
+          <div className="grid grid-cols-2 gap-2">
+            {THEME_PRESETS.map((p) => (
+              <button
+                key={p.id}
+                type="button"
+                onClick={() => applyPreset(p.id)}
+                className="group flex items-center gap-2 rounded-sm border-2 border-border bg-card px-3 py-2 text-left transition-colors hover:border-forge"
+              >
+                <span
+                  aria-hidden
+                  className="size-3.5 shrink-0 rounded-full border-2 border-border"
+                  style={{ background: p.swatch }}
+                />
+                <span className="text-sm">{p.label}</span>
+              </button>
+            ))}
+          </div>
+          <p className="mt-2 text-[11px] text-muted-foreground">
+            Presets only override the accent and ring — neutrals stay intact.
+          </p>
+        </Section>
+
+        <Section
+          title="Paste CSS variables"
+          hint={`Targets ${mode} when no .light/.dark selector is given`}
+        >
+          <textarea
+            value={paste}
+            onChange={(e) => setPaste(e.target.value)}
+            placeholder={`:root {\n  --background: oklch(...);\n  --foreground: oklch(...);\n  --primary: oklch(...);\n  ...\n}\n\n.dark {\n  ...\n}`}
+            spellCheck={false}
+            className="h-44 w-full resize-y rounded-sm border-2 border-border bg-card px-3 py-2 font-mono text-[11px] leading-relaxed text-foreground outline-none placeholder:text-muted-foreground/60 focus-visible:border-ring"
+          />
+          <div className="mt-2 flex items-center justify-between gap-3">
+            <p
+              className={cn(
+                "text-[11px]",
+                parseStatus.kind === "warn"
+                  ? "text-destructive"
+                  : parseStatus.kind === "ok"
+                    ? "text-forge"
+                    : "text-muted-foreground"
+              )}
+            >
+              {parseStatus.kind === "idle"
+                ? "Accepts :root, .light, .dark, or bare declarations."
+                : parseStatus.msg}
+            </p>
+            <Button
+              type="button"
+              size="sm"
+              variant="forge"
+              onClick={applyPaste}
+              disabled={!paste.trim()}
+            >
+              Apply
+            </Button>
+          </div>
+        </Section>
+
+        <Section
+          title="Export"
+          hint={`${overrideCount} override${overrideCount === 1 ? "" : "s"} active`}
+        >
+          <pre className="max-h-40 overflow-auto rounded-sm border-2 border-border bg-card p-3 font-mono text-[11px] leading-relaxed">
+            <code>{exportCss}</code>
+          </pre>
+          <div className="mt-2 flex items-center justify-end">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={copyExport}
+              disabled={!overrideCount}
+            >
+              {copied ? (
+                <Check className="size-3.5" />
+              ) : (
+                <Copy className="size-3.5" />
+              )}
+              {copied ? "Copied" : "Copy CSS"}
+            </Button>
+          </div>
+        </Section>
+      </SheetBody>
+
+      <SheetFooter>
+        <p className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+          live · persisted in this browser
+        </p>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={reset}
+          disabled={!overrideCount}
+        >
+          <RotateCcw className="size-3.5" />
+          Reset
+        </Button>
+      </SheetFooter>
+    </>
+  )
+}
+
+function Section({
+  title,
+  hint,
+  children,
+}: {
+  title: string
+  hint?: string
+  children: React.ReactNode
+}) {
+  return (
+    <section>
+      <div className="mb-2 flex items-baseline justify-between">
+        <h3 className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+          {title}
+        </h3>
+        {hint && (
+          <span className="font-mono text-[9px] uppercase tracking-[0.08em] text-muted-foreground/70">
+            {hint}
+          </span>
+        )}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function ModeButton({
+  active,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean
+  onClick: () => void
+  icon: React.ReactNode
+  label: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        "flex items-center justify-center gap-2 rounded-sm border-2 px-3 py-2 text-sm transition-colors",
+        active
+          ? "border-forge bg-accent text-foreground"
+          : "border-border bg-card text-muted-foreground hover:text-foreground"
+      )}
+    >
+      {icon}
+      {label}
+      {active && <span className="ml-1 size-1.5 rounded-full bg-forge" />}
+    </button>
+  )
+}
+
+// Re-export for client mode usage on the mode-helper as needed.
+export type { ThemeMode }

--- a/lib/highlight.ts
+++ b/lib/highlight.ts
@@ -1,0 +1,86 @@
+/**
+ * Server-side syntax highlighting via shiki.
+ *
+ * The highlighter is created once per server process (cached as a module-level
+ * promise) and reused across requests. Output uses dual themes — CSS variables
+ * carry both the light and dark token colors, and a small block in
+ * globals.css picks the right one based on the `.light` mode class.
+ */
+
+import type { BundledLanguage, Highlighter } from "shiki"
+
+const DARK_THEME = "vesper"
+const LIGHT_THEME = "vitesse-light"
+
+const SUPPORTED_LANGS: BundledLanguage[] = [
+  "tsx",
+  "ts",
+  "jsx",
+  "js",
+  "bash",
+  "shell",
+  "css",
+  "json",
+  "html",
+  "md",
+]
+
+let highlighterPromise: Promise<Highlighter> | undefined
+
+async function getHighlighter(): Promise<Highlighter> {
+  if (!highlighterPromise) {
+    const { createHighlighter } = await import("shiki")
+    highlighterPromise = createHighlighter({
+      themes: [DARK_THEME, LIGHT_THEME],
+      langs: SUPPORTED_LANGS,
+    })
+  }
+  return highlighterPromise
+}
+
+export type HighlightLang = BundledLanguage | "plaintext"
+
+export async function highlightCode(
+  code: string,
+  lang: HighlightLang
+): Promise<string> {
+  const safeLang = SUPPORTED_LANGS.includes(lang as BundledLanguage)
+    ? (lang as BundledLanguage)
+    : "tsx"
+  const hl = await getHighlighter()
+  return hl.codeToHtml(code, {
+    lang: safeLang,
+    themes: { light: LIGHT_THEME, dark: DARK_THEME },
+    defaultColor: "dark",
+  })
+}
+
+/** Infer a shiki lang from a filename. */
+export function langFromPath(filePath: string): HighlightLang {
+  const ext = filePath.split(".").pop()?.toLowerCase()
+  switch (ext) {
+    case "tsx":
+    case "jsx":
+      return "tsx"
+    case "ts":
+      return "ts"
+    case "js":
+    case "mjs":
+    case "cjs":
+      return "js"
+    case "css":
+      return "css"
+    case "json":
+      return "json"
+    case "html":
+      return "html"
+    case "md":
+    case "mdx":
+      return "md"
+    case "sh":
+    case "bash":
+      return "bash"
+    default:
+      return "tsx"
+  }
+}

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,0 +1,264 @@
+/**
+ * Theme token model + CSS parsing / formatting for the live theme settings sheet.
+ *
+ * The showcase's globals.css uses `:root` for dark (default) and `.light`
+ * for the light variant. The live editor lets users paste CSS that follows
+ * either convention — this module reconciles both into a {light, dark}
+ * record that the provider applies via inline CSS custom properties.
+ */
+
+export type ThemeMode = "light" | "dark"
+
+export type ThemeTokens = Record<string, string>
+
+export type Theme = {
+  light: ThemeTokens
+  dark: ThemeTokens
+}
+
+/** Tokens the editor is aware of. Anything outside this list is ignored on paste. */
+export const THEME_TOKEN_KEYS = [
+  "background",
+  "foreground",
+  "card",
+  "card-foreground",
+  "popover",
+  "popover-foreground",
+  "primary",
+  "primary-foreground",
+  "secondary",
+  "secondary-foreground",
+  "muted",
+  "muted-foreground",
+  "accent",
+  "accent-foreground",
+  "destructive",
+  "border",
+  "input",
+  "ring",
+  "forge",
+  "forge-foreground",
+  "sidebar",
+  "sidebar-foreground",
+  "sidebar-border",
+  "sidebar-accent",
+  "sidebar-accent-foreground",
+  "radius",
+] as const
+
+export type ThemeTokenKey = (typeof THEME_TOKEN_KEYS)[number]
+
+const TOKEN_SET = new Set<string>(THEME_TOKEN_KEYS)
+
+/**
+ * Parse one or more CSS blocks into {light, dark} token maps.
+ *
+ * Accepts:
+ *   - `:root { ... }` + `.dark { ... }`   (shadcn convention — :root is light)
+ *   - `:root { ... }` + `.light { ... }`  (this repo's convention — :root is dark)
+ *   - A single `:root { ... }` block      (applied to currentMode)
+ *   - Bare `--token: value;` lines        (applied to currentMode)
+ */
+export function parseThemeCss(
+  css: string,
+  currentMode: ThemeMode = "dark"
+): { theme: Partial<Theme>; warnings: string[] } {
+  const warnings: string[] = []
+  const blocks = extractBlocks(css)
+
+  const result: Partial<Theme> = {}
+
+  if (blocks.length === 0) {
+    const bare = extractDeclarations(css)
+    if (Object.keys(bare).length) {
+      result[currentMode] = bare
+    } else {
+      warnings.push("No CSS variables found.")
+    }
+    return { theme: result, warnings }
+  }
+
+  const hasDark = blocks.some((b) => b.selector === ".dark")
+  const hasLight = blocks.some((b) => b.selector === ".light")
+
+  // Disambiguate :root.
+  // shadcn outputs `:root` (light) + `.dark` → :root is LIGHT.
+  // This repo writes `:root` (dark) + `.light` → :root is DARK.
+  const rootIsLight = hasDark && !hasLight
+  const rootIsDark = hasLight && !hasDark
+  // Ambiguous (just :root, or all three): default to currentMode.
+
+  for (const block of blocks) {
+    const decls = extractDeclarations(block.body)
+    if (!Object.keys(decls).length) continue
+
+    if (block.selector === ".light") {
+      result.light = { ...(result.light ?? {}), ...decls }
+    } else if (block.selector === ".dark") {
+      result.dark = { ...(result.dark ?? {}), ...decls }
+    } else if (block.selector === ":root") {
+      const mode: ThemeMode = rootIsLight
+        ? "light"
+        : rootIsDark
+          ? "dark"
+          : currentMode
+      result[mode] = { ...(result[mode] ?? {}), ...decls }
+    }
+  }
+
+  if (!result.light && !result.dark) {
+    warnings.push("No matching tokens found in the pasted CSS.")
+  }
+  return { theme: result, warnings }
+}
+
+type CssBlock = { selector: string; body: string }
+
+function extractBlocks(css: string): CssBlock[] {
+  // Strip comments first.
+  const cleaned = css.replace(/\/\*[\s\S]*?\*\//g, "")
+  const blocks: CssBlock[] = []
+  const re = /([^{}]+)\{([^{}]*)\}/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(cleaned)) !== null) {
+    const selector = m[1].trim()
+    const body = m[2]
+    // Only single selectors we care about.
+    if (selector === ":root" || selector === ".light" || selector === ".dark") {
+      blocks.push({ selector, body })
+    }
+  }
+  return blocks
+}
+
+function extractDeclarations(body: string): ThemeTokens {
+  const out: ThemeTokens = {}
+  // Match `--token: value;` (value may contain parens / spaces).
+  const re = /--([a-z0-9-]+)\s*:\s*([^;]+?)\s*(?:;|$)/gi
+  let m: RegExpExecArray | null
+  while ((m = re.exec(body)) !== null) {
+    const key = m[1]
+    if (!TOKEN_SET.has(key)) continue
+    out[key] = m[2].trim()
+  }
+  return out
+}
+
+/** Serialize a {light, dark} theme back into a paste-able CSS string. */
+export function formatThemeCss(theme: Theme): string {
+  const dark = formatBlock(":root", theme.dark)
+  const light = formatBlock(".light", theme.light)
+  return [dark, light].filter(Boolean).join("\n\n")
+}
+
+function formatBlock(selector: string, tokens: ThemeTokens): string {
+  const keys = Object.keys(tokens).sort()
+  if (!keys.length) return ""
+  const lines = keys.map((k) => `  --${k}: ${tokens[k]};`)
+  return `${selector} {\n${lines.join("\n")}\n}`
+}
+
+/**
+ * Curated presets. Each only overrides the accent hue + ring, so the rest of
+ * the neutral palette stays consistent with the default forge look.
+ */
+export type ThemePreset = {
+  id: string
+  label: string
+  swatch: string
+  overrides: Partial<Theme>
+}
+
+export const THEME_PRESETS: ThemePreset[] = [
+  {
+    id: "forge",
+    label: "Forge",
+    swatch: "oklch(0.72 0.14 55)",
+    overrides: {
+      dark: {
+        forge: "oklch(0.72 0.14 55)",
+        "forge-foreground": "oklch(0.14 0.01 55)",
+        ring: "oklch(0.68 0.14 55)",
+      },
+      light: {
+        forge: "oklch(0.56 0.14 55)",
+        "forge-foreground": "oklch(0.98 0.005 80)",
+        ring: "oklch(0.62 0.14 55)",
+      },
+    },
+  },
+  {
+    id: "emerald",
+    label: "Emerald",
+    swatch: "oklch(0.72 0.16 155)",
+    overrides: {
+      dark: {
+        forge: "oklch(0.72 0.16 155)",
+        "forge-foreground": "oklch(0.14 0.02 155)",
+        ring: "oklch(0.68 0.16 155)",
+      },
+      light: {
+        forge: "oklch(0.52 0.14 155)",
+        "forge-foreground": "oklch(0.98 0.01 155)",
+        ring: "oklch(0.58 0.14 155)",
+      },
+    },
+  },
+  {
+    id: "indigo",
+    label: "Indigo",
+    swatch: "oklch(0.68 0.18 270)",
+    overrides: {
+      dark: {
+        forge: "oklch(0.68 0.18 270)",
+        "forge-foreground": "oklch(0.14 0.02 270)",
+        ring: "oklch(0.64 0.18 270)",
+      },
+      light: {
+        forge: "oklch(0.52 0.18 270)",
+        "forge-foreground": "oklch(0.98 0.01 270)",
+        ring: "oklch(0.58 0.18 270)",
+      },
+    },
+  },
+  {
+    id: "rose",
+    label: "Rose",
+    swatch: "oklch(0.7 0.18 15)",
+    overrides: {
+      dark: {
+        forge: "oklch(0.7 0.18 15)",
+        "forge-foreground": "oklch(0.14 0.02 15)",
+        ring: "oklch(0.66 0.18 15)",
+      },
+      light: {
+        forge: "oklch(0.56 0.18 15)",
+        "forge-foreground": "oklch(0.98 0.01 15)",
+        ring: "oklch(0.6 0.18 15)",
+      },
+    },
+  },
+]
+
+export const STORAGE_KEY = "sabk.theme.v1"
+export const MODE_STORAGE_KEY = "sabk.theme.mode.v1"
+
+/**
+ * Inline script (stringified) that runs before hydration to apply persisted
+ * mode + custom tokens, preventing a flash of default theme.
+ */
+export function themePrehydrationScript(): string {
+  return `(()=>{try{
+    var modeKey=${JSON.stringify(MODE_STORAGE_KEY)};
+    var themeKey=${JSON.stringify(STORAGE_KEY)};
+    var mode=localStorage.getItem(modeKey);
+    var html=document.documentElement;
+    if(mode==='light'){html.classList.add('light');}
+    var raw=localStorage.getItem(themeKey);
+    if(!raw)return;
+    var t=JSON.parse(raw);
+    var active=mode==='light'?t.light:t.dark;
+    if(!active)return;
+    for(var k in active){html.style.setProperty('--'+k,active[k]);}
+  }catch(e){}})();`
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "shadcn": "^3.0.0",
+    "shiki": "^4.1.0",
     "tailwind-merge": "^3.3.1",
     "tw-animate-css": "^1.3.6",
     "zod": "^3.25.76"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "registry:build": "shadcn build"
   },
   "dependencies": {
+    "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       shadcn:
         specifier: ^3.0.0
         version: 3.0.0(@types/node@20.19.9)(typescript@5.9.2)
+      shiki:
+        specifier: ^4.1.0
+        version: 4.1.0
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -913,6 +916,37 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
+  '@shikijs/core@4.1.0':
+    resolution: {integrity: sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.1.0':
+    resolution: {integrity: sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@4.1.0':
+    resolution: {integrity: sha512-axLpjVs45YBvvINa+dJF+NPW+KtFkNXsFr4SDw2BMj9GdeMnGxVB9PQb2xXlJYovslt/nz6giedAyOANkfc7hg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.1.0':
+    resolution: {integrity: sha512-nwOMruEkbgdZfQ/b8CgpNBVOpvG1k0N5tbmgiFeqsan401+x3ILqlzZJowSla4Agmq4hG2Uf2wh5jLTEhR8VSg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.1.0':
+    resolution: {integrity: sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@4.1.0':
+    resolution: {integrity: sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.1.0':
+    resolution: {integrity: sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
@@ -1024,11 +1058,17 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
   '@types/node@20.19.9':
     resolution: {integrity: sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==}
@@ -1046,6 +1086,9 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@typescript-eslint/eslint-plugin@8.39.0':
     resolution: {integrity: sha512-bhEz6OZeUR+O/6yx9Jk6ohX6H9JSFTaiY0v9/PuKT3oGK0rn0jNplLmyFUGV+a9gfYnVNwGDwS/UkLIuXNb2Rw==}
@@ -1105,6 +1148,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.39.0':
     resolution: {integrity: sha512-ldgiJ+VAhQCfIjeOgu8Kj5nSxds0ktPOSO9p4+0VDH2R2pLvQraaM5Oen2d7NxzMCm+Sn/vJT+mv2H5u6b/3fA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -1361,6 +1407,9 @@ packages:
   caniuse-lite@1.0.30001731:
     resolution: {integrity: sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1368,6 +1417,12 @@ packages:
   chalk@5.5.0:
     resolution: {integrity: sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
@@ -1421,6 +1476,9 @@ packages:
   color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -1535,12 +1593,19 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   diff@8.0.2:
     resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
@@ -1981,8 +2046,17 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
@@ -2363,6 +2437,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
@@ -2377,6 +2454,21 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -2551,6 +2643,12 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -2660,6 +2758,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -2738,6 +2839,15 @@ packages:
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
+
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -2850,6 +2960,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shiki@4.1.0:
+    resolution: {integrity: sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==}
+    engines: {node: '>=20'}
+
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
@@ -2886,6 +3000,9 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -2939,6 +3056,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   stringify-object@5.0.0:
     resolution: {integrity: sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==}
@@ -3025,6 +3145,9 @@ packages:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
     engines: {node: '>=18.12'}
@@ -3095,6 +3218,21 @@ packages:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
 
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
@@ -3145,6 +3283,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -3229,6 +3373,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -4026,6 +4173,46 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
+  '@shikijs/core@4.1.0':
+    dependencies:
+      '@shikijs/primitive': 4.1.0
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+
+  '@shikijs/primitive@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/themes@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+
+  '@shikijs/types@4.1.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@swc/helpers@0.5.15':
@@ -4119,9 +4306,17 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/node@20.19.9':
     dependencies:
@@ -4138,6 +4333,8 @@ snapshots:
   '@types/statuses@2.0.6': {}
 
   '@types/tough-cookie@4.0.5': {}
+
+  '@types/unist@3.0.3': {}
 
   '@typescript-eslint/eslint-plugin@8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
@@ -4231,6 +4428,8 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.39.0
       eslint-visitor-keys: 4.2.1
+
+  '@ungap/structured-clone@1.3.1': {}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     optional: true
@@ -4475,12 +4674,18 @@ snapshots:
 
   caniuse-lite@1.0.30001731: {}
 
+  ccount@2.0.1: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
   chalk@5.5.0: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
 
   chownr@3.0.0: {}
 
@@ -4537,6 +4742,8 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
     optional: true
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
 
@@ -4628,9 +4835,15 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.0.4: {}
 
   detect-node-es@1.1.0: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   diff@8.0.2: {}
 
@@ -5248,7 +5461,27 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   headers-polyfill@4.0.3: {}
+
+  html-void-elements@3.0.0: {}
 
   http-errors@2.0.0:
     dependencies:
@@ -5579,6 +5812,18 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.1
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
   media-typer@1.1.0: {}
 
   merge-descriptors@2.0.0: {}
@@ -5586,6 +5831,23 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -5763,6 +6025,14 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -5870,6 +6140,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  property-information@7.1.0: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -5952,6 +6224,16 @@ snapshots:
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -6153,6 +6435,17 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shiki@4.1.0:
+    dependencies:
+      '@shikijs/core': 4.1.0
+      '@shikijs/engine-javascript': 4.1.0
+      '@shikijs/engine-oniguruma': 4.1.0
+      '@shikijs/langs': 4.1.0
+      '@shikijs/themes': 4.1.0
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -6195,6 +6488,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   source-map@0.6.1: {}
+
+  space-separated-tokens@2.0.2: {}
 
   stable-hash@0.0.5: {}
 
@@ -6273,6 +6568,11 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   stringify-object@5.0.0:
     dependencies:
       get-own-enumerable-keys: 1.0.0
@@ -6344,6 +6644,8 @@ snapshots:
       punycode: 2.3.1
       universalify: 0.2.0
       url-parse: 1.5.10
+
+  trim-lines@3.0.1: {}
 
   ts-api-utils@2.1.0(typescript@5.9.2):
     dependencies:
@@ -6431,6 +6733,29 @@ snapshots:
 
   unicorn-magic@0.3.0: {}
 
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   universalify@0.2.0: {}
 
   universalify@2.0.1: {}
@@ -6492,6 +6817,16 @@ snapshots:
       '@types/react': 19.1.2
 
   vary@1.1.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   web-streams-polyfill@3.3.3: {}
 
@@ -6589,3 +6924,5 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-accordion':
+        specifier: ^1.2.12
+        version: 1.2.12(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -622,8 +625,34 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/react-accordion@1.2.12':
+    resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
+    peerDependencies:
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collapsible@1.1.12':
+    resolution: {integrity: sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==}
     peerDependencies:
       '@types/react': 19.1.2
       '@types/react-dom': 19.1.2
@@ -3908,9 +3937,42 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.2)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+
+  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.2)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:

--- a/registry.json
+++ b/registry.json
@@ -75,31 +75,49 @@
       "name": "tag-input",
       "type": "registry:ui",
       "title": "Tag Input",
-      "description": "Chip input with paste-to-split, dedupe, validation hook, max tags.",
+      "description": "Chip input with paste-to-split, dedupe, validation hook, max tags. Compound and single-prop APIs.",
       "categories": ["inputs"],
       "dependencies": ["lucide-react"],
-      "registryDependencies": ["badge", "input"],
-      "files": []
+      "registryDependencies": ["badge"],
+      "files": [
+        {
+          "path": "registry/sabk/tag-input/tag-input.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/tag-input.tsx"
+        }
+      ]
     },
     {
       "name": "combobox",
       "type": "registry:ui",
       "title": "Combobox",
-      "description": "Searchable single-select with debounced async loader, empty/loading/error states.",
+      "description": "Searchable single-select with debounced async loader, group headings and clearable selection.",
       "categories": ["inputs"],
       "dependencies": ["cmdk", "lucide-react"],
       "registryDependencies": ["button", "popover", "command"],
-      "files": []
+      "files": [
+        {
+          "path": "registry/sabk/combobox/combobox.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/combobox.tsx"
+        }
+      ]
     },
     {
       "name": "password-input",
       "type": "registry:ui",
       "title": "Password Input",
-      "description": "Show/hide toggle and optional pluggable strength meter.",
+      "description": "Show/hide toggle with an optional pluggable strength meter. Compound and single-prop APIs.",
       "categories": ["inputs"],
       "dependencies": ["lucide-react"],
-      "registryDependencies": ["input", "button"],
-      "files": []
+      "registryDependencies": ["input"],
+      "files": [
+        {
+          "path": "registry/sabk/password-input/password-input.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/password-input.tsx"
+        }
+      ]
     },
     {
       "name": "phone-input",

--- a/registry.json
+++ b/registry.json
@@ -158,6 +158,150 @@
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button", "popover", "input"],
       "files": []
+    },
+    {
+      "name": "accordion",
+      "type": "registry:ui",
+      "title": "Accordion",
+      "description": "Radix-powered accordion primitive used by the FAQ blocks. Plus icon rotates to an X on open.",
+      "categories": ["primitives"],
+      "dependencies": ["@radix-ui/react-accordion", "lucide-react"],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/sabk/ui/accordion.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/accordion.tsx"
+        }
+      ]
+    },
+    {
+      "name": "hero-01",
+      "type": "registry:block",
+      "title": "Hero · stat strip + install card",
+      "description": "Split hero with eyebrow tag, display headline, dual CTA, three-stat strip and a mock install-card visual.",
+      "categories": ["blocks", "hero"],
+      "dependencies": ["lucide-react"],
+      "registryDependencies": ["button"],
+      "files": [
+        {
+          "path": "registry/sabk/blocks/hero-01/hero-01.tsx",
+          "type": "registry:block",
+          "target": "components/blocks/hero-01.tsx"
+        }
+      ]
+    },
+    {
+      "name": "hero-02",
+      "type": "registry:block",
+      "title": "Hero · centered editorial",
+      "description": "Centered hero with animated live-pill, display headline with underlined accent, sub-copy and a trusted-by wordmark strip.",
+      "categories": ["blocks", "hero"],
+      "dependencies": ["lucide-react"],
+      "registryDependencies": ["button"],
+      "files": [
+        {
+          "path": "registry/sabk/blocks/hero-02/hero-02.tsx",
+          "type": "registry:block",
+          "target": "components/blocks/hero-02.tsx"
+        }
+      ]
+    },
+    {
+      "name": "cta-01",
+      "type": "registry:block",
+      "title": "CTA · framed band",
+      "description": "Framed CTA card with forge corner marks, headline + sub-copy on the left, dual buttons stacked on the right.",
+      "categories": ["blocks", "cta"],
+      "dependencies": ["lucide-react"],
+      "registryDependencies": ["button"],
+      "files": [
+        {
+          "path": "registry/sabk/blocks/cta-01/cta-01.tsx",
+          "type": "registry:block",
+          "target": "components/blocks/cta-01.tsx"
+        }
+      ]
+    },
+    {
+      "name": "cta-02",
+      "type": "registry:block",
+      "title": "CTA · centered announce",
+      "description": "Full-bleed centered CTA with framing rules, highlight underlay on the key word, and an inline install command.",
+      "categories": ["blocks", "cta"],
+      "dependencies": ["lucide-react"],
+      "registryDependencies": ["button"],
+      "files": [
+        {
+          "path": "registry/sabk/blocks/cta-02/cta-02.tsx",
+          "type": "registry:block",
+          "target": "components/blocks/cta-02.tsx"
+        }
+      ]
+    },
+    {
+      "name": "faq-01",
+      "type": "registry:block",
+      "title": "FAQ · sticky split",
+      "description": "Two-column FAQ — sticky heading + contact card on the left, numbered accordion on the right.",
+      "categories": ["blocks", "faq"],
+      "dependencies": ["@radix-ui/react-accordion", "lucide-react"],
+      "registryDependencies": ["button", "accordion"],
+      "files": [
+        {
+          "path": "registry/sabk/blocks/faq-01/faq-01.tsx",
+          "type": "registry:block",
+          "target": "components/blocks/faq-01.tsx"
+        }
+      ]
+    },
+    {
+      "name": "faq-02",
+      "type": "registry:block",
+      "title": "FAQ · centered grid",
+      "description": "Centered heading with two-column accordion grid below. Each row tagged with a Qn index.",
+      "categories": ["blocks", "faq"],
+      "dependencies": ["@radix-ui/react-accordion"],
+      "registryDependencies": ["accordion"],
+      "files": [
+        {
+          "path": "registry/sabk/blocks/faq-02/faq-02.tsx",
+          "type": "registry:block",
+          "target": "components/blocks/faq-02.tsx"
+        }
+      ]
+    },
+    {
+      "name": "login-01",
+      "type": "registry:block",
+      "title": "Login · centered card",
+      "description": "Centered login card with forge monogram, email + password (using the password-input component), remember-me, divider and GitHub / Google providers.",
+      "categories": ["blocks", "login"],
+      "dependencies": ["lucide-react"],
+      "registryDependencies": ["button", "input", "label", "password-input"],
+      "files": [
+        {
+          "path": "registry/sabk/blocks/login-01/login-01.tsx",
+          "type": "registry:block",
+          "target": "components/blocks/login-01.tsx"
+        }
+      ]
+    },
+    {
+      "name": "login-02",
+      "type": "registry:block",
+      "title": "Login · split testimonial",
+      "description": "Two-pane login: form on the left, dark testimonial panel with quote and metrics on the right. Uses the strength-meter variant of password-input.",
+      "categories": ["blocks", "login"],
+      "dependencies": ["lucide-react"],
+      "registryDependencies": ["button", "input", "label", "password-input"],
+      "files": [
+        {
+          "path": "registry/sabk/blocks/login-02/login-02.tsx",
+          "type": "registry:block",
+          "target": "components/blocks/login-02.tsx"
+        }
+      ]
     }
   ]
 }

--- a/registry/sabk/blocks/cta-01/cta-01.tsx
+++ b/registry/sabk/blocks/cta-01/cta-01.tsx
@@ -36,7 +36,7 @@ export default function Cta01() {
                 <span className="size-1 rounded-full bg-forge" />
                 Ready to ship?
               </span>
-              <h2 className="text-balance text-3xl font-semibold tracking-[-0.03em] sm:text-4xl lg:text-5xl">
+              <h2 className="text-balance text-2xl font-semibold leading-[1.1] tracking-[-0.03em] sm:text-3xl md:text-4xl lg:text-5xl">
                 Stop rebuilding the components{" "}
                 <span className="text-forge">every project</span> needs.
               </h2>

--- a/registry/sabk/blocks/cta-01/cta-01.tsx
+++ b/registry/sabk/blocks/cta-01/cta-01.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import * as React from "react"
+import { ArrowRight, Github } from "lucide-react"
+
+import { Button } from "@/registry/sabk/ui/button"
+
+export default function Cta01() {
+  return (
+    <section className="bg-background py-20 md:py-28">
+      <div className="mx-auto w-full max-w-5xl px-6 md:px-10">
+        <div
+          className="relative rounded-sm border-2 border-border bg-card"
+          style={{ boxShadow: "10px 10px 0 0 var(--border)" }}
+        >
+          <span
+            aria-hidden
+            className="absolute -left-1.5 -top-1.5 size-3 rounded-[2px] bg-forge"
+          />
+          <span
+            aria-hidden
+            className="absolute -right-1.5 -top-1.5 size-3 rounded-[2px] border-2 border-forge bg-background"
+          />
+          <span
+            aria-hidden
+            className="absolute -bottom-1.5 -left-1.5 size-3 rounded-[2px] border-2 border-forge bg-background"
+          />
+          <span
+            aria-hidden
+            className="absolute -bottom-1.5 -right-1.5 size-3 rounded-[2px] bg-forge"
+          />
+
+          <div className="grid grid-cols-1 gap-10 p-8 sm:p-12 lg:grid-cols-12 lg:items-center lg:gap-16">
+            <div className="flex flex-col gap-5 lg:col-span-7">
+              <span className="inline-flex w-fit items-center gap-2 font-mono text-[10px] uppercase tracking-[0.14em] text-forge">
+                <span className="size-1 rounded-full bg-forge" />
+                Ready to ship?
+              </span>
+              <h2 className="text-balance text-3xl font-semibold tracking-[-0.03em] sm:text-4xl lg:text-5xl">
+                Stop rebuilding the components{" "}
+                <span className="text-forge">every project</span> needs.
+              </h2>
+              <p className="max-w-xl text-sm text-muted-foreground sm:text-base">
+                Pull a real multi-select, year picker, or tag input into your
+                repo in one command. No package, no version pin — just the
+                source, in your codebase, yours to shape.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-3 lg:col-span-5 lg:items-end">
+              <Button
+                variant="forge"
+                size="lg"
+                className="group w-full justify-between lg:w-auto"
+              >
+                Install via shadcn CLI
+                <ArrowRight className="size-4 transition-transform duration-150 ease-[var(--ease-forge)] group-hover:translate-x-0.5" />
+              </Button>
+              <Button
+                variant="outline"
+                size="lg"
+                className="w-full justify-between lg:w-auto"
+              >
+                <span className="inline-flex items-center gap-2">
+                  <Github className="size-4" />
+                  Star on GitHub
+                </span>
+                <span className="font-mono text-[10px] tabular-nums text-muted-foreground">
+                  1.2k
+                </span>
+              </Button>
+              <p className="text-right font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                MIT · no runtime dependency
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/registry/sabk/blocks/cta-01/index.ts
+++ b/registry/sabk/blocks/cta-01/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./cta-01"

--- a/registry/sabk/blocks/cta-02/cta-02.tsx
+++ b/registry/sabk/blocks/cta-02/cta-02.tsx
@@ -38,7 +38,7 @@ export default function Cta02() {
           ◆ one-line install
         </span>
 
-        <h2 className="text-balance text-4xl font-semibold leading-[1.05] tracking-[-0.04em] sm:text-5xl lg:text-6xl">
+        <h2 className="text-balance text-3xl font-semibold leading-[1.05] tracking-[-0.04em] sm:text-4xl md:text-5xl lg:text-6xl">
           Make your component layer{" "}
           <span className="relative inline-block">
             <span className="relative z-10">do its job.</span>
@@ -69,9 +69,9 @@ export default function Cta02() {
           </span>
         </div>
 
-        <div className="mt-2 inline-flex items-center gap-3 rounded-sm border-2 border-border bg-card px-3 py-2 font-mono text-xs">
-          <span className="text-forge">$</span>
-          <code className="text-foreground">
+        <div className="mt-2 flex max-w-full items-center gap-3 overflow-x-auto rounded-sm border-2 border-border bg-card px-3 py-2 font-mono text-xs">
+          <span className="shrink-0 text-forge">$</span>
+          <code className="whitespace-nowrap text-foreground">
             npx shadcn add{" "}
             <span className="text-muted-foreground">
               https://sabk.dev/r/multi-select

--- a/registry/sabk/blocks/cta-02/cta-02.tsx
+++ b/registry/sabk/blocks/cta-02/cta-02.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import * as React from "react"
+import { ArrowRight } from "lucide-react"
+
+import { Button } from "@/registry/sabk/ui/button"
+
+export default function Cta02() {
+  return (
+    <section className="relative isolate overflow-hidden bg-background py-24 md:py-32">
+      <div
+        aria-hidden
+        className="absolute inset-x-0 top-0 h-px"
+        style={{
+          background:
+            "linear-gradient(to right, transparent, var(--border) 20%, var(--border) 80%, transparent)",
+        }}
+      />
+      <div
+        aria-hidden
+        className="absolute inset-x-0 bottom-0 h-px"
+        style={{
+          background:
+            "linear-gradient(to right, transparent, var(--border) 20%, var(--border) 80%, transparent)",
+        }}
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10 opacity-[0.5]"
+        style={{
+          backgroundImage:
+            "radial-gradient(ellipse 80% 50% at 50% 50%, color-mix(in oklch, var(--forge) 12%, transparent), transparent 70%)",
+        }}
+      />
+
+      <div className="mx-auto flex w-full max-w-3xl flex-col items-center gap-7 px-6 text-center md:px-10">
+        <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-forge">
+          ◆ one-line install
+        </span>
+
+        <h2 className="text-balance text-4xl font-semibold leading-[1.05] tracking-[-0.04em] sm:text-5xl lg:text-6xl">
+          Make your component layer{" "}
+          <span className="relative inline-block">
+            <span className="relative z-10">do its job.</span>
+            <span
+              aria-hidden
+              className="absolute inset-x-0 bottom-1 -z-0 h-3"
+              style={{ background: "color-mix(in oklch, var(--forge) 35%, transparent)" }}
+            />
+          </span>
+        </h2>
+
+        <p className="max-w-xl text-balance text-base text-muted-foreground">
+          Sabk fills the obvious gaps in shadcn — the components your team
+          quietly rebuilds project after project — so you can spend that
+          time on the work only you can do.
+        </p>
+
+        <div className="flex flex-col items-center gap-3 sm:flex-row">
+          <Button variant="forge" size="lg" className="group">
+            Browse the registry
+            <ArrowRight className="size-4 transition-transform duration-150 ease-[var(--ease-forge)] group-hover:translate-x-0.5" />
+          </Button>
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            or{" "}
+            <a className="underline-offset-4 hover:text-forge hover:underline" href="#">
+              read the dual-API contract
+            </a>
+          </span>
+        </div>
+
+        <div className="mt-2 inline-flex items-center gap-3 rounded-sm border-2 border-border bg-card px-3 py-2 font-mono text-xs">
+          <span className="text-forge">$</span>
+          <code className="text-foreground">
+            npx shadcn add{" "}
+            <span className="text-muted-foreground">
+              https://sabk.dev/r/multi-select
+            </span>
+          </code>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/registry/sabk/blocks/cta-02/index.ts
+++ b/registry/sabk/blocks/cta-02/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./cta-02"

--- a/registry/sabk/blocks/faq-01/faq-01.tsx
+++ b/registry/sabk/blocks/faq-01/faq-01.tsx
@@ -48,7 +48,7 @@ export default function Faq01() {
               <span className="size-1 rounded-full bg-forge" />
               FAQ · the short answers
             </span>
-            <h2 className="text-balance text-4xl font-semibold tracking-[-0.035em] sm:text-5xl">
+            <h2 className="text-balance text-3xl font-semibold leading-[1.05] tracking-[-0.035em] sm:text-4xl md:text-5xl">
               Frequently{" "}
               <span className="text-forge">unobvious</span> questions.
             </h2>

--- a/registry/sabk/blocks/faq-01/faq-01.tsx
+++ b/registry/sabk/blocks/faq-01/faq-01.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import * as React from "react"
+import { ArrowUpRight, MessageCircleQuestion } from "lucide-react"
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/registry/sabk/ui/accordion"
+import { Button } from "@/registry/sabk/ui/button"
+
+const FAQS = [
+  {
+    q: "How is Sabk different from shadcn/ui?",
+    a: "Sabk is a peer, not a replacement. shadcn/ui covers the canonical primitives — Button, Dialog, Select. Sabk ships the dense, real-world components every product still has to build: multi-select, tag input, year picker, combobox with async loading, password strength. Both registries use the same CLI and the same install URL pattern, so you can mix and match.",
+  },
+  {
+    q: "Is Sabk a dependency I install?",
+    a: "No. Sabk is a registry, not a package. `npx shadcn add` copies the component source straight into your repo at components/ui/*. You own the code, you can edit it, and there is zero runtime dependency on Sabk.",
+  },
+  {
+    q: "What is the dual-API contract?",
+    a: "Every Sabk component ships two surface areas in the same file: a compound API (Root + named parts, for full layout control) and a single-prop API (one component, options-as-prop, for the 90% case). They share state — you can drop in either depending on the use case.",
+  },
+  {
+    q: "Can I theme it?",
+    a: "Yes. Sabk reads the same CSS variables as shadcn/ui plus a forge accent token. The /theme playground lets you tune the accent live; every component re-skins in place. Drop-in compatible with any shadcn theme.",
+  },
+  {
+    q: "Does it work with React Server Components?",
+    a: "Yes. Components that need client interactivity are marked 'use client' at the top of their file. Static components can render on the server. Both work in App Router and Pages Router.",
+  },
+  {
+    q: "Is it production-ready?",
+    a: "Yes. Every shipped component is typed end-to-end, keyboard-accessible, and SSR-safe. We don't tag a component as stable until it has both API shapes, focus-management coverage, and a working demo in the registry.",
+  },
+] as const
+
+export default function Faq01() {
+  return (
+    <section className="bg-background py-20 md:py-28">
+      <div className="mx-auto grid w-full max-w-6xl grid-cols-1 gap-12 px-6 md:px-10 lg:grid-cols-12 lg:gap-16">
+        <div className="flex flex-col gap-6 lg:col-span-5">
+          <div className="sticky top-12 flex flex-col gap-6">
+            <span className="inline-flex w-fit items-center gap-2 font-mono text-[10px] uppercase tracking-[0.14em] text-forge">
+              <span className="size-1 rounded-full bg-forge" />
+              FAQ · the short answers
+            </span>
+            <h2 className="text-balance text-4xl font-semibold tracking-[-0.035em] sm:text-5xl">
+              Frequently{" "}
+              <span className="text-forge">unobvious</span> questions.
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              The questions teams ask in their first ten minutes with Sabk —
+              answered the way we&apos;d want them answered. If something
+              isn&apos;t here, the issue tracker is open.
+            </p>
+
+            <div className="mt-2 flex flex-col gap-3 rounded-sm border-2 border-border bg-card p-5">
+              <div className="inline-flex items-center gap-2">
+                <MessageCircleQuestion className="size-4 text-forge" />
+                <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                  still stuck?
+                </span>
+              </div>
+              <p className="text-sm">
+                Drop a question in the repo. Responses usually within a day.
+              </p>
+              <Button variant="outline" size="sm" className="w-fit">
+                Open an issue
+                <ArrowUpRight className="size-3.5" />
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <div className="lg:col-span-7">
+          <Accordion type="single" collapsible defaultValue="item-0" className="border-y-2 border-border">
+            {FAQS.map((f, i) => (
+              <AccordionItem key={f.q} value={`item-${i}`} className="px-1">
+                <AccordionTrigger>
+                  <span className="flex items-baseline gap-4">
+                    <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                      {String(i + 1).padStart(2, "0")}
+                    </span>
+                    <span>{f.q}</span>
+                  </span>
+                </AccordionTrigger>
+                <AccordionContent>
+                  <div className="ml-10 max-w-2xl">{f.a}</div>
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/registry/sabk/blocks/faq-01/index.ts
+++ b/registry/sabk/blocks/faq-01/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./faq-01"

--- a/registry/sabk/blocks/faq-02/faq-02.tsx
+++ b/registry/sabk/blocks/faq-02/faq-02.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import * as React from "react"
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/registry/sabk/ui/accordion"
+
+const FAQS = [
+  {
+    q: "Do I need to install a package?",
+    a: "No. Sabk is a registry — components copy straight into your repo via the shadcn CLI. Zero runtime dependency.",
+  },
+  {
+    q: "Will updates break my code?",
+    a: "You own the copied source, so updates are opt-in. Re-run the install command to pull the latest, then diff and merge.",
+  },
+  {
+    q: "Is it compatible with shadcn themes?",
+    a: "Yes. Same CSS variables, plus a forge accent token. Any shadcn theme works out of the box.",
+  },
+  {
+    q: "What about accessibility?",
+    a: "Every shipped component is keyboard-navigable with proper ARIA roles. We test focus management before tagging stable.",
+  },
+  {
+    q: "Can I use it with Pages Router?",
+    a: "Yes. Components are React-first and framework-agnostic — App Router, Pages Router, Remix, anywhere React runs.",
+  },
+  {
+    q: "Is it really free?",
+    a: "MIT-licensed and free, forever. The source is on GitHub. No paywall, no telemetry.",
+  },
+] as const
+
+export default function Faq02() {
+  return (
+    <section className="bg-background py-20 md:py-28">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-12 px-6 md:px-10">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-forge">
+            ◆ frequently asked
+          </span>
+          <h2 className="max-w-2xl text-balance text-4xl font-semibold tracking-[-0.035em] sm:text-5xl">
+            Everything you&apos;d ask in the first ten minutes.
+          </h2>
+          <p className="max-w-xl text-balance text-sm text-muted-foreground">
+            Short answers first. If something isn&apos;t here, the issue
+            tracker is open and we usually respond within a day.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 gap-x-12 gap-y-0 lg:grid-cols-2">
+          {[FAQS.slice(0, 3), FAQS.slice(3)].map((col, ci) => (
+            <Accordion
+              key={ci}
+              type="multiple"
+              defaultValue={ci === 0 ? ["item-0-0"] : []}
+              className="border-y-2 border-border lg:border-y-2"
+            >
+              {col.map((f, i) => (
+                <AccordionItem
+                  key={f.q}
+                  value={`item-${ci}-${i}`}
+                  className="px-1"
+                >
+                  <AccordionTrigger>
+                    <span className="flex items-baseline gap-3">
+                      <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                        Q{ci * 3 + i + 1}
+                      </span>
+                      <span>{f.q}</span>
+                    </span>
+                  </AccordionTrigger>
+                  <AccordionContent>
+                    <div className="ml-8">{f.a}</div>
+                  </AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/registry/sabk/blocks/faq-02/faq-02.tsx
+++ b/registry/sabk/blocks/faq-02/faq-02.tsx
@@ -44,7 +44,7 @@ export default function Faq02() {
           <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-forge">
             ◆ frequently asked
           </span>
-          <h2 className="max-w-2xl text-balance text-4xl font-semibold tracking-[-0.035em] sm:text-5xl">
+          <h2 className="max-w-2xl text-balance text-3xl font-semibold leading-[1.05] tracking-[-0.035em] sm:text-4xl md:text-5xl">
             Everything you&apos;d ask in the first ten minutes.
           </h2>
           <p className="max-w-xl text-balance text-sm text-muted-foreground">

--- a/registry/sabk/blocks/faq-02/index.ts
+++ b/registry/sabk/blocks/faq-02/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./faq-02"

--- a/registry/sabk/blocks/hero-01/hero-01.tsx
+++ b/registry/sabk/blocks/hero-01/hero-01.tsx
@@ -1,0 +1,139 @@
+"use client"
+
+import * as React from "react"
+import { ArrowRight, Sparkles, Terminal } from "lucide-react"
+
+import { Button } from "@/registry/sabk/ui/button"
+
+const STATS = [
+  { value: "12", label: "components" },
+  { value: "2", label: "API shapes" },
+  { value: "0", label: "runtime deps" },
+] as const
+
+const REGISTRY_LINES = [
+  { kind: "cmd", text: "npx shadcn add" },
+  { kind: "arg", text: "  https://sabk.dev/r/multi-select" },
+  { kind: "out", text: "✓ resolved registry" },
+  { kind: "out", text: "✓ checked dependencies" },
+  { kind: "out", text: "✓ created multi-select.tsx" },
+  { kind: "blank", text: "" },
+  { kind: "meta", text: "components/ui/multi-select.tsx · 562 B" },
+] as const
+
+export default function Hero01() {
+  return (
+    <section className="relative isolate overflow-hidden bg-background">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10 opacity-[0.35] [mask-image:radial-gradient(ellipse_at_center,black_30%,transparent_75%)]"
+        style={{
+          backgroundImage:
+            "linear-gradient(to right, var(--border) 1px, transparent 1px), linear-gradient(to bottom, var(--border) 1px, transparent 1px)",
+          backgroundSize: "32px 32px",
+        }}
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -right-32 -top-32 -z-10 size-[420px] rounded-full opacity-[0.15] blur-3xl"
+        style={{ background: "var(--forge)" }}
+      />
+
+      <div className="mx-auto grid w-full max-w-6xl grid-cols-1 gap-12 px-6 py-20 md:px-10 lg:grid-cols-12 lg:gap-16 lg:py-28">
+        <div className="flex flex-col gap-8 lg:col-span-7">
+          <span className="inline-flex w-fit items-center gap-1.5 rounded-sm border-2 border-border bg-card px-2 py-1 font-mono text-[10px] uppercase tracking-[0.12em]">
+            <Sparkles className="size-3 text-forge" />
+            v0.1 · production-ready
+          </span>
+
+          <h1 className="text-5xl font-semibold tracking-[-0.04em] sm:text-6xl lg:text-7xl">
+            Ship the parts shadcn{" "}
+            <span className="text-forge">doesn&apos;t</span>{" "}
+            include.
+          </h1>
+
+          <p className="max-w-xl text-base text-muted-foreground sm:text-lg">
+            Multi-select, year picker, tag input, combobox — every component
+            real products need but shadcn doesn&apos;t ship. Copied straight
+            into your repo via the CLI. Two APIs per component. No runtime
+            dependency.
+          </p>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button variant="forge" size="lg" className="group">
+              Get started
+              <ArrowRight className="size-4 transition-transform duration-150 ease-[var(--ease-forge)] group-hover:translate-x-0.5" />
+            </Button>
+            <Button variant="outline" size="lg">
+              Browse the registry
+            </Button>
+          </div>
+
+          <dl className="mt-4 grid grid-cols-3 divide-x-2 divide-border border-y-2 border-border">
+            {STATS.map((s, i) => (
+              <div key={s.label} className={i === 0 ? "py-4 pr-4" : "p-4"}>
+                <dt className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                  {s.label}
+                </dt>
+                <dd className="mt-1 font-mono text-2xl font-medium tabular-nums">
+                  {s.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+
+        <div className="flex items-start lg:col-span-5">
+          <div
+            className="relative w-full rounded-sm border-2 border-border bg-card"
+            style={{ boxShadow: "8px 8px 0 0 var(--border)" }}
+          >
+            <div className="flex items-center justify-between border-b-2 border-border px-4 py-2.5">
+              <span className="inline-flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                <Terminal className="size-3" />
+                sabk/install.sh
+              </span>
+              <div className="flex items-center gap-1">
+                <span className="size-1.5 rounded-full bg-border" />
+                <span className="size-1.5 rounded-full bg-border" />
+                <span className="size-1.5 rounded-full bg-forge" />
+              </div>
+            </div>
+
+            <pre className="overflow-x-auto p-4 font-mono text-[12px] leading-[1.7]">
+              <code>
+                {REGISTRY_LINES.map((line, i) => (
+                  <span key={i} className="block">
+                    {line.kind === "cmd" && (
+                      <>
+                        <span className="text-forge">$</span>{" "}
+                        <span className="text-foreground">{line.text.slice(2)}</span>
+                      </>
+                    )}
+                    {line.kind === "arg" && (
+                      <span className="text-muted-foreground">{line.text}</span>
+                    )}
+                    {line.kind === "out" && (
+                      <span className="text-emerald-500">{line.text}</span>
+                    )}
+                    {line.kind === "blank" && <span>&nbsp;</span>}
+                    {line.kind === "meta" && (
+                      <span className="text-muted-foreground">{line.text}</span>
+                    )}
+                  </span>
+                ))}
+              </code>
+            </pre>
+
+            <div className="border-t-2 border-border bg-background/60 px-4 py-2.5">
+              <div className="flex items-center justify-between font-mono text-[10px] uppercase tracking-[0.1em]">
+                <span className="text-muted-foreground">added</span>
+                <span className="text-foreground">multi-select.tsx</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/registry/sabk/blocks/hero-01/hero-01.tsx
+++ b/registry/sabk/blocks/hero-01/hero-01.tsx
@@ -46,7 +46,7 @@ export default function Hero01() {
             v0.1 · production-ready
           </span>
 
-          <h1 className="text-5xl font-semibold tracking-[-0.04em] sm:text-6xl lg:text-7xl">
+          <h1 className="text-balance text-4xl font-semibold leading-[1.05] tracking-[-0.04em] sm:text-5xl md:text-6xl lg:text-7xl">
             Ship the parts shadcn{" "}
             <span className="text-forge">doesn&apos;t</span>{" "}
             include.

--- a/registry/sabk/blocks/hero-01/index.ts
+++ b/registry/sabk/blocks/hero-01/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./hero-01"

--- a/registry/sabk/blocks/hero-02/hero-02.tsx
+++ b/registry/sabk/blocks/hero-02/hero-02.tsx
@@ -52,7 +52,7 @@ export default function Hero02() {
           <span className="text-muted-foreground">2026.05</span>
         </span>
 
-        <h1 className="max-w-4xl text-balance text-5xl font-semibold leading-[1.02] tracking-[-0.045em] sm:text-6xl lg:text-7xl">
+        <h1 className="max-w-4xl text-balance text-4xl font-semibold leading-[1.05] tracking-[-0.045em] sm:text-5xl md:text-6xl lg:text-7xl">
           The component registry for{" "}
           <span className="relative whitespace-nowrap text-forge">
             serious

--- a/registry/sabk/blocks/hero-02/hero-02.tsx
+++ b/registry/sabk/blocks/hero-02/hero-02.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import * as React from "react"
+import { ArrowRight } from "lucide-react"
+
+import { Button } from "@/registry/sabk/ui/button"
+
+const WORDMARKS = [
+  "ACME / Co.",
+  "Helix",
+  "Northwind",
+  "Forge ◆ Labs",
+  "Vanta",
+  "Quartz",
+] as const
+
+export default function Hero02() {
+  return (
+    <section className="relative isolate overflow-hidden bg-background">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10 opacity-[0.25] [mask-image:radial-gradient(ellipse_at_top,black_20%,transparent_70%)]"
+        style={{
+          backgroundImage:
+            "radial-gradient(circle at 1px 1px, var(--border) 1px, transparent 0)",
+          backgroundSize: "24px 24px",
+        }}
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-px"
+        style={{
+          background:
+            "linear-gradient(to right, transparent 0%, var(--forge) 50%, transparent 100%)",
+        }}
+      />
+
+      <div className="mx-auto flex w-full max-w-5xl flex-col items-center gap-10 px-6 py-24 text-center md:px-10 lg:py-32">
+        <span className="inline-flex items-center gap-2 rounded-sm border-2 border-border bg-card px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em]">
+          <span className="relative flex size-1.5">
+            <span
+              className="absolute inline-flex size-full animate-ping rounded-full opacity-75"
+              style={{ background: "var(--forge)" }}
+            />
+            <span
+              className="relative inline-flex size-1.5 rounded-full"
+              style={{ background: "var(--forge)" }}
+            />
+          </span>
+          Now in public beta
+          <span className="text-muted-foreground">·</span>
+          <span className="text-muted-foreground">2026.05</span>
+        </span>
+
+        <h1 className="max-w-4xl text-balance text-5xl font-semibold leading-[1.02] tracking-[-0.045em] sm:text-6xl lg:text-7xl">
+          The component registry for{" "}
+          <span className="relative whitespace-nowrap text-forge">
+            serious
+            <svg
+              aria-hidden
+              viewBox="0 0 200 12"
+              preserveAspectRatio="none"
+              className="absolute -bottom-1 left-0 h-2 w-full text-forge/70"
+            >
+              <path
+                d="M2 8 Q 50 2, 100 7 T 198 6"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              />
+            </svg>
+          </span>{" "}
+          product teams.
+        </h1>
+
+        <p className="max-w-2xl text-balance text-base text-muted-foreground sm:text-lg">
+          Sabk ships the dense, real-world components every product hits a
+          wall on — tag input, multi-select, combobox, year picker — wired
+          with the dual-API contract and a forge-warm aesthetic that earns
+          its place in your codebase.
+        </p>
+
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <Button variant="forge" size="lg" className="group">
+            Get started
+            <ArrowRight className="size-4 transition-transform duration-150 ease-[var(--ease-forge)] group-hover:translate-x-0.5" />
+          </Button>
+          <Button variant="ghost" size="lg" className="text-foreground">
+            View on GitHub →
+          </Button>
+        </div>
+
+        <div className="mt-8 flex w-full flex-col items-center gap-4">
+          <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+            Trusted by teams shipping at scale
+          </p>
+          <div className="grid w-full grid-cols-2 gap-px overflow-hidden rounded-sm border-2 border-border bg-border sm:grid-cols-3 lg:grid-cols-6">
+            {WORDMARKS.map((w) => (
+              <div
+                key={w}
+                className="flex items-center justify-center bg-background px-3 py-4 font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:text-foreground"
+              >
+                {w}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/registry/sabk/blocks/hero-02/index.ts
+++ b/registry/sabk/blocks/hero-02/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./hero-02"

--- a/registry/sabk/blocks/login-01/index.ts
+++ b/registry/sabk/blocks/login-01/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./login-01"

--- a/registry/sabk/blocks/login-01/login-01.tsx
+++ b/registry/sabk/blocks/login-01/login-01.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import * as React from "react"
+import { ArrowRight } from "lucide-react"
+
+import { Button } from "@/registry/sabk/ui/button"
+import { Input } from "@/registry/sabk/ui/input"
+import { Label } from "@/registry/sabk/ui/label"
+import { PasswordInput } from "@/registry/sabk/password-input/password-input"
+
+function GoogleIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden {...props}>
+      <path
+        fill="currentColor"
+        d="M21.35 11.1H12v3.2h5.34c-.23 1.4-1.66 4.1-5.34 4.1A6.4 6.4 0 1 1 12 5.6c1.83 0 3.05.78 3.75 1.45l2.55-2.46C16.74 3.05 14.55 2 12 2 6.95 2 2.85 6.1 2.85 11.15S6.95 20.3 12 20.3c6.93 0 9.5-4.86 9.5-7.4 0-.5-.06-.88-.15-1.8Z"
+      />
+    </svg>
+  )
+}
+
+function GithubIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden {...props}>
+      <path
+        fill="currentColor"
+        d="M12 2C6.48 2 2 6.58 2 12.22c0 4.5 2.87 8.32 6.84 9.67.5.1.68-.22.68-.49 0-.24-.01-.87-.01-1.7-2.78.61-3.37-1.36-3.37-1.36-.45-1.18-1.11-1.49-1.11-1.49-.91-.63.07-.62.07-.62 1 .07 1.53 1.05 1.53 1.05.9 1.56 2.35 1.11 2.92.85.09-.66.35-1.11.63-1.37-2.22-.26-4.55-1.13-4.55-5.04 0-1.11.39-2.02 1.03-2.74-.1-.26-.45-1.3.1-2.7 0 0 .84-.27 2.75 1.04A9.4 9.4 0 0 1 12 7.04c.85 0 1.7.12 2.5.34 1.9-1.31 2.74-1.04 2.74-1.04.55 1.4.2 2.44.1 2.7.64.72 1.03 1.63 1.03 2.74 0 3.92-2.34 4.78-4.57 5.03.36.32.68.94.68 1.9 0 1.37-.01 2.47-.01 2.81 0 .27.18.6.69.49A10.04 10.04 0 0 0 22 12.22C22 6.58 17.52 2 12 2Z"
+      />
+    </svg>
+  )
+}
+
+export default function Login01() {
+  const [email, setEmail] = React.useState("")
+  const [password, setPassword] = React.useState("")
+  const [remember, setRemember] = React.useState(true)
+
+  return (
+    <section className="relative isolate flex min-h-[640px] items-center justify-center bg-background py-16 md:py-24">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10 opacity-[0.35] [mask-image:radial-gradient(ellipse_at_center,black_30%,transparent_75%)]"
+        style={{
+          backgroundImage:
+            "linear-gradient(to right, var(--border) 1px, transparent 1px), linear-gradient(to bottom, var(--border) 1px, transparent 1px)",
+          backgroundSize: "32px 32px",
+        }}
+      />
+
+      <div className="mx-auto w-full max-w-md px-6">
+        <div
+          className="rounded-sm border-2 border-border bg-card"
+          style={{ boxShadow: "8px 8px 0 0 var(--border)" }}
+        >
+          <div className="flex flex-col items-center gap-4 border-b-2 border-border px-8 pb-6 pt-8">
+            <div className="relative flex size-10 items-center justify-center rounded-sm border-2 border-border bg-background">
+              <span className="text-lg font-semibold tracking-[-0.04em] text-forge">
+                ◆
+              </span>
+              <span
+                aria-hidden
+                className="absolute -bottom-1 -right-1 size-1.5 rounded-full bg-forge"
+              />
+            </div>
+            <div className="flex flex-col items-center gap-1 text-center">
+              <h1 className="text-2xl font-semibold tracking-[-0.025em]">
+                Welcome back
+              </h1>
+              <p className="text-xs text-muted-foreground">
+                Sign in to your Sabk workspace to continue.
+              </p>
+            </div>
+          </div>
+
+          <form
+            className="flex flex-col gap-5 p-8"
+            onSubmit={(e) => e.preventDefault()}
+          >
+            <div className="grid gap-1.5">
+              <Label
+                htmlFor="login01-email"
+                className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground"
+              >
+                Email
+              </Label>
+              <Input
+                id="login01-email"
+                type="email"
+                placeholder="you@studio.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                autoComplete="email"
+              />
+            </div>
+
+            <div className="grid gap-1.5">
+              <div className="flex items-center justify-between">
+                <Label
+                  htmlFor="login01-password"
+                  className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground"
+                >
+                  Password
+                </Label>
+                <a
+                  href="#"
+                  className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:text-forge"
+                >
+                  Forgot?
+                </a>
+              </div>
+              <PasswordInput
+                id="login01-password"
+                value={password}
+                onChange={setPassword}
+                placeholder="••••••••"
+              />
+            </div>
+
+            <label className="inline-flex cursor-pointer items-center gap-2 text-xs text-muted-foreground select-none">
+              <span
+                role="checkbox"
+                aria-checked={remember}
+                tabIndex={0}
+                onClick={() => setRemember(!remember)}
+                onKeyDown={(e) => {
+                  if (e.key === " " || e.key === "Enter") {
+                    e.preventDefault()
+                    setRemember(!remember)
+                  }
+                }}
+                className="relative inline-flex size-4 items-center justify-center rounded-[2px] border-2 border-border bg-transparent transition-colors data-[checked=true]:border-forge data-[checked=true]:bg-forge"
+                data-checked={remember}
+              >
+                {remember && (
+                  <svg
+                    viewBox="0 0 12 12"
+                    aria-hidden
+                    className="size-2.5 text-forge-foreground"
+                  >
+                    <path
+                      d="M2 6.5 5 9.5 10 3.5"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2.2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                )}
+              </span>
+              Keep me signed in
+            </label>
+
+            <Button type="submit" variant="forge" size="lg" className="group">
+              Sign in
+              <ArrowRight className="size-4 transition-transform duration-150 ease-[var(--ease-forge)] group-hover:translate-x-0.5" />
+            </Button>
+
+            <div className="relative my-1">
+              <div className="absolute inset-0 flex items-center">
+                <span className="w-full border-t-2 border-border" />
+              </div>
+              <div className="relative flex justify-center">
+                <span className="bg-card px-2 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                  or continue with
+                </span>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <Button type="button" variant="outline">
+                <GithubIcon className="size-4" />
+                GitHub
+              </Button>
+              <Button type="button" variant="outline">
+                <GoogleIcon className="size-4" />
+                Google
+              </Button>
+            </div>
+          </form>
+
+          <div className="border-t-2 border-border px-8 py-4 text-center">
+            <p className="text-xs text-muted-foreground">
+              No account yet?{" "}
+              <a
+                href="#"
+                className="font-medium text-foreground underline-offset-4 hover:text-forge hover:underline"
+              >
+                Create one
+              </a>
+            </p>
+          </div>
+        </div>
+
+        <p className="mt-4 text-center font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+          Protected by single-tenant auth · SOC2 in progress
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/registry/sabk/blocks/login-01/login-01.tsx
+++ b/registry/sabk/blocks/login-01/login-01.tsx
@@ -116,7 +116,7 @@ export default function Login01() {
               />
             </div>
 
-            <label className="inline-flex cursor-pointer items-center gap-2 text-xs text-muted-foreground select-none">
+            <label className="inline-flex cursor-pointer select-none items-center gap-2 text-xs text-muted-foreground">
               <span
                 role="checkbox"
                 aria-checked={remember}
@@ -128,7 +128,7 @@ export default function Login01() {
                     setRemember(!remember)
                   }
                 }}
-                className="relative inline-flex size-4 items-center justify-center rounded-[2px] border-2 border-border bg-transparent transition-colors data-[checked=true]:border-forge data-[checked=true]:bg-forge"
+                className="relative inline-flex size-4 items-center justify-center rounded-[2px] border-2 border-border bg-transparent transition-colors data-[checked=true]:border-forge data-[checked=true]:bg-forge focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card"
                 data-checked={remember}
               >
                 {remember && (

--- a/registry/sabk/blocks/login-02/index.ts
+++ b/registry/sabk/blocks/login-02/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./login-02"

--- a/registry/sabk/blocks/login-02/login-02.tsx
+++ b/registry/sabk/blocks/login-02/login-02.tsx
@@ -13,8 +13,8 @@ export default function Login02() {
   const [password, setPassword] = React.useState("")
 
   return (
-    <section className="grid min-h-[640px] grid-cols-1 bg-background lg:grid-cols-2">
-      <div className="flex items-center justify-center px-6 py-16 md:px-12">
+    <section className="grid min-h-[640px] grid-cols-1 bg-background md:grid-cols-2">
+      <div className="flex items-center justify-center px-6 py-16 md:px-10 lg:px-12">
         <div className="w-full max-w-sm">
           <div className="mb-10 flex items-center gap-2">
             <span className="inline-flex size-7 items-center justify-center rounded-sm border-2 border-border bg-card text-base font-semibold text-forge">
@@ -104,7 +104,7 @@ export default function Login02() {
         </div>
       </div>
 
-      <div className="relative isolate hidden overflow-hidden border-l-2 border-border bg-card lg:flex lg:items-center lg:justify-center">
+      <div className="relative isolate hidden overflow-hidden border-l-2 border-border bg-card md:flex md:items-center md:justify-center">
         <div
           aria-hidden
           className="pointer-events-none absolute inset-0 -z-10 opacity-30"
@@ -120,10 +120,10 @@ export default function Login02() {
           style={{ background: "var(--forge)" }}
         />
 
-        <div className="flex w-full max-w-md flex-col gap-10 px-12 py-16">
-          <Quote className="size-8 text-forge" strokeWidth={1.5} />
+        <div className="flex w-full max-w-md flex-col gap-8 px-8 py-12 md:gap-10 md:px-10 lg:px-12 lg:py-16">
+          <Quote className="size-7 text-forge md:size-8" strokeWidth={1.5} />
 
-          <blockquote className="text-2xl font-medium leading-[1.3] tracking-[-0.02em] sm:text-3xl">
+          <blockquote className="text-balance text-xl font-medium leading-[1.3] tracking-[-0.02em] md:text-2xl lg:text-3xl">
             Sabk gave us back the week we were going to spend rebuilding
             a <span className="text-forge">multi-select</span> for the
             fourth time.

--- a/registry/sabk/blocks/login-02/login-02.tsx
+++ b/registry/sabk/blocks/login-02/login-02.tsx
@@ -1,0 +1,163 @@
+"use client"
+
+import * as React from "react"
+import { ArrowRight, Quote } from "lucide-react"
+
+import { Button } from "@/registry/sabk/ui/button"
+import { Input } from "@/registry/sabk/ui/input"
+import { Label } from "@/registry/sabk/ui/label"
+import { PasswordInput } from "@/registry/sabk/password-input/password-input"
+
+export default function Login02() {
+  const [email, setEmail] = React.useState("")
+  const [password, setPassword] = React.useState("")
+
+  return (
+    <section className="grid min-h-[640px] grid-cols-1 bg-background lg:grid-cols-2">
+      <div className="flex items-center justify-center px-6 py-16 md:px-12">
+        <div className="w-full max-w-sm">
+          <div className="mb-10 flex items-center gap-2">
+            <span className="inline-flex size-7 items-center justify-center rounded-sm border-2 border-border bg-card text-base font-semibold text-forge">
+              ◆
+            </span>
+            <span className="text-base font-semibold tracking-[-0.025em]">
+              sabk
+            </span>
+            <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+              · forge
+            </span>
+          </div>
+
+          <div className="mb-8 flex flex-col gap-2">
+            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-forge">
+              ◆ sign in
+            </span>
+            <h1 className="text-3xl font-semibold tracking-[-0.03em] sm:text-4xl">
+              Welcome back.
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Use the email you signed up with. We&apos;ll fetch your
+              workspace from there.
+            </p>
+          </div>
+
+          <form
+            className="flex flex-col gap-4"
+            onSubmit={(e) => e.preventDefault()}
+          >
+            <div className="grid gap-1.5">
+              <Label
+                htmlFor="login02-email"
+                className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground"
+              >
+                Work email
+              </Label>
+              <Input
+                id="login02-email"
+                type="email"
+                placeholder="you@studio.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                autoComplete="email"
+              />
+            </div>
+
+            <div className="grid gap-1.5">
+              <div className="flex items-center justify-between">
+                <Label
+                  htmlFor="login02-password"
+                  className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground"
+                >
+                  Password
+                </Label>
+                <a
+                  href="#"
+                  className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:text-forge"
+                >
+                  Reset
+                </a>
+              </div>
+              <PasswordInput
+                id="login02-password"
+                value={password}
+                onChange={setPassword}
+                showStrength
+                placeholder="••••••••"
+              />
+            </div>
+
+            <Button type="submit" variant="forge" size="lg" className="group mt-2">
+              Continue
+              <ArrowRight className="size-4 transition-transform duration-150 ease-[var(--ease-forge)] group-hover:translate-x-0.5" />
+            </Button>
+
+            <p className="mt-2 text-center text-xs text-muted-foreground">
+              No account yet?{" "}
+              <a
+                href="#"
+                className="font-medium text-foreground underline-offset-4 hover:text-forge hover:underline"
+              >
+                Start a workspace
+              </a>
+            </p>
+          </form>
+        </div>
+      </div>
+
+      <div className="relative isolate hidden overflow-hidden border-l-2 border-border bg-card lg:flex lg:items-center lg:justify-center">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 -z-10 opacity-30"
+          style={{
+            backgroundImage:
+              "linear-gradient(to right, var(--border) 1px, transparent 1px), linear-gradient(to bottom, var(--border) 1px, transparent 1px)",
+            backgroundSize: "28px 28px",
+          }}
+        />
+        <div
+          aria-hidden
+          className="pointer-events-none absolute -bottom-32 -right-24 -z-10 size-[420px] rounded-full opacity-[0.18] blur-3xl"
+          style={{ background: "var(--forge)" }}
+        />
+
+        <div className="flex w-full max-w-md flex-col gap-10 px-12 py-16">
+          <Quote className="size-8 text-forge" strokeWidth={1.5} />
+
+          <blockquote className="text-2xl font-medium leading-[1.3] tracking-[-0.02em] sm:text-3xl">
+            Sabk gave us back the week we were going to spend rebuilding
+            a <span className="text-forge">multi-select</span> for the
+            fourth time.
+          </blockquote>
+
+          <div className="flex items-center gap-4 border-t-2 border-border pt-6">
+            <div className="flex size-10 items-center justify-center rounded-sm border-2 border-border bg-background font-mono text-sm font-medium text-forge">
+              MR
+            </div>
+            <div className="flex flex-col">
+              <span className="text-sm font-medium">Mara Riviera</span>
+              <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                Eng lead · Helix
+              </span>
+            </div>
+          </div>
+
+          <dl className="grid grid-cols-2 gap-px overflow-hidden rounded-sm border-2 border-border bg-border">
+            {[
+              ["12", "components"],
+              ["0", "runtime deps"],
+            ].map(([n, label]) => (
+              <div key={label} className="bg-card px-4 py-3">
+                <dt className="font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground">
+                  {label}
+                </dt>
+                <dd className="mt-0.5 font-mono text-xl font-medium tabular-nums">
+                  {n}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/registry/sabk/combobox/combobox.demo.tsx
+++ b/registry/sabk/combobox/combobox.demo.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import * as React from "react"
+
+import { Label } from "@/registry/sabk/ui/label"
+import {
+  Combobox,
+  useAsyncComboboxOptions,
+} from "@/registry/sabk/combobox/combobox"
+
+const FRAMEWORKS = [
+  { value: "next", label: "Next.js", group: "React" },
+  { value: "remix", label: "Remix", group: "React" },
+  { value: "astro", label: "Astro", group: "Hybrid" },
+  { value: "nuxt", label: "Nuxt", group: "Vue" },
+  { value: "sveltekit", label: "SvelteKit", group: "Svelte" },
+  { value: "solid-start", label: "SolidStart", group: "Solid" },
+  { value: "tanstack-start", label: "TanStack Start", group: "React" },
+]
+
+/** Simulates an async API: filters the static list with a small delay. */
+type Pkg = { name: string; description: string }
+async function fakeSearchPackages(q: string): Promise<Pkg[]> {
+  await new Promise((r) => setTimeout(r, 250))
+  const all: Pkg[] = [
+    { name: "react", description: "A JS library for UIs" },
+    { name: "react-dom", description: "Renderer for the DOM" },
+    { name: "react-router", description: "Declarative routing" },
+    { name: "zod", description: "TypeScript-first schemas" },
+    { name: "next", description: "The React framework" },
+    { name: "tailwindcss", description: "Utility-first CSS" },
+    { name: "shadcn", description: "Build your own component library" },
+    { name: "lucide-react", description: "Icon set" },
+  ]
+  if (!q) return all.slice(0, 5)
+  return all.filter((p) =>
+    `${p.name} ${p.description}`.toLowerCase().includes(q.toLowerCase())
+  )
+}
+
+export default function ComboboxDemo() {
+  const [staticValue, setStaticValue] = React.useState<string | undefined>(
+    "next"
+  )
+  const [asyncValue, setAsyncValue] = React.useState<string | undefined>()
+
+  const mapPkg = React.useCallback(
+    (p: Pkg) => ({ value: p.name, label: p.name, group: "npm" }),
+    []
+  )
+  const { setQuery, options, loading } = useAsyncComboboxOptions(
+    fakeSearchPackages,
+    mapPkg
+  )
+
+  return (
+    <div className="grid w-full max-w-md gap-8">
+      <div className="grid gap-2">
+        <Label>Single-prop API · static options</Label>
+        <Combobox
+          options={FRAMEWORKS}
+          value={staticValue}
+          onChange={setStaticValue}
+          placeholder="Pick a framework"
+        />
+      </div>
+
+      <div className="grid gap-2">
+        <Label>Compound API · async loader (250ms simulated)</Label>
+        <Combobox.Root
+          value={asyncValue}
+          onValueChange={setAsyncValue}
+          options={options}
+          loading={loading}
+          onSearchChange={setQuery}
+          externalFilter
+        >
+          <Combobox.Trigger placeholder="Search npm packages…" />
+          <Combobox.Content
+            searchPlaceholder="Type to query…"
+            emptyMessage="No packages match."
+          />
+        </Combobox.Root>
+        <p className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+          value = {asyncValue ? `"${asyncValue}"` : "—"}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/registry/sabk/combobox/combobox.tsx
+++ b/registry/sabk/combobox/combobox.tsx
@@ -1,0 +1,468 @@
+"use client"
+
+import * as React from "react"
+import { Check, ChevronDown, Loader2, X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/registry/sabk/ui/popover"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/registry/sabk/ui/command"
+
+/* ============================================================================
+ * Types
+ * ========================================================================== */
+
+export type ComboboxOption = {
+  value: string
+  label: string
+  group?: string
+  disabled?: boolean
+}
+
+type Ctx = {
+  value: string | undefined
+  setValue: (next: string | undefined) => void
+  options: ComboboxOption[]
+  open: boolean
+  setOpen: (next: boolean) => void
+  search: string
+  setSearch: (next: string) => void
+  loading?: boolean
+  disabled?: boolean
+  clearable: boolean
+  /** When true, the consumer is filtering externally (async); cmdk should not filter again. */
+  externalFilter: boolean
+}
+
+const ComboboxContext = React.createContext<Ctx | null>(null)
+
+function useCombobox() {
+  const ctx = React.useContext(ComboboxContext)
+  if (!ctx) {
+    throw new Error(
+      "Combobox compound parts must be used inside <Combobox.Root>"
+    )
+  }
+  return ctx
+}
+
+/* ============================================================================
+ * Root
+ * ========================================================================== */
+
+export type ComboboxRootProps = {
+  value?: string
+  defaultValue?: string
+  onValueChange?: (value: string | undefined) => void
+  options?: ComboboxOption[]
+  open?: boolean
+  defaultOpen?: boolean
+  onOpenChange?: (open: boolean) => void
+  /** Forwards search input changes (use for async loaders). */
+  onSearchChange?: (search: string) => void
+  /** When set, cmdk's internal filtering is disabled — useful for async. */
+  externalFilter?: boolean
+  loading?: boolean
+  disabled?: boolean
+  /** Allow clearing the selection via the trigger's clear button. Default: true. */
+  clearable?: boolean
+  children?: React.ReactNode
+}
+
+function ComboboxRoot({
+  value: valueProp,
+  defaultValue,
+  onValueChange,
+  options = [],
+  open: openProp,
+  defaultOpen = false,
+  onOpenChange,
+  onSearchChange,
+  externalFilter = false,
+  loading,
+  disabled,
+  clearable = true,
+  children,
+}: ComboboxRootProps) {
+  const [internalValue, setInternalValue] = React.useState<string | undefined>(
+    defaultValue
+  )
+  const value = valueProp !== undefined ? valueProp : internalValue
+  const setValue = React.useCallback(
+    (next: string | undefined) => {
+      if (valueProp === undefined) setInternalValue(next)
+      onValueChange?.(next)
+    },
+    [valueProp, onValueChange]
+  )
+
+  const [internalOpen, setInternalOpen] = React.useState(defaultOpen)
+  const open = openProp ?? internalOpen
+  const setOpen = React.useCallback(
+    (next: boolean) => {
+      if (openProp === undefined) setInternalOpen(next)
+      onOpenChange?.(next)
+    },
+    [openProp, onOpenChange]
+  )
+
+  const [search, setSearchState] = React.useState("")
+  const setSearch = React.useCallback(
+    (next: string) => {
+      setSearchState(next)
+      onSearchChange?.(next)
+    },
+    [onSearchChange]
+  )
+
+  const ctx = React.useMemo<Ctx>(
+    () => ({
+      value,
+      setValue,
+      options,
+      open,
+      setOpen,
+      search,
+      setSearch,
+      loading,
+      disabled,
+      clearable,
+      externalFilter,
+    }),
+    [
+      value,
+      setValue,
+      options,
+      open,
+      setOpen,
+      search,
+      setSearch,
+      loading,
+      disabled,
+      clearable,
+      externalFilter,
+    ]
+  )
+
+  return (
+    <ComboboxContext.Provider value={ctx}>
+      <Popover open={open} onOpenChange={setOpen}>
+        {children}
+      </Popover>
+    </ComboboxContext.Provider>
+  )
+}
+
+/* ============================================================================
+ * Trigger
+ * ========================================================================== */
+
+type ComboboxTriggerProps = Omit<
+  React.ComponentProps<"button">,
+  "children"
+> & {
+  placeholder?: string
+  className?: string
+  children?: React.ReactNode | ((ctx: Ctx) => React.ReactNode)
+}
+
+function ComboboxTrigger({
+  placeholder = "Select…",
+  className,
+  children,
+  ...props
+}: ComboboxTriggerProps) {
+  const ctx = useCombobox()
+  const selected = ctx.options.find((o) => o.value === ctx.value)
+
+  return (
+    <PopoverTrigger asChild>
+      <button
+        type="button"
+        role="combobox"
+        aria-expanded={ctx.open}
+        aria-haspopup="listbox"
+        disabled={ctx.disabled}
+        data-slot="combobox-trigger"
+        data-state={ctx.open ? "open" : "closed"}
+        className={cn(
+          "group flex h-9 w-full items-center justify-between gap-2 rounded-sm border-2 border-input bg-transparent px-2.5 text-left text-sm outline-none transition-colors",
+          "hover:border-ring/60 focus-visible:border-ring",
+          "data-[state=open]:border-ring",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      >
+        {typeof children === "function" ? (
+          children(ctx)
+        ) : children ? (
+          children
+        ) : (
+          <>
+            <span
+              className={cn(
+                "flex-1 truncate",
+                !selected && "text-muted-foreground"
+              )}
+            >
+              {selected ? selected.label : placeholder}
+            </span>
+            <span className="flex shrink-0 items-center gap-1 text-muted-foreground">
+              {ctx.clearable && ctx.value !== undefined && !ctx.disabled && (
+                <span
+                  role="button"
+                  tabIndex={-1}
+                  aria-label="Clear selection"
+                  onPointerDown={(e) => {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    ctx.setValue(undefined)
+                  }}
+                  className="inline-flex size-4 items-center justify-center rounded-[2px] hover:bg-accent hover:text-foreground"
+                >
+                  <X className="size-3" />
+                </span>
+              )}
+              <ChevronDown
+                className={cn(
+                  "size-3.5 transition-transform duration-150",
+                  ctx.open && "rotate-180"
+                )}
+              />
+            </span>
+          </>
+        )}
+      </button>
+    </PopoverTrigger>
+  )
+}
+
+/* ============================================================================
+ * Content (the dropdown)
+ * ========================================================================== */
+
+type ComboboxContentProps = React.ComponentProps<typeof PopoverContent> & {
+  searchPlaceholder?: string
+  emptyMessage?: string
+  loadingMessage?: string
+  children?: React.ReactNode
+}
+
+function ComboboxContent({
+  className,
+  searchPlaceholder = "Search…",
+  emptyMessage = "Nothing found.",
+  loadingMessage = "Loading…",
+  children,
+  ...props
+}: ComboboxContentProps) {
+  const ctx = useCombobox()
+
+  const groups = React.useMemo(() => {
+    const map = new Map<string | undefined, ComboboxOption[]>()
+    for (const opt of ctx.options) {
+      const key = opt.group
+      if (!map.has(key)) map.set(key, [])
+      map.get(key)!.push(opt)
+    }
+    return Array.from(map.entries())
+  }, [ctx.options])
+
+  return (
+    <PopoverContent
+      align="start"
+      sideOffset={6}
+      className={cn(
+        "w-(--radix-popover-trigger-width) min-w-[14rem] p-0",
+        className
+      )}
+      onOpenAutoFocus={(e) => e.preventDefault()}
+      {...props}
+    >
+      <Command shouldFilter={!ctx.externalFilter} loop>
+        <CommandInput
+          placeholder={searchPlaceholder}
+          value={ctx.search}
+          onValueChange={ctx.setSearch}
+        />
+        <CommandList>
+          {ctx.loading ? (
+            <div className="flex items-center justify-center gap-2 py-6 text-xs text-muted-foreground">
+              <Loader2 className="size-3.5 animate-spin" />
+              {loadingMessage}
+            </div>
+          ) : (
+            <>
+              <CommandEmpty>{emptyMessage}</CommandEmpty>
+              {children ??
+                groups.map(([group, items]) => (
+                  <CommandGroup key={group ?? "__default"} heading={group}>
+                    {items.map((opt) => (
+                      <ComboboxItem key={opt.value} option={opt} />
+                    ))}
+                  </CommandGroup>
+                ))}
+            </>
+          )}
+        </CommandList>
+      </Command>
+    </PopoverContent>
+  )
+}
+
+/* ============================================================================
+ * Item
+ * ========================================================================== */
+
+type ComboboxItemProps = Omit<
+  React.ComponentProps<typeof CommandItem>,
+  "value" | "onSelect" | "children"
+> & {
+  option: ComboboxOption
+  children?: React.ReactNode
+}
+
+function ComboboxItem({
+  option,
+  children,
+  className,
+  ...props
+}: ComboboxItemProps) {
+  const ctx = useCombobox()
+  const selected = ctx.value === option.value
+
+  return (
+    <CommandItem
+      value={`${option.label} ${option.value}`}
+      disabled={option.disabled}
+      onSelect={() => {
+        ctx.setValue(selected ? undefined : option.value)
+        ctx.setOpen(false)
+      }}
+      className={cn("justify-between", className)}
+      {...props}
+    >
+      <span className="truncate">{children ?? option.label}</span>
+      {selected && <Check className="size-3.5 text-forge" strokeWidth={3} />}
+    </CommandItem>
+  )
+}
+
+/* ============================================================================
+ * Async loader hook
+ * ========================================================================== */
+
+export function useAsyncComboboxOptions<T>(
+  loader: (query: string) => Promise<T[]>,
+  map: (item: T) => ComboboxOption,
+  { debounce = 200, initialQuery = "" }: { debounce?: number; initialQuery?: string } = {}
+) {
+  const [query, setQuery] = React.useState(initialQuery)
+  const [options, setOptions] = React.useState<ComboboxOption[]>([])
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState<unknown>(null)
+  const reqId = React.useRef(0)
+
+  React.useEffect(() => {
+    const id = ++reqId.current
+    const t = setTimeout(async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const result = await loader(query)
+        if (id === reqId.current) setOptions(result.map(map))
+      } catch (e) {
+        if (id === reqId.current) setError(e)
+      } finally {
+        if (id === reqId.current) setLoading(false)
+      }
+    }, debounce)
+    return () => clearTimeout(t)
+  }, [query, loader, map, debounce])
+
+  return { query, setQuery, options, loading, error }
+}
+
+/* ============================================================================
+ * Single-prop convenience wrapper
+ * ========================================================================== */
+
+export type ComboboxProps = Omit<ComboboxRootProps, "children"> & {
+  placeholder?: string
+  searchPlaceholder?: string
+  emptyMessage?: string
+  loadingMessage?: string
+  className?: string
+  onChange?: (value: string | undefined) => void
+}
+
+function Combobox({
+  options,
+  value,
+  defaultValue,
+  onValueChange,
+  onChange,
+  onSearchChange,
+  externalFilter,
+  loading,
+  disabled,
+  clearable,
+  placeholder,
+  searchPlaceholder,
+  emptyMessage,
+  loadingMessage,
+  className,
+  ...rest
+}: ComboboxProps) {
+  return (
+    <ComboboxRoot
+      options={options}
+      value={value}
+      defaultValue={defaultValue}
+      onValueChange={onValueChange ?? onChange}
+      onSearchChange={onSearchChange}
+      externalFilter={externalFilter}
+      loading={loading}
+      disabled={disabled}
+      clearable={clearable}
+      {...rest}
+    >
+      <ComboboxTrigger placeholder={placeholder} className={className} />
+      <ComboboxContent
+        searchPlaceholder={searchPlaceholder}
+        emptyMessage={emptyMessage}
+        loadingMessage={loadingMessage}
+      />
+    </ComboboxRoot>
+  )
+}
+
+/* ============================================================================
+ * Exports
+ * ========================================================================== */
+
+const ComboboxNamespace = Object.assign(Combobox, {
+  Root: ComboboxRoot,
+  Trigger: ComboboxTrigger,
+  Content: ComboboxContent,
+  Item: ComboboxItem,
+})
+
+export {
+  ComboboxNamespace as Combobox,
+  ComboboxRoot,
+  ComboboxTrigger,
+  ComboboxContent,
+  ComboboxItem,
+}

--- a/registry/sabk/combobox/index.ts
+++ b/registry/sabk/combobox/index.ts
@@ -1,0 +1,1 @@
+export * from "./combobox"

--- a/registry/sabk/password-input/index.ts
+++ b/registry/sabk/password-input/index.ts
@@ -1,0 +1,1 @@
+export * from "./password-input"

--- a/registry/sabk/password-input/password-input.demo.tsx
+++ b/registry/sabk/password-input/password-input.demo.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import * as React from "react"
+
+import { Label } from "@/registry/sabk/ui/label"
+import { PasswordInput } from "@/registry/sabk/password-input/password-input"
+
+export default function PasswordInputDemo() {
+  const [single, setSingle] = React.useState("")
+  const [compound, setCompound] = React.useState("hunter2")
+
+  return (
+    <div className="grid w-full max-w-md gap-8">
+      <div className="grid gap-2">
+        <Label htmlFor="pw-single">Single-prop API · with strength meter</Label>
+        <PasswordInput
+          id="pw-single"
+          value={single}
+          onChange={setSingle}
+          showStrength
+          placeholder="Pick a strong one"
+        />
+      </div>
+
+      <div className="grid gap-2">
+        <Label htmlFor="pw-compound">Compound API · custom strength hint</Label>
+        <PasswordInput.Root
+          id="pw-compound"
+          value={compound}
+          onValueChange={setCompound}
+        >
+          <PasswordInput.Field placeholder="Type to see strength" />
+          <PasswordInput.Strength
+            renderMeta={(s) => (
+              <p className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+                score {s.score} / 4 · {s.label}
+              </p>
+            )}
+          />
+        </PasswordInput.Root>
+      </div>
+    </div>
+  )
+}

--- a/registry/sabk/password-input/password-input.tsx
+++ b/registry/sabk/password-input/password-input.tsx
@@ -1,0 +1,316 @@
+"use client"
+
+import * as React from "react"
+import { Eye, EyeOff } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Input } from "@/registry/sabk/ui/input"
+
+/* ============================================================================
+ * Types & default scorer
+ * ========================================================================== */
+
+export type PasswordStrength = {
+  /** Integer 0-4. */
+  score: number
+  /** Short label (e.g. "weak"). */
+  label: string
+  /** Optional hint shown next to the meter. */
+  hint?: string
+}
+
+export type PasswordScorer = (value: string) => PasswordStrength
+
+/** Default scorer: counts length and character classes; produces a 0-4 score. */
+export const defaultPasswordScorer: PasswordScorer = (value) => {
+  if (!value) return { score: 0, label: "empty" }
+  let score = 0
+  if (value.length >= 8) score++
+  if (value.length >= 12) score++
+  const classes =
+    Number(/[a-z]/.test(value)) +
+    Number(/[A-Z]/.test(value)) +
+    Number(/\d/.test(value)) +
+    Number(/[^A-Za-z0-9]/.test(value))
+  if (classes >= 2) score++
+  if (classes >= 3) score++
+  score = Math.min(score, 4)
+  const labels = ["weak", "weak", "fair", "good", "strong"] as const
+  const hints = [
+    "8+ chars, mix character types",
+    "Try a longer passphrase",
+    "Add a number or symbol",
+    "Nearly there — make it longer",
+    "Strong",
+  ] as const
+  return { score, label: labels[score], hint: hints[score] }
+}
+
+/* ============================================================================
+ * Context
+ * ========================================================================== */
+
+type Ctx = {
+  id: string
+  value: string
+  setValue: (v: string) => void
+  visible: boolean
+  setVisible: (v: boolean) => void
+  disabled?: boolean
+  scorer: PasswordScorer
+  strength: PasswordStrength
+}
+
+const PasswordContext = React.createContext<Ctx | null>(null)
+
+function usePasswordContext() {
+  const ctx = React.useContext(PasswordContext)
+  if (!ctx) {
+    throw new Error(
+      "PasswordInput compound parts must be used inside <PasswordInput.Root>"
+    )
+  }
+  return ctx
+}
+
+/* ============================================================================
+ * Root
+ * ========================================================================== */
+
+export type PasswordInputRootProps = {
+  id?: string
+  value?: string
+  defaultValue?: string
+  onValueChange?: (value: string) => void
+  disabled?: boolean
+  scorer?: PasswordScorer
+  children: React.ReactNode
+}
+
+function PasswordInputRoot({
+  id,
+  value: valueProp,
+  defaultValue = "",
+  onValueChange,
+  disabled,
+  scorer = defaultPasswordScorer,
+  children,
+}: PasswordInputRootProps) {
+  const reactId = React.useId()
+  const fieldId = id ?? reactId
+
+  const [internalValue, setInternalValue] = React.useState(defaultValue)
+  const value = valueProp ?? internalValue
+  const setValue = React.useCallback(
+    (next: string) => {
+      if (valueProp === undefined) setInternalValue(next)
+      onValueChange?.(next)
+    },
+    [valueProp, onValueChange]
+  )
+
+  const [visible, setVisible] = React.useState(false)
+
+  const strength = React.useMemo(() => scorer(value), [scorer, value])
+
+  const ctx = React.useMemo<Ctx>(
+    () => ({
+      id: fieldId,
+      value,
+      setValue,
+      visible,
+      setVisible,
+      disabled,
+      scorer,
+      strength,
+    }),
+    [fieldId, value, setValue, visible, disabled, scorer, strength]
+  )
+
+  return (
+    <PasswordContext.Provider value={ctx}>{children}</PasswordContext.Provider>
+  )
+}
+
+/* ============================================================================
+ * Field (the input + toggle)
+ * ========================================================================== */
+
+type PasswordInputFieldProps = Omit<
+  React.ComponentProps<"input">,
+  "type" | "value" | "defaultValue" | "onChange" | "id"
+> & {
+  showToggle?: boolean
+  toggleLabel?: { show: string; hide: string }
+  className?: string
+}
+
+function PasswordInputField({
+  showToggle = true,
+  toggleLabel = { show: "Show password", hide: "Hide password" },
+  className,
+  ...props
+}: PasswordInputFieldProps) {
+  const ctx = usePasswordContext()
+  return (
+    <div className="relative">
+      <Input
+        id={ctx.id}
+        type={ctx.visible ? "text" : "password"}
+        value={ctx.value}
+        onChange={(e) => ctx.setValue(e.target.value)}
+        disabled={ctx.disabled}
+        autoComplete="current-password"
+        className={cn(showToggle && "pr-10", className)}
+        data-slot="password-input"
+        {...props}
+      />
+      {showToggle && (
+        <button
+          type="button"
+          tabIndex={-1}
+          aria-label={ctx.visible ? toggleLabel.hide : toggleLabel.show}
+          aria-pressed={ctx.visible}
+          onClick={() => ctx.setVisible(!ctx.visible)}
+          disabled={ctx.disabled}
+          className="absolute right-1 top-1/2 inline-flex size-7 -translate-y-1/2 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+        >
+          {ctx.visible ? (
+            <EyeOff className="size-3.5" />
+          ) : (
+            <Eye className="size-3.5" />
+          )}
+        </button>
+      )}
+    </div>
+  )
+}
+
+/* ============================================================================
+ * Strength meter
+ * ========================================================================== */
+
+const STRENGTH_COLORS = [
+  "bg-destructive",
+  "bg-destructive",
+  "bg-amber-500",
+  "bg-forge",
+  "bg-emerald-500",
+] as const
+
+type PasswordInputStrengthProps = React.ComponentProps<"div"> & {
+  showLabel?: boolean
+  /** Render a custom label/hint pair given the strength. */
+  renderMeta?: (strength: PasswordStrength) => React.ReactNode
+}
+
+function PasswordInputStrength({
+  showLabel = true,
+  renderMeta,
+  className,
+  ...props
+}: PasswordInputStrengthProps) {
+  const ctx = usePasswordContext()
+  const s = ctx.strength
+  const bar = STRENGTH_COLORS[s.score] ?? STRENGTH_COLORS[0]
+  return (
+    <div
+      data-slot="password-strength"
+      className={cn("flex flex-col gap-1.5", className)}
+      {...props}
+    >
+      <div className="grid grid-cols-4 gap-1">
+        {[1, 2, 3, 4].map((tier) => (
+          <span
+            key={tier}
+            className={cn(
+              "h-1 rounded-sm bg-border transition-colors duration-200 ease-[var(--ease-forge)]",
+              s.score >= tier && bar
+            )}
+          />
+        ))}
+      </div>
+      {showLabel &&
+        (renderMeta ? (
+          renderMeta(s)
+        ) : (
+          <div className="flex items-center justify-between gap-2">
+            <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+              {s.label}
+            </span>
+            {s.hint && (
+              <span className="text-[11px] text-muted-foreground">
+                {s.hint}
+              </span>
+            )}
+          </div>
+        ))}
+    </div>
+  )
+}
+
+/* ============================================================================
+ * Single-prop convenience wrapper
+ * ========================================================================== */
+
+export type PasswordInputProps = Omit<
+  React.ComponentProps<"input">,
+  "type" | "value" | "defaultValue" | "onChange"
+> & {
+  value?: string
+  defaultValue?: string
+  onValueChange?: (value: string) => void
+  onChange?: (value: string) => void
+  showToggle?: boolean
+  showStrength?: boolean
+  scorer?: PasswordScorer
+}
+
+function PasswordInput({
+  id,
+  value,
+  defaultValue,
+  onValueChange,
+  onChange,
+  disabled,
+  showToggle,
+  showStrength = false,
+  scorer,
+  className,
+  ...rest
+}: PasswordInputProps) {
+  return (
+    <PasswordInputRoot
+      id={id}
+      value={value}
+      defaultValue={defaultValue}
+      onValueChange={onValueChange ?? onChange}
+      disabled={disabled}
+      scorer={scorer}
+    >
+      <PasswordInputField
+        showToggle={showToggle}
+        className={className}
+        {...rest}
+      />
+      {showStrength && <PasswordInputStrength />}
+    </PasswordInputRoot>
+  )
+}
+
+/* ============================================================================
+ * Exports
+ * ========================================================================== */
+
+const PasswordInputNamespace = Object.assign(PasswordInput, {
+  Root: PasswordInputRoot,
+  Field: PasswordInputField,
+  Strength: PasswordInputStrength,
+})
+
+export {
+  PasswordInputNamespace as PasswordInput,
+  PasswordInputRoot,
+  PasswordInputField,
+  PasswordInputStrength,
+}

--- a/registry/sabk/registry-meta.ts
+++ b/registry/sabk/registry-meta.ts
@@ -1,7 +1,10 @@
 import * as React from "react"
 
+import ComboboxDemo from "@/registry/sabk/combobox/combobox.demo"
 import MultiSelectDemo from "@/registry/sabk/multi-select/multi-select.demo"
 import NumberRangeDemo from "@/registry/sabk/number-range/number-range.demo"
+import PasswordInputDemo from "@/registry/sabk/password-input/password-input.demo"
+import TagInputDemo from "@/registry/sabk/tag-input/tag-input.demo"
 import YearPickerDemo from "@/registry/sabk/year-picker/year-picker.demo"
 
 export type ComponentCategory = "inputs" | "pickers" | "files"
@@ -59,6 +62,42 @@ export const REGISTRY: RegistryEntryMeta[] = [
     registryDependencies: ["button", "popover"],
     dependencies: ["lucide-react"],
   },
+  {
+    name: "tag-input",
+    title: "Tag Input",
+    description:
+      "Chip input with paste-to-split, dedupe, validation hook, max tags. Compound and single-prop APIs.",
+    category: "inputs",
+    status: "stable",
+    Demo: TagInputDemo,
+    sourceFiles: ["registry/sabk/tag-input/tag-input.tsx"],
+    registryDependencies: ["badge"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "combobox",
+    title: "Combobox",
+    description:
+      "Searchable single-select with debounced async loader, group headings and clearable selection.",
+    category: "inputs",
+    status: "stable",
+    Demo: ComboboxDemo,
+    sourceFiles: ["registry/sabk/combobox/combobox.tsx"],
+    registryDependencies: ["button", "popover", "command"],
+    dependencies: ["cmdk", "lucide-react"],
+  },
+  {
+    name: "password-input",
+    title: "Password Input",
+    description:
+      "Show/hide toggle with an optional pluggable strength meter. Compound and single-prop APIs.",
+    category: "inputs",
+    status: "stable",
+    Demo: PasswordInputDemo,
+    sourceFiles: ["registry/sabk/password-input/password-input.tsx"],
+    registryDependencies: ["input"],
+    dependencies: ["lucide-react"],
+  },
   // Phase 1 stubs — declared in registry.json, implementation pending.
   {
     name: "month-picker",
@@ -72,27 +111,6 @@ export const REGISTRY: RegistryEntryMeta[] = [
     title: "Time Picker",
     description: "Hour / minute / second wheels, 12 or 24h, step intervals.",
     category: "pickers",
-    status: "planned",
-  },
-  {
-    name: "tag-input",
-    title: "Tag Input",
-    description: "Chip input with paste-to-split, dedupe, validation, max tags.",
-    category: "inputs",
-    status: "planned",
-  },
-  {
-    name: "combobox",
-    title: "Combobox (async)",
-    description: "Searchable single-select with debounced loader.",
-    category: "inputs",
-    status: "planned",
-  },
-  {
-    name: "password-input",
-    title: "Password Input",
-    description: "Show/hide toggle, optional zxcvbn-pluggable strength meter.",
-    category: "inputs",
     status: "planned",
   },
   {

--- a/registry/sabk/registry-meta.ts
+++ b/registry/sabk/registry-meta.ts
@@ -7,7 +7,18 @@ import PasswordInputDemo from "@/registry/sabk/password-input/password-input.dem
 import TagInputDemo from "@/registry/sabk/tag-input/tag-input.demo"
 import YearPickerDemo from "@/registry/sabk/year-picker/year-picker.demo"
 
-export type ComponentCategory = "inputs" | "pickers" | "files"
+import Cta01 from "@/registry/sabk/blocks/cta-01/cta-01"
+import Cta02 from "@/registry/sabk/blocks/cta-02/cta-02"
+import Faq01 from "@/registry/sabk/blocks/faq-01/faq-01"
+import Faq02 from "@/registry/sabk/blocks/faq-02/faq-02"
+import Hero01 from "@/registry/sabk/blocks/hero-01/hero-01"
+import Hero02 from "@/registry/sabk/blocks/hero-02/hero-02"
+import Login01 from "@/registry/sabk/blocks/login-01/login-01"
+import Login02 from "@/registry/sabk/blocks/login-02/login-02"
+
+export type ComponentCategory = "inputs" | "pickers" | "files" | "blocks"
+
+export type BlockKind = "hero" | "cta" | "faq" | "login"
 
 export type RegistryEntryMeta = {
   name: string
@@ -23,6 +34,10 @@ export type RegistryEntryMeta = {
   installSlug?: string
   registryDependencies?: string[]
   dependencies?: string[]
+  /** Block-only: the kind of section this block is, used for /blocks grouping. */
+  blockKind?: BlockKind
+  /** Block-only: short tagline shown on the /blocks index cards. */
+  blockTagline?: string
 }
 
 export const REGISTRY: RegistryEntryMeta[] = [
@@ -98,7 +113,120 @@ export const REGISTRY: RegistryEntryMeta[] = [
     registryDependencies: ["input"],
     dependencies: ["lucide-react"],
   },
-  // Phase 1 stubs — declared in registry.json, implementation pending.
+  // ===== Blocks =====
+  {
+    name: "hero-01",
+    title: "Hero · stat strip + install card",
+    description:
+      "Split hero with eyebrow tag, display headline, dual CTA, three-stat strip and a mock install-card visual.",
+    blockTagline: "Split layout · stat strip · mock install card",
+    category: "blocks",
+    blockKind: "hero",
+    status: "stable",
+    Demo: Hero01,
+    sourceFiles: ["registry/sabk/blocks/hero-01/hero-01.tsx"],
+    registryDependencies: ["button"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "hero-02",
+    title: "Hero · centered editorial",
+    description:
+      "Centered hero with animated live-pill, display headline with underlined accent, sub-copy and a trusted-by wordmark strip.",
+    blockTagline: "Centered · live pill · wordmark strip",
+    category: "blocks",
+    blockKind: "hero",
+    status: "stable",
+    Demo: Hero02,
+    sourceFiles: ["registry/sabk/blocks/hero-02/hero-02.tsx"],
+    registryDependencies: ["button"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "cta-01",
+    title: "CTA · framed band",
+    description:
+      "Framed CTA card with forge corner marks, headline + sub-copy on the left, dual buttons stacked on the right.",
+    blockTagline: "Framed · split layout · corner marks",
+    category: "blocks",
+    blockKind: "cta",
+    status: "stable",
+    Demo: Cta01,
+    sourceFiles: ["registry/sabk/blocks/cta-01/cta-01.tsx"],
+    registryDependencies: ["button"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "cta-02",
+    title: "CTA · centered announce",
+    description:
+      "Full-bleed centered CTA with framing top/bottom rules, highlight underlay on the key word, and an inline install command.",
+    blockTagline: "Centered · highlight underlay · install command",
+    category: "blocks",
+    blockKind: "cta",
+    status: "stable",
+    Demo: Cta02,
+    sourceFiles: ["registry/sabk/blocks/cta-02/cta-02.tsx"],
+    registryDependencies: ["button"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "faq-01",
+    title: "FAQ · sticky split",
+    description:
+      "Two-column FAQ — sticky heading + contact card on the left, numbered accordion on the right.",
+    blockTagline: "Sticky split · numbered · contact card",
+    category: "blocks",
+    blockKind: "faq",
+    status: "stable",
+    Demo: Faq01,
+    sourceFiles: ["registry/sabk/blocks/faq-01/faq-01.tsx"],
+    registryDependencies: ["button", "accordion"],
+    dependencies: ["@radix-ui/react-accordion", "lucide-react"],
+  },
+  {
+    name: "faq-02",
+    title: "FAQ · centered grid",
+    description:
+      "Centered heading with two-column accordion grid below. Each row tagged with a Qn index.",
+    blockTagline: "Centered · two-column grid · Qn-indexed",
+    category: "blocks",
+    blockKind: "faq",
+    status: "stable",
+    Demo: Faq02,
+    sourceFiles: ["registry/sabk/blocks/faq-02/faq-02.tsx"],
+    registryDependencies: ["accordion"],
+    dependencies: ["@radix-ui/react-accordion"],
+  },
+  {
+    name: "login-01",
+    title: "Login · centered card",
+    description:
+      "Centered login card with forge monogram, email + password (using the password-input component), remember-me, divider and GitHub / Google providers.",
+    blockTagline: "Centered card · providers · password-input",
+    category: "blocks",
+    blockKind: "login",
+    status: "stable",
+    Demo: Login01,
+    sourceFiles: ["registry/sabk/blocks/login-01/login-01.tsx"],
+    registryDependencies: ["button", "input", "label", "password-input"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "login-02",
+    title: "Login · split testimonial",
+    description:
+      "Two-pane login: form on the left, dark testimonial panel with quote and metrics on the right. Uses the strength-meter variant of password-input.",
+    blockTagline: "Split · testimonial pane · strength meter",
+    category: "blocks",
+    blockKind: "login",
+    status: "stable",
+    Demo: Login02,
+    sourceFiles: ["registry/sabk/blocks/login-02/login-02.tsx"],
+    registryDependencies: ["button", "input", "label", "password-input"],
+    dependencies: ["lucide-react"],
+  },
+  // ===== Phase 1 stubs — declared in registry.json, implementation pending =====
   {
     name: "month-picker",
     title: "Month Picker",
@@ -151,6 +279,7 @@ export const CATEGORY_LABELS: Record<ComponentCategory, string> = {
   inputs: "Inputs",
   pickers: "Pickers",
   files: "Files",
+  blocks: "Blocks",
 }
 
 export const REGISTRY_BY_CATEGORY = (() => {
@@ -158,7 +287,32 @@ export const REGISTRY_BY_CATEGORY = (() => {
     inputs: [],
     pickers: [],
     files: [],
+    blocks: [],
   }
   for (const entry of REGISTRY) groups[entry.category].push(entry)
   return groups
 })()
+
+export const BLOCK_KIND_LABELS: Record<BlockKind, string> = {
+  hero: "Hero sections",
+  cta: "Call-to-action",
+  faq: "FAQ",
+  login: "Auth · login",
+}
+
+export const BLOCKS_BY_KIND = (() => {
+  const groups: Record<BlockKind, RegistryEntryMeta[]> = {
+    hero: [],
+    cta: [],
+    faq: [],
+    login: [],
+  }
+  for (const entry of REGISTRY) {
+    if (entry.category === "blocks" && entry.blockKind) {
+      groups[entry.blockKind].push(entry)
+    }
+  }
+  return groups
+})()
+
+export const BLOCK_KIND_ORDER: BlockKind[] = ["hero", "cta", "faq", "login"]

--- a/registry/sabk/tag-input/index.ts
+++ b/registry/sabk/tag-input/index.ts
@@ -1,0 +1,1 @@
+export * from "./tag-input"

--- a/registry/sabk/tag-input/tag-input.demo.tsx
+++ b/registry/sabk/tag-input/tag-input.demo.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import * as React from "react"
+
+import { Label } from "@/registry/sabk/ui/label"
+import { TagInput } from "@/registry/sabk/tag-input/tag-input"
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export default function TagInputDemo() {
+  const [single, setSingle] = React.useState<string[]>(["typescript", "react"])
+  const [emails, setEmails] = React.useState<string[]>(["jane@sabk.dev"])
+
+  return (
+    <div className="grid w-full max-w-md gap-8">
+      <div className="grid gap-2">
+        <Label>Single-prop API · max 6 tags</Label>
+        <TagInput
+          value={single}
+          onChange={setSingle}
+          maxTags={6}
+          placeholder="Enter, comma, or paste to split"
+        />
+        <p className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+          {single.length} / 6 · paste &ldquo;a, b, c&rdquo; to split
+        </p>
+      </div>
+
+      <div className="grid gap-2">
+        <Label>Compound API · validates emails</Label>
+        <TagInput.Root
+          value={emails}
+          onValueChange={setEmails}
+          validate={(tag) =>
+            EMAIL_RE.test(tag) ? true : `Not a valid email: ${tag}`
+          }
+          maxTags={5}
+        >
+          <TagInput.Container>
+            {emails.map((_, i) => (
+              <TagInput.Tag key={i} index={i} />
+            ))}
+            <TagInput.Field placeholder="you@example.com" />
+          </TagInput.Container>
+          <TagInput.Error className="mt-1" />
+        </TagInput.Root>
+      </div>
+    </div>
+  )
+}

--- a/registry/sabk/tag-input/tag-input.tsx
+++ b/registry/sabk/tag-input/tag-input.tsx
@@ -1,0 +1,438 @@
+"use client"
+
+import * as React from "react"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Badge } from "@/registry/sabk/ui/badge"
+
+/* ============================================================================
+ * Types
+ * ========================================================================== */
+
+export type TagValidator = (
+  candidate: string,
+  current: string[]
+) => true | string
+
+type Ctx = {
+  value: string[]
+  setValue: (next: string[]) => void
+  draft: string
+  setDraft: (next: string) => void
+  error: string | null
+  setError: (next: string | null) => void
+  add: (candidates: string | string[]) => boolean
+  remove: (index: number) => void
+  disabled?: boolean
+  readOnly?: boolean
+  maxTags?: number
+  caseSensitive: boolean
+  validate?: TagValidator
+  /** Keys that commit the draft. */
+  commitKeys: string[]
+  /** Characters that split a paste into multiple tags. */
+  splitOn: RegExp
+  inputRef: React.RefObject<HTMLInputElement | null>
+}
+
+const TagInputContext = React.createContext<Ctx | null>(null)
+
+function useTagInput() {
+  const ctx = React.useContext(TagInputContext)
+  if (!ctx) {
+    throw new Error(
+      "TagInput compound parts must be used inside <TagInput.Root>"
+    )
+  }
+  return ctx
+}
+
+/* ============================================================================
+ * Root
+ * ========================================================================== */
+
+export type TagInputRootProps = {
+  value?: string[]
+  defaultValue?: string[]
+  onValueChange?: (value: string[]) => void
+  disabled?: boolean
+  readOnly?: boolean
+  maxTags?: number
+  /** Trim whitespace and dedupe inputs. Default: true. */
+  unique?: boolean
+  caseSensitive?: boolean
+  /** Returns true (accept) or an error message (reject). */
+  validate?: TagValidator
+  commitKeys?: string[]
+  /** Regex used to split pasted text into multiple tags. */
+  splitOn?: RegExp
+  children?: React.ReactNode
+}
+
+function TagInputRoot({
+  value: valueProp,
+  defaultValue,
+  onValueChange,
+  disabled,
+  readOnly,
+  maxTags,
+  unique = true,
+  caseSensitive = false,
+  validate,
+  commitKeys = ["Enter", ","],
+  splitOn = /[,\n\t]+/,
+  children,
+}: TagInputRootProps) {
+  const [internalValue, setInternalValue] = React.useState<string[]>(
+    defaultValue ?? []
+  )
+  const value = valueProp ?? internalValue
+  const setValue = React.useCallback(
+    (next: string[]) => {
+      if (valueProp === undefined) setInternalValue(next)
+      onValueChange?.(next)
+    },
+    [valueProp, onValueChange]
+  )
+
+  const [draft, setDraft] = React.useState("")
+  const [error, setError] = React.useState<string | null>(null)
+  const inputRef = React.useRef<HTMLInputElement | null>(null)
+
+  const norm = React.useCallback(
+    (s: string) => (caseSensitive ? s : s.toLowerCase()),
+    [caseSensitive]
+  )
+
+  const add = React.useCallback(
+    (candidates: string | string[]): boolean => {
+      if (disabled || readOnly) return false
+      const list = Array.isArray(candidates) ? candidates : [candidates]
+      const next = [...value]
+      let anyAdded = false
+      for (const raw of list) {
+        const tag = raw.trim()
+        if (!tag) continue
+        if (maxTags !== undefined && next.length >= maxTags) {
+          setError(`Limit ${maxTags} tag${maxTags === 1 ? "" : "s"}.`)
+          break
+        }
+        if (unique) {
+          const haystack = next.map(norm)
+          if (haystack.includes(norm(tag))) continue
+        }
+        if (validate) {
+          const result = validate(tag, next)
+          if (result !== true) {
+            setError(result)
+            continue
+          }
+        }
+        next.push(tag)
+        anyAdded = true
+      }
+      if (anyAdded) {
+        setValue(next)
+        setError(null)
+      }
+      return anyAdded
+    },
+    [disabled, readOnly, value, maxTags, unique, norm, validate, setValue]
+  )
+
+  const remove = React.useCallback(
+    (index: number) => {
+      if (disabled || readOnly) return
+      const next = value.filter((_, i) => i !== index)
+      setValue(next)
+      setError(null)
+    },
+    [disabled, readOnly, value, setValue]
+  )
+
+  const ctx = React.useMemo<Ctx>(
+    () => ({
+      value,
+      setValue,
+      draft,
+      setDraft,
+      error,
+      setError,
+      add,
+      remove,
+      disabled,
+      readOnly,
+      maxTags,
+      caseSensitive,
+      validate,
+      commitKeys,
+      splitOn,
+      inputRef,
+    }),
+    [
+      value,
+      setValue,
+      draft,
+      error,
+      add,
+      remove,
+      disabled,
+      readOnly,
+      maxTags,
+      caseSensitive,
+      validate,
+      commitKeys,
+      splitOn,
+    ]
+  )
+
+  return (
+    <TagInputContext.Provider value={ctx}>{children}</TagInputContext.Provider>
+  )
+}
+
+/* ============================================================================
+ * Container (the bordered chip area)
+ * ========================================================================== */
+
+type TagInputContainerProps = React.ComponentProps<"div">
+
+function TagInputContainer({
+  className,
+  children,
+  onMouseDown,
+  ...props
+}: TagInputContainerProps) {
+  const ctx = useTagInput()
+  return (
+    <div
+      data-slot="tag-input"
+      data-disabled={ctx.disabled || undefined}
+      data-readonly={ctx.readOnly || undefined}
+      onMouseDown={(e) => {
+        onMouseDown?.(e)
+        if (e.defaultPrevented) return
+        if (e.target === e.currentTarget) {
+          e.preventDefault()
+          ctx.inputRef.current?.focus()
+        }
+      }}
+      className={cn(
+        "flex min-h-9 w-full flex-wrap items-center gap-1 rounded-sm border-2 border-input bg-transparent px-1.5 py-1 text-sm outline-none transition-colors",
+        "focus-within:border-ring",
+        ctx.error && "border-destructive focus-within:border-destructive",
+        (ctx.disabled || ctx.readOnly) && "opacity-60 cursor-not-allowed",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+/* ============================================================================
+ * Tag (chip)
+ * ========================================================================== */
+
+type TagInputTagProps = Omit<React.ComponentProps<"span">, "children"> & {
+  /** Index of the tag in the value array. */
+  index: number
+  children?: React.ReactNode
+}
+
+function TagInputTag({ index, children, className, ...props }: TagInputTagProps) {
+  const ctx = useTagInput()
+  const tag = ctx.value[index]
+  if (tag === undefined) return null
+  return (
+    <Badge
+      variant="forge"
+      className={cn("gap-1 pr-1 font-normal", className)}
+      {...props}
+    >
+      <span className="truncate">{children ?? tag}</span>
+      {!(ctx.disabled || ctx.readOnly) && (
+        <button
+          type="button"
+          tabIndex={-1}
+          aria-label={`Remove ${tag}`}
+          onClick={() => ctx.remove(index)}
+          className="inline-flex size-3.5 items-center justify-center rounded-[2px] text-forge/70 transition-colors hover:bg-forge/20 hover:text-forge"
+        >
+          <X className="size-2.5" />
+        </button>
+      )}
+    </Badge>
+  )
+}
+
+/* ============================================================================
+ * Field (the inline input)
+ * ========================================================================== */
+
+type TagInputFieldProps = Omit<
+  React.ComponentProps<"input">,
+  "value" | "defaultValue" | "onChange" | "type"
+>
+
+function TagInputField({
+  placeholder = "Add tag…",
+  className,
+  onKeyDown,
+  onPaste,
+  onBlur,
+  ...props
+}: TagInputFieldProps) {
+  const ctx = useTagInput()
+
+  const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    onKeyDown?.(e)
+    if (e.defaultPrevented) return
+    if (ctx.commitKeys.includes(e.key)) {
+      if (ctx.draft.trim()) {
+        e.preventDefault()
+        if (ctx.add(ctx.draft)) ctx.setDraft("")
+      } else if (e.key === "Enter") {
+        // Allow form submission only when draft is empty.
+      }
+      return
+    }
+    if (e.key === "Backspace" && !ctx.draft && ctx.value.length > 0) {
+      e.preventDefault()
+      ctx.remove(ctx.value.length - 1)
+    }
+  }
+
+  const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    onPaste?.(e)
+    if (e.defaultPrevented) return
+    const text = e.clipboardData.getData("text")
+    if (!text) return
+    if (ctx.splitOn.test(text)) {
+      e.preventDefault()
+      const parts = text.split(ctx.splitOn).map((p) => p.trim()).filter(Boolean)
+      ctx.add(parts)
+    }
+  }
+
+  return (
+    <input
+      ref={ctx.inputRef}
+      type="text"
+      value={ctx.draft}
+      onChange={(e) => {
+        ctx.setDraft(e.target.value)
+        if (ctx.error) ctx.setError(null)
+      }}
+      onKeyDown={handleKey}
+      onPaste={handlePaste}
+      onBlur={(e) => {
+        onBlur?.(e)
+        if (ctx.draft.trim()) {
+          if (ctx.add(ctx.draft)) ctx.setDraft("")
+        }
+      }}
+      placeholder={ctx.value.length === 0 ? placeholder : undefined}
+      disabled={ctx.disabled}
+      readOnly={ctx.readOnly}
+      data-slot="tag-input-field"
+      className={cn(
+        "flex-1 min-w-[6rem] bg-transparent px-1.5 py-0.5 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+/* ============================================================================
+ * Error message
+ * ========================================================================== */
+
+function TagInputError({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  const ctx = useTagInput()
+  if (!ctx.error) return null
+  return (
+    <p
+      role="alert"
+      className={cn("text-[11px] text-destructive", className)}
+      {...props}
+    >
+      {ctx.error}
+    </p>
+  )
+}
+
+/* ============================================================================
+ * Single-prop convenience wrapper
+ * ========================================================================== */
+
+export type TagInputProps = Omit<TagInputRootProps, "children"> & {
+  placeholder?: string
+  onChange?: (value: string[]) => void
+  className?: string
+  showError?: boolean
+}
+
+function TagInput({
+  value,
+  defaultValue,
+  onValueChange,
+  onChange,
+  placeholder,
+  className,
+  showError = true,
+  ...rest
+}: TagInputProps) {
+  return (
+    <TagInputRoot
+      value={value}
+      defaultValue={defaultValue}
+      onValueChange={onValueChange ?? onChange}
+      {...rest}
+    >
+      <TagInputContainer className={className}>
+        <TagsRenderer />
+        <TagInputField placeholder={placeholder} />
+      </TagInputContainer>
+      {showError && <TagInputError className="mt-1" />}
+    </TagInputRoot>
+  )
+}
+
+function TagsRenderer() {
+  const ctx = useTagInput()
+  return (
+    <>
+      {ctx.value.map((_, i) => (
+        <TagInputTag key={`${ctx.value[i]}-${i}`} index={i} />
+      ))}
+    </>
+  )
+}
+
+/* ============================================================================
+ * Exports
+ * ========================================================================== */
+
+const TagInputNamespace = Object.assign(TagInput, {
+  Root: TagInputRoot,
+  Container: TagInputContainer,
+  Tag: TagInputTag,
+  Field: TagInputField,
+  Error: TagInputError,
+})
+
+export {
+  TagInputNamespace as TagInput,
+  TagInputRoot,
+  TagInputContainer,
+  TagInputTag,
+  TagInputField,
+  TagInputError,
+}

--- a/registry/sabk/ui/accordion.tsx
+++ b/registry/sabk/ui/accordion.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import * as React from "react"
+import * as AccordionPrimitive from "@radix-ui/react-accordion"
+import { Plus } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Accordion({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+  return (
+    <AccordionPrimitive.Root
+      data-slot="accordion"
+      className={cn("flex flex-col", className)}
+      {...props}
+    />
+  )
+}
+
+function AccordionItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn(
+        "border-b-2 border-border last:border-b-0 data-[state=open]:border-b-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "group flex w-full flex-1 items-center justify-between gap-4 py-5 text-left text-base font-medium tracking-[-0.01em] outline-none transition-colors",
+          "hover:text-forge focus-visible:text-forge",
+          "data-[state=open]:text-foreground",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <Plus
+          aria-hidden
+          className="size-4 shrink-0 text-muted-foreground transition-transform duration-200 ease-[var(--ease-forge)] group-data-[state=open]:rotate-45 group-data-[state=open]:text-forge"
+        />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  )
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+  return (
+    <AccordionPrimitive.Content
+      data-slot="accordion-content"
+      className={cn(
+        "overflow-hidden text-sm text-muted-foreground",
+        "data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+      )}
+      {...props}
+    >
+      <div className={cn("pb-5 pr-8", className)}>{children}</div>
+    </AccordionPrimitive.Content>
+  )
+}
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }

--- a/registry/sabk/ui/sheet.tsx
+++ b/registry/sabk/ui/sheet.tsx
@@ -1,0 +1,173 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Sheet(props: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger(
+  props: React.ComponentProps<typeof DialogPrimitive.Trigger>
+) {
+  return <DialogPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose(
+  props: React.ComponentProps<typeof DialogPrimitive.Close>
+) {
+  return <DialogPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal(
+  props: React.ComponentProps<typeof DialogPrimitive.Portal>
+) {
+  return <DialogPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/60 backdrop-blur-[2px]",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "duration-200 ease-[var(--ease-forge)]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+type SheetContentProps = React.ComponentProps<typeof DialogPrimitive.Content> & {
+  side?: "left" | "right"
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  ...props
+}: SheetContentProps) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <DialogPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "fixed z-50 flex h-svh w-full max-w-md flex-col gap-0 border-border bg-background text-foreground shadow-2xl outline-none",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out duration-250 ease-[var(--ease-forge)]",
+          side === "right" &&
+            "right-0 top-0 border-l-2 data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right",
+          side === "left" &&
+            "left-0 top-0 border-r-2 data-[state=open]:slide-in-from-left data-[state=closed]:slide-out-to-left",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close
+          aria-label="Close"
+          className="absolute right-3 top-3 rounded-sm p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <X className="size-4" />
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn(
+        "flex flex-col gap-1 border-b-2 border-border px-6 py-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="sheet-title"
+      className={cn(
+        "text-base font-semibold tracking-[-0.02em]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetBody({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-body"
+      className={cn("flex-1 overflow-y-auto px-6 py-5", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn(
+        "flex items-center justify-between gap-2 border-t-2 border-border px-6 py-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetPortal,
+  SheetOverlay,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+  SheetBody,
+  SheetFooter,
+}


### PR DESCRIPTION
Adds a live theme customization surface so users can see how Sabk renders
against their own theme:

- ThemeProvider applies user-supplied CSS variables to <html> for the
  active mode (light/dark), persists to localStorage, and ships a
  pre-hydration script to avoid FOUC.
- ThemeSheetTrigger opens a settings sheet (sidebar + playground header)
  with mode toggle, accent presets (Forge / Emerald / Indigo / Rose), a
  paste-CSS-variables editor that accepts :root / .light / .dark blocks
  in either convention, and a copyable export of the active overrides.
- /theme playground page renders every stable component plus surface,
  primitive, and swatch samples so a theme can be evaluated at a glance.

Adds server-side syntax highlighting via shiki (vesper + vitesse-light
dual theme):

- lib/highlight.ts builds a cached highlighter for tsx/ts/bash/css/etc.
- CodeBlock and InlineCodeBlock components consume pre-highlighted HTML
  with copy-to-clipboard and (for the file-tabbed variant) tab switching.
- Component Code tab, home page dual-API snippet, and install command now
  render highlighted; light/dark swap is handled in globals.css.