### PR TITLE
Fix shiki code block: theme bg + doubled line spacing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -123,8 +123,11 @@
 }
 
 /* shiki dual-theme: defaultColor=dark means the inline color/bg are dark
-   values; --shiki-light + --shiki-light-bg are CSS vars. Override them in
-   .light to swap. */
+   values; --shiki-light + --shiki-light-bg are CSS vars we swap to in
+   light mode. The block uses --card so it picks up the page theme in
+   both modes (vitesse-light's #ffffff bg is too bright against our warm
+   neutrals). Line spans stay inline so the natural \n inside <pre>
+   produces line breaks — display:block here doubles every row. */
 .shiki {
   background-color: var(--card) !important;
   font-family: var(--font-geist-mono), ui-monospace, monospace;
@@ -134,16 +137,9 @@
   tab-size: 2;
 }
 .shiki code {
-  display: block;
   background: transparent !important;
-  counter-reset: line;
-}
-.shiki .line {
-  display: block;
-  min-height: 1lh;
 }
 html.light .shiki {
-  background-color: var(--shiki-light-bg) !important;
   color: var(--shiki-light) !important;
 }
 html.light .shiki span {


### PR DESCRIPTION
Two issues in app/globals.css:

- Light mode forced `.shiki` background to var(--shiki-light-bg)
  (= #ffffff from vitesse-light) instead of var(--card), so the code
  block didn't pick up the page theme — most visible against the warm
  neutrals on the rest of the page. Use --card consistently in both
  modes so the playground's theme actually applies to the block.

- `.shiki .line { display: block; min-height: 1lh }` combined with the
  literal \n characters between line spans inside <pre> (preserved by
  white-space: pre) rendered every row twice: once as a block-level
  span, once as the trailing newline text node. Measured 39.6px between
  consecutive lines with a 19.8px line-height — exactly doubled. Drop
  the display:block / min-height rule (and the matching one on .code);
  pre's natural whitespace handling renders each newline once, including
  legitimate blank lines in the source.