### PR TITLE
Rebrand from Sabk to msh ui with new landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sabk
+# msh ui
 
 **shadcn's missing pieces.** A peer registry — not a replacement — for the
 30-ish components every real product needs but shadcn doesn't ship.
@@ -6,21 +6,20 @@ Multi-select, number range, year picker, tag input, phone input,
 file dropzone, the lot.
 
 ```bash
-npx shadcn@latest add https://sabk.dev/r/multi-select.json
+npx shadcn@latest add https://forgecn.dev/r/multi-select.json
 ```
 
 ## Positioning
 
-- **Peer of shadcn.** You must have shadcn installed first. Sabk components
-  import from `@/components/ui/*` (Button, Input, Popover, Command, …)
-  just like shadcn's own composed blocks do.
+- **Peer of shadcn.** You must have shadcn installed first. msh ui
+  components import from `@/components/ui/*` (Button, Input, Popover,
+  Command, …) just like shadcn's own composed blocks do.
 - **Distributed via the shadcn registry schema.** No runtime dependency
-  on a Sabk package — source is copied straight into your repo.
-- **Efferd-aligned aesthetic.** Modern shadcn polish: 1px soft borders,
-  0.65rem radius scale (sm/md/lg/xl derived from `--radius`), zinc
-  neutrals, dark as primary canvas, no chromatic accent — primary draws
-  the eye. Geist Sans for body, Geist Mono reserved for code and
-  identifiers.
+  on an msh ui package — source is copied straight into your repo.
+- **Modern shadcn polish.** 1px soft borders, 0.65rem radius scale
+  (sm/md/lg/xl derived from `--radius`), zinc neutrals, dark as primary
+  canvas, no chromatic accent — primary draws the eye. Geist Sans for
+  body, Geist Mono reserved for code and identifiers.
 
 ## Composition (shadcn-style)
 
@@ -70,19 +69,20 @@ JsonViewer, DiffViewer, Breadcrumb, CommandPalette — not in this cut.
 ## Repository layout
 
 ```
-sabk/
+msh-ui/
   app/
+    page.tsx                   # landing
     (showcase)/
+      components/page.tsx      # full component index
       [component]/page.tsx     # per-component page: preview · code · install
       layout.tsx               # sidebar + main column
-      page.tsx                 # landing
     layout.tsx
     globals.css                # design tokens (zinc, 0.65rem radius)
   components/
     showcase/                  # shell-only chrome, not part of the registry
   registry/
     sabk/
-      ui/                      # shadcn primitives Sabk imports from
+      ui/                      # shadcn primitives msh ui imports from
       multi-select/
         multi-select.tsx         # component, flat compound exports
         multi-select.demo.tsx
@@ -112,7 +112,7 @@ pnpm typecheck
    inlines source file contents into `/public/r/<name>.json`, and writes
    `target: components/ui/<name>.tsx` so the consumer's shadcn CLI knows
    where to drop the file.
-3. A consumer runs `npx shadcn add https://sabk.dev/r/<name>.json`. The
+3. A consumer runs `npx shadcn add https://forgecn.dev/r/<name>.json`. The
    shadcn CLI fetches each registryDependency from the upstream shadcn
    registry, installs the listed npm dependencies, and copies the source
    file — rewriting alias-prefixed imports to match the consumer's
@@ -154,3 +154,7 @@ light). Radii follow shadcn's standard scale derived from
 xl = radius + 4px). Geist Sans is the default body face; Geist Mono is
 reserved for code, install commands, and identifiers. Motion stays
 short (120–180ms, ease-out).
+
+## License
+
+MIT — © Mohammad Shehadeh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# msh ui
+# forgecn
 
 **shadcn's missing pieces.** A peer registry — not a replacement — for the
 30-ish components every real product needs but shadcn doesn't ship.
@@ -11,11 +11,11 @@ npx shadcn@latest add https://forgecn.dev/r/multi-select.json
 
 ## Positioning
 
-- **Peer of shadcn.** You must have shadcn installed first. msh ui
+- **Peer of shadcn.** You must have shadcn installed first. forgecn
   components import from `@/components/ui/*` (Button, Input, Popover,
   Command, …) just like shadcn's own composed blocks do.
 - **Distributed via the shadcn registry schema.** No runtime dependency
-  on an msh ui package — source is copied straight into your repo.
+  on an forgecn package — source is copied straight into your repo.
 - **Modern shadcn polish.** 1px soft borders, 0.65rem radius scale
   (sm/md/lg/xl derived from `--radius`), zinc neutrals, dark as primary
   canvas, no chromatic accent — primary draws the eye. Geist Sans for
@@ -69,7 +69,7 @@ JsonViewer, DiffViewer, Breadcrumb, CommandPalette — not in this cut.
 ## Repository layout
 
 ```
-msh-ui/
+forgecn/
   app/
     page.tsx                   # landing
     (showcase)/
@@ -82,7 +82,7 @@ msh-ui/
     showcase/                  # shell-only chrome, not part of the registry
   registry/
     sabk/
-      ui/                      # shadcn primitives msh ui imports from
+      ui/                      # shadcn primitives forgecn imports from
       multi-select/
         multi-select.tsx         # component, flat compound exports
         multi-select.demo.tsx

--- a/app/(showcase)/[component]/page.tsx
+++ b/app/(showcase)/[component]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({
   const entry = REGISTRY_BY_NAME[component]
   if (!entry || entry.category === "blocks") return {}
   return {
-    title: `${entry.title} — Sabk`,
+    title: entry.title,
     description: entry.description,
   }
 }

--- a/app/(showcase)/[component]/page.tsx
+++ b/app/(showcase)/[component]/page.tsx
@@ -37,11 +37,17 @@ async function loadSource(
   if (!files) return out
   await Promise.all(
     files.map(async (f) => {
+      const abs = path.join(process.cwd(), f)
       let code: string
       try {
-        code = await fs.readFile(path.join(process.cwd(), f), "utf8")
-      } catch {
-        code = "// (unable to read source)"
+        code = await fs.readFile(abs, "utf8")
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        // Surface the real reason — silently rendering the stub made it
+        // very hard to tell whether the path was wrong, the file was
+        // missing, or the deploy bundle didn't include it.
+        console.error(`[loadSource] could not read ${abs}: ${msg}`)
+        code = `// (unable to read source: ${msg})`
       }
       const lang = langFromPath(f)
       const html = await highlightCode(code, lang)

--- a/app/(showcase)/blocks/[block]/page.tsx
+++ b/app/(showcase)/blocks/[block]/page.tsx
@@ -37,11 +37,14 @@ async function loadSource(
   if (!files) return out
   await Promise.all(
     files.map(async (f) => {
+      const abs = path.join(process.cwd(), f)
       let code: string
       try {
-        code = await fs.readFile(path.join(process.cwd(), f), "utf8")
-      } catch {
-        code = "// (unable to read source)"
+        code = await fs.readFile(abs, "utf8")
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        console.error(`[loadSource] could not read ${abs}: ${msg}`)
+        code = `// (unable to read source: ${msg})`
       }
       const lang = langFromPath(f)
       const html = await highlightCode(code, lang)

--- a/app/(showcase)/blocks/[block]/page.tsx
+++ b/app/(showcase)/blocks/[block]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({
   const entry = REGISTRY_BY_NAME[block]
   if (!entry || entry.category !== "blocks") return {}
   return {
-    title: `${entry.title} — Sabk blocks`,
+    title: `${entry.title} block`,
     description: entry.description,
   }
 }

--- a/app/(showcase)/blocks/page.tsx
+++ b/app/(showcase)/blocks/page.tsx
@@ -11,9 +11,9 @@ import {
 } from "@/registry/sabk/registry-meta"
 
 export const metadata: Metadata = {
-  title: "Blocks — Sabk",
+  title: "Blocks",
   description:
-    "Top-tier, copy-into-your-repo section blocks — heroes, FAQs, CTAs and login screens that share the Sabk aesthetic.",
+    "Top-tier, copy-into-your-repo section blocks — heroes, FAQs, CTAs and login screens that share the msh ui aesthetic.",
 }
 
 export default function BlocksIndex() {
@@ -34,9 +34,9 @@ export default function BlocksIndex() {
           Blocks that compose, not decorate.
         </h1>
         <p className="max-w-2xl text-base text-muted-foreground">
-          Heroes, CTAs, FAQs and auth screens — built on top of the Sabk
-          component registry and the Sabk aesthetic. Copy a block in one
-          command, then shape it like any other source file in your repo.
+          Heroes, CTAs, FAQs and auth screens — built on top of the msh ui
+          component registry and aesthetic. Copy a block in one command, then
+          shape it like any other source file in your repo.
         </p>
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           {blockCount} blocks · {BLOCK_KIND_ORDER.length} categories · MIT

--- a/app/(showcase)/blocks/page.tsx
+++ b/app/(showcase)/blocks/page.tsx
@@ -13,7 +13,7 @@ import {
 export const metadata: Metadata = {
   title: "Blocks",
   description:
-    "Top-tier, copy-into-your-repo section blocks — heroes, FAQs, CTAs and login screens that share the msh ui aesthetic.",
+    "Top-tier, copy-into-your-repo section blocks — heroes, FAQs, CTAs and login screens that share the forgecn aesthetic.",
 }
 
 export default function BlocksIndex() {
@@ -34,7 +34,7 @@ export default function BlocksIndex() {
           Blocks that compose, not decorate.
         </h1>
         <p className="max-w-2xl text-base text-muted-foreground">
-          Heroes, CTAs, FAQs and auth screens — built on top of the msh ui
+          Heroes, CTAs, FAQs and auth screens — built on top of the forgecn
           component registry and aesthetic. Copy a block in one command, then
           shape it like any other source file in your repo.
         </p>

--- a/app/(showcase)/components/page.tsx
+++ b/app/(showcase)/components/page.tsx
@@ -35,9 +35,9 @@ const COMPOSE_SNIPPET = `import {
 </MultiSelect>`
 
 export const metadata: Metadata = {
-  title: "Components — msh ui",
+  title: "Components — forgecn",
   description:
-    "Browse the full msh ui component registry — multi-select, combobox, tag input, currency input, file dropzone, and the rest of the components shadcn doesn't ship.",
+    "Browse the full forgecn component registry — multi-select, combobox, tag input, currency input, file dropzone, and the rest of the components shadcn doesn't ship.",
 }
 
 export default async function ComponentsIndex() {
@@ -64,7 +64,7 @@ export default async function ComponentsIndex() {
           Production-grade components shadcn doesn&apos;t ship — multi-select,
           combobox, tag input, currency input, file dropzone — plus {blocks.length} section
           blocks across {BLOCK_KIND_ORDER.length} categories. Distributed via the shadcn
-          CLI: source lands in your repo, no msh ui runtime, no breaking
+          CLI: source lands in your repo, no forgecn runtime, no breaking
           version bumps.
         </p>
         <InstallBlock name="multi-select" className="mt-2 max-w-2xl" />

--- a/app/(showcase)/components/page.tsx
+++ b/app/(showcase)/components/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import type { Metadata } from "next"
 import { ArrowRight, Layers, Palette } from "lucide-react"
 
 import { InlineCodeBlock } from "@/components/showcase/code-block"
@@ -33,7 +34,13 @@ const COMPOSE_SNIPPET = `import {
   <MultiSelectContent searchPlaceholder="Filter…" />
 </MultiSelect>`
 
-export default async function ShowcaseHome() {
+export const metadata: Metadata = {
+  title: "Components — msh ui",
+  description:
+    "Browse the full msh ui component registry — multi-select, combobox, tag input, currency input, file dropzone, and the rest of the components shadcn doesn't ship.",
+}
+
+export default async function ComponentsIndex() {
   const components = REGISTRY.filter((r) => r.category !== "blocks")
   const blocks = REGISTRY_BY_CATEGORY.blocks
   const stableComponents = components.filter((r) => r.status === "stable")
@@ -41,24 +48,23 @@ export default async function ShowcaseHome() {
 
   return (
     <div className="mx-auto flex w-full max-w-4xl flex-col gap-12 px-4 py-10 sm:gap-14 sm:px-6 sm:py-12 md:px-10 md:py-16">
-      {/* Hero / Above the fold */}
       <header className="flex flex-col gap-5 border-b border-border pb-10">
         <div className="flex flex-wrap items-center gap-2">
           <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-foreground">
-            ◆ sabk · v0.1
+            ◆ components
           </span>
           <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
             peer of shadcn, not a replacement
           </span>
         </div>
-        <h1 className="text-balance text-4xl font-semibold leading-[1.05] tracking-[-0.04em] sm:text-5xl md:text-6xl">
-          shadcn&apos;s missing pieces.
+        <h1 className="text-balance text-4xl font-semibold leading-[1.05] tracking-[-0.04em] sm:text-5xl">
+          The registry, in full.
         </h1>
         <p className="max-w-2xl text-base text-muted-foreground">
           Production-grade components shadcn doesn&apos;t ship — multi-select,
-          combobox, tag input, currency input, file dropzone — plus 17
-          section blocks across 10 categories. Distributed via the shadcn
-          CLI: source lands in your repo, no Sabk runtime, no breaking
+          combobox, tag input, currency input, file dropzone — plus {blocks.length} section
+          blocks across {BLOCK_KIND_ORDER.length} categories. Distributed via the shadcn
+          CLI: source lands in your repo, no msh ui runtime, no breaking
           version bumps.
         </p>
         <InstallBlock name="multi-select" className="mt-2 max-w-2xl" />
@@ -70,7 +76,6 @@ export default async function ShowcaseHome() {
         />
       </header>
 
-      {/* Components — every category, every item */}
       <section className="flex flex-col gap-8">
         <div className="flex items-baseline justify-between">
           <h2 className="font-mono text-xs uppercase tracking-[0.12em] text-foreground">
@@ -134,7 +139,6 @@ export default async function ShowcaseHome() {
         })}
       </section>
 
-      {/* Blocks — every kind, every item, inline */}
       <section className="flex flex-col gap-8 border-t border-border pt-10">
         <div className="flex items-baseline justify-between">
           <h2 className="font-mono text-xs uppercase tracking-[0.12em] text-foreground">
@@ -190,7 +194,6 @@ export default async function ShowcaseHome() {
         </div>
       </section>
 
-      {/* How it works */}
       <section className="flex flex-col gap-5 border-t border-border pt-10">
         <h2 className="font-mono text-xs uppercase tracking-[0.12em] text-foreground">
           Composition (the shadcn way)
@@ -207,7 +210,6 @@ export default async function ShowcaseHome() {
         <InlineCodeBlock code={COMPOSE_SNIPPET} html={composeHtml} />
       </section>
 
-      {/* Footer — adjacent surfaces */}
       <section className="grid gap-3 border-t border-border pt-10 sm:grid-cols-2">
         <Link
           href="/theme"

--- a/app/(showcase)/layout.tsx
+++ b/app/(showcase)/layout.tsx
@@ -1,11 +1,11 @@
 import { cookies } from "next/headers"
 
 import { ShowcaseSidebar } from "@/components/showcase/sidebar"
-import { Separator } from "@/registry/sabk/ui/separator"
+import { ShowcaseTopbar } from "@/components/showcase/topbar"
+import { SiteFooter } from "@/components/showcase/site-footer"
 import {
   SidebarInset,
   SidebarProvider,
-  SidebarTrigger,
 } from "@/registry/sabk/ui/sidebar"
 
 export default async function ShowcaseLayout({
@@ -19,23 +19,10 @@ export default async function ShowcaseLayout({
   return (
     <SidebarProvider defaultOpen={defaultOpen}>
       <ShowcaseSidebar />
-      <SidebarInset>
-        <header className="sticky top-0 z-30 flex h-12 shrink-0 items-center gap-2 border-b border-border bg-background/85 px-3 backdrop-blur-md md:hidden">
-          <SidebarTrigger className="-ml-1" />
-          <Separator orientation="vertical" className="mx-1 h-5" />
-          <div className="flex items-baseline gap-2">
-            <span className="text-base font-semibold tracking-[-0.04em]">
-              sabk
-            </span>
-            <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-foreground">
-              ◆ forge
-            </span>
-          </div>
-        </header>
-        <div className="hidden md:flex md:h-10 md:items-center md:gap-2 md:px-3">
-          <SidebarTrigger className="-ml-1" />
-        </div>
+      <SidebarInset className="min-w-0">
+        <ShowcaseTopbar />
         <main className="min-w-0 flex-1">{children}</main>
+        <SiteFooter />
       </SidebarInset>
     </SidebarProvider>
   )

--- a/app/(showcase)/theme/page.tsx
+++ b/app/(showcase)/theme/page.tsx
@@ -1,9 +1,9 @@
 import { ThemePlayground } from "./playground"
 
 export const metadata = {
-  title: "Theme playground — Sabk",
+  title: "Theme playground",
   description:
-    "Preview every Sabk component against your own theme. Paste CSS variables, pick a preset, and see the registry render live.",
+    "Preview every msh ui component against your own theme. Paste CSS variables, pick a preset, and see the registry render live.",
 }
 
 export default function ThemePage() {

--- a/app/(showcase)/theme/page.tsx
+++ b/app/(showcase)/theme/page.tsx
@@ -3,7 +3,7 @@ import { ThemePlayground } from "./playground"
 export const metadata = {
   title: "Theme playground",
   description:
-    "Preview every msh ui component against your own theme. Paste CSS variables, pick a preset, and see the registry render live.",
+    "Preview every forgecn component against your own theme. Paste CSS variables, pick a preset, and see the registry render live.",
 }
 
 export default function ThemePage() {

--- a/app/(showcase)/theme/playground.tsx
+++ b/app/(showcase)/theme/playground.tsx
@@ -34,7 +34,7 @@ export function ThemePlayground() {
         </h1>
         <p className="max-w-2xl text-sm text-muted-foreground">
           Paste a CSS variable block from your own app — or any shadcn theme
-          generator — and watch the entire Sabk registry re-skin. The active
+          generator — and watch the entire msh ui registry re-skin. The active
           theme is persisted in your browser; reset any time.
         </p>
 
@@ -67,7 +67,7 @@ export function ThemePlayground() {
       <Section
         eyebrow="Primitives"
         title="Buttons, badges, inputs"
-        description="The base shadcn primitives Sabk components compose on top of."
+        description="The base shadcn primitives msh ui components compose on top of."
       >
         <div className="grid gap-6 rounded-sm border border-border bg-card/40 p-6">
           <div className="flex flex-wrap items-center gap-2">
@@ -88,7 +88,7 @@ export function ThemePlayground() {
             <Input
               id="theme-preview-input"
               placeholder="you@example.com"
-              defaultValue="hello@sabk.dev"
+              defaultValue="hello@msh-ui.dev"
             />
             <p className="text-xs text-muted-foreground">
               Muted foreground reads against background.
@@ -99,7 +99,7 @@ export function ThemePlayground() {
 
       <Section
         eyebrow="Registry"
-        title="Sabk components"
+        title="msh ui components"
         description="Every stable component re-renders against the active theme. Edit it and watch them all update at once."
       >
         <div className="grid grid-cols-1 gap-px overflow-hidden rounded-sm border border-border bg-border lg:grid-cols-2">

--- a/app/(showcase)/theme/playground.tsx
+++ b/app/(showcase)/theme/playground.tsx
@@ -34,7 +34,7 @@ export function ThemePlayground() {
         </h1>
         <p className="max-w-2xl text-sm text-muted-foreground">
           Paste a CSS variable block from your own app — or any shadcn theme
-          generator — and watch the entire msh ui registry re-skin. The active
+          generator — and watch the entire forgecn registry re-skin. The active
           theme is persisted in your browser; reset any time.
         </p>
 
@@ -67,7 +67,7 @@ export function ThemePlayground() {
       <Section
         eyebrow="Primitives"
         title="Buttons, badges, inputs"
-        description="The base shadcn primitives msh ui components compose on top of."
+        description="The base shadcn primitives forgecn components compose on top of."
       >
         <div className="grid gap-6 rounded-sm border border-border bg-card/40 p-6">
           <div className="flex flex-wrap items-center gap-2">
@@ -88,7 +88,7 @@ export function ThemePlayground() {
             <Input
               id="theme-preview-input"
               placeholder="you@example.com"
-              defaultValue="hello@msh-ui.dev"
+              defaultValue="hello@forgecn.dev"
             />
             <p className="text-xs text-muted-foreground">
               Muted foreground reads against background.
@@ -99,7 +99,7 @@ export function ThemePlayground() {
 
       <Section
         eyebrow="Registry"
-        title="msh ui components"
+        title="forgecn components"
         description="Every stable component re-renders against the active theme. Edit it and watch them all update at once."
       >
         <div className="grid grid-cols-1 gap-px overflow-hidden rounded-sm border border-border bg-border lg:grid-cols-2">

--- a/app/globals.css
+++ b/app/globals.css
@@ -220,4 +220,30 @@ html.light .shiki span {
     );
     background-size: 22px 22px;
   }
+
+  /* Small cross marker used at section corners (blueprint feel). The
+     ::before / ::after pseudo-elements draw the two strokes of a + glyph
+     so we can position it inside any container that has overflow visible. */
+  .corner-mark {
+    position: absolute;
+    width: 12px;
+    height: 12px;
+    color: var(--muted-foreground);
+    opacity: 0.55;
+    pointer-events: none;
+  }
+  .corner-mark::before,
+  .corner-mark::after {
+    content: "";
+    position: absolute;
+    background-color: currentColor;
+  }
+  .corner-mark::before {
+    inset: 5px 0;
+    height: 1px;
+  }
+  .corner-mark::after {
+    inset: 0 5px;
+    width: 1px;
+  }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,7 @@
 @import "tw-animate-css";
 
 @custom-variant dark (&:is(.dark *));
+@custom-variant light (&:is(.light *));
 
 @theme inline {
   --font-sans: var(--font-geist-sans);
@@ -80,6 +81,12 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+
+  /* Decorative glow token used by .bg-aurora / .card-glow and the hero orbs.
+     Dark mode: a warm amber tint that reads as a soft glow on the near-black
+     canvas without breaking the achromatic palette of the components. */
+  --glow: oklch(0.78 0.13 70);
+  --glow-strong: oklch(0.86 0.16 70);
 }
 
 /* Light: faithful inverse, zinc neutral. */
@@ -115,6 +122,11 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+
+  /* Light-mode decorative glow: a very pale warm tint so radial glows read
+     as a soft cream wash on white, not a dark splotch. */
+  --glow: oklch(0.92 0.06 70);
+  --glow-strong: oklch(0.86 0.1 70);
 }
 
 /* shiki dual-theme: defaultColor=dark means the inline color/bg are dark
@@ -210,38 +222,49 @@ html.light .shiki span {
   }
 
   /* Subtle aurora glow used behind the hero. Reads as warm amber in dark,
-     pale yellow in light. Stacks two color stops for a soft falloff. */
+     pale cream wash in light — both via the --glow token. */
   .bg-aurora {
     background-image:
       radial-gradient(
         ellipse 80% 50% at 50% -10%,
-        color-mix(in oklch, var(--primary) 22%, transparent),
+        color-mix(in oklch, var(--glow) 30%, transparent),
         transparent 60%
       ),
       radial-gradient(
         ellipse 60% 40% at 80% 10%,
-        color-mix(in oklch, var(--primary) 14%, transparent),
+        color-mix(in oklch, var(--glow) 20%, transparent),
         transparent 70%
       ),
       radial-gradient(
         ellipse 60% 40% at 20% 10%,
-        color-mix(in oklch, var(--primary) 14%, transparent),
+        color-mix(in oklch, var(--glow) 20%, transparent),
         transparent 70%
       );
   }
 
   /* Animated horizontal sweep used on the top of the hero (premium feel). */
   .bg-sheen-top {
-    background:
-      linear-gradient(
-        to right,
-        transparent 0%,
-        color-mix(in oklch, var(--primary) 60%, transparent) 50%,
-        transparent 100%
-      );
+    background: linear-gradient(
+      to right,
+      transparent 0%,
+      color-mix(in oklch, var(--glow-strong) 70%, transparent) 50%,
+      transparent 100%
+    );
   }
 
-  /* Subtle inner glow + lift on cards during hover. */
+  /* Spinning conic-gradient orb. */
+  .bg-glow-orb {
+    background: conic-gradient(
+      from 90deg,
+      color-mix(in oklch, var(--glow) 50%, transparent),
+      transparent 30%,
+      color-mix(in oklch, var(--glow) 32%, transparent) 60%,
+      transparent 80%
+    );
+  }
+
+  /* Subtle inner glow + lift on cards during hover. Light mode uses a
+     softer neutral shadow so it never looks like a heavy drop shadow. */
   .card-glow {
     transition:
       border-color 180ms ease-out,
@@ -250,12 +273,45 @@ html.light .shiki span {
   }
   .card-glow:hover {
     box-shadow:
-      0 0 0 1px color-mix(in oklch, var(--primary) 14%, transparent) inset,
-      0 12px 32px -16px color-mix(in oklch, var(--primary) 28%, transparent);
+      0 0 0 1px color-mix(in oklch, var(--glow) 18%, transparent) inset,
+      0 12px 32px -16px color-mix(in oklch, var(--glow) 36%, transparent);
+  }
+  html.light .card-glow:hover {
+    box-shadow:
+      0 0 0 1px color-mix(in oklch, var(--glow-strong) 22%, transparent) inset,
+      0 14px 28px -18px oklch(0.4 0 0 / 14%);
   }
 
-  /* Faint gradient text used for one accent word in the hero. */
+  /* Primary-button glow ring + warm hover halo. */
+  .btn-glow-ring {
+    box-shadow:
+      0 0 0 1px color-mix(in oklch, var(--primary) 50%, transparent);
+  }
+  .btn-glow-ring:hover {
+    box-shadow:
+      0 0 0 1px color-mix(in oklch, var(--primary) 50%, transparent),
+      0 0 32px -8px color-mix(in oklch, var(--glow) 60%, transparent);
+  }
+  html.light .btn-glow-ring:hover {
+    box-shadow:
+      0 0 0 1px color-mix(in oklch, var(--primary) 60%, transparent),
+      0 8px 28px -14px oklch(0.3 0 0 / 22%);
+  }
+
+  /* Faint gradient text used for one accent word in the hero. Dark mode:
+     foreground → glow tint. Light mode: foreground → muted-foreground
+     (subtle and clean). */
   .text-gradient-primary {
+    background: linear-gradient(
+      180deg,
+      var(--foreground) 0%,
+      color-mix(in oklch, var(--foreground) 60%, var(--glow-strong)) 100%
+    );
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+  html.light .text-gradient-primary {
     background: linear-gradient(
       180deg,
       var(--foreground) 0%,

--- a/app/globals.css
+++ b/app/globals.css
@@ -208,4 +208,90 @@ html.light .shiki span {
   .cpx {
     @apply px-4 lg:px-6;
   }
+
+  /* Subtle aurora glow used behind the hero. Reads as warm amber in dark,
+     pale yellow in light. Stacks two color stops for a soft falloff. */
+  .bg-aurora {
+    background-image:
+      radial-gradient(
+        ellipse 80% 50% at 50% -10%,
+        color-mix(in oklch, var(--primary) 22%, transparent),
+        transparent 60%
+      ),
+      radial-gradient(
+        ellipse 60% 40% at 80% 10%,
+        color-mix(in oklch, var(--primary) 14%, transparent),
+        transparent 70%
+      ),
+      radial-gradient(
+        ellipse 60% 40% at 20% 10%,
+        color-mix(in oklch, var(--primary) 14%, transparent),
+        transparent 70%
+      );
+  }
+
+  /* Animated horizontal sweep used on the top of the hero (premium feel). */
+  .bg-sheen-top {
+    background:
+      linear-gradient(
+        to right,
+        transparent 0%,
+        color-mix(in oklch, var(--primary) 60%, transparent) 50%,
+        transparent 100%
+      );
+  }
+
+  /* Subtle inner glow + lift on cards during hover. */
+  .card-glow {
+    transition:
+      border-color 180ms ease-out,
+      box-shadow 180ms ease-out,
+      transform 180ms ease-out;
+  }
+  .card-glow:hover {
+    box-shadow:
+      0 0 0 1px color-mix(in oklch, var(--primary) 14%, transparent) inset,
+      0 12px 32px -16px color-mix(in oklch, var(--primary) 28%, transparent);
+  }
+
+  /* Faint gradient text used for one accent word in the hero. */
+  .text-gradient-primary {
+    background: linear-gradient(
+      180deg,
+      var(--foreground) 0%,
+      color-mix(in oklch, var(--foreground) 55%, var(--muted-foreground)) 100%
+    );
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+
+  /* Pulsing ring used around the live-status dot. */
+  @keyframes ping-soft {
+    0% {
+      transform: scale(1);
+      opacity: 0.8;
+    }
+    75%,
+    100% {
+      transform: scale(2.2);
+      opacity: 0;
+    }
+  }
+  .animate-ping-soft {
+    animation: ping-soft 1.8s cubic-bezier(0, 0, 0.2, 1) infinite;
+  }
+
+  /* Slow rotation used for the hero ambient orb. */
+  @keyframes spin-slow {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  .animate-spin-slow {
+    animation: spin-slow 30s linear infinite;
+  }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -81,12 +81,6 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
-
-  /* Decorative glow token used by .bg-aurora / .card-glow and the hero orbs.
-     Dark mode: a warm amber tint that reads as a soft glow on the near-black
-     canvas without breaking the achromatic palette of the components. */
-  --glow: oklch(0.78 0.13 70);
-  --glow-strong: oklch(0.86 0.16 70);
 }
 
 /* Light: faithful inverse, zinc neutral. */
@@ -122,11 +116,6 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
-
-  /* Light-mode decorative glow: a very pale warm tint so radial glows read
-     as a soft cream wash on white, not a dark splotch. */
-  --glow: oklch(0.92 0.06 70);
-  --glow-strong: oklch(0.86 0.1 70);
 }
 
 /* shiki dual-theme: defaultColor=dark means the inline color/bg are dark
@@ -221,133 +210,14 @@ html.light .shiki span {
     @apply px-4 lg:px-6;
   }
 
-  /* Subtle aurora glow used behind the hero. Reads as warm amber in dark,
-     pale cream wash in light — both via the --glow token. */
-  .bg-aurora {
-    background-image:
-      radial-gradient(
-        ellipse 80% 50% at 50% -10%,
-        color-mix(in oklch, var(--glow) 30%, transparent),
-        transparent 60%
-      ),
-      radial-gradient(
-        ellipse 60% 40% at 80% 10%,
-        color-mix(in oklch, var(--glow) 20%, transparent),
-        transparent 70%
-      ),
-      radial-gradient(
-        ellipse 60% 40% at 20% 10%,
-        color-mix(in oklch, var(--glow) 20%, transparent),
-        transparent 70%
-      );
-  }
-
-  /* Animated horizontal sweep used on the top of the hero (premium feel). */
-  .bg-sheen-top {
-    background: linear-gradient(
-      to right,
-      transparent 0%,
-      color-mix(in oklch, var(--glow-strong) 70%, transparent) 50%,
-      transparent 100%
+  /* Faint dot grid used as a subtle background texture on the hero —
+     reads as monochrome zinc dots in both themes. */
+  .bg-dot-grid {
+    background-image: radial-gradient(
+      circle at 1px 1px,
+      var(--border) 1px,
+      transparent 0
     );
-  }
-
-  /* Spinning conic-gradient orb. */
-  .bg-glow-orb {
-    background: conic-gradient(
-      from 90deg,
-      color-mix(in oklch, var(--glow) 50%, transparent),
-      transparent 30%,
-      color-mix(in oklch, var(--glow) 32%, transparent) 60%,
-      transparent 80%
-    );
-  }
-
-  /* Subtle inner glow + lift on cards during hover. Light mode uses a
-     softer neutral shadow so it never looks like a heavy drop shadow. */
-  .card-glow {
-    transition:
-      border-color 180ms ease-out,
-      box-shadow 180ms ease-out,
-      transform 180ms ease-out;
-  }
-  .card-glow:hover {
-    box-shadow:
-      0 0 0 1px color-mix(in oklch, var(--glow) 18%, transparent) inset,
-      0 12px 32px -16px color-mix(in oklch, var(--glow) 36%, transparent);
-  }
-  html.light .card-glow:hover {
-    box-shadow:
-      0 0 0 1px color-mix(in oklch, var(--glow-strong) 22%, transparent) inset,
-      0 14px 28px -18px oklch(0.4 0 0 / 14%);
-  }
-
-  /* Primary-button glow ring + warm hover halo. */
-  .btn-glow-ring {
-    box-shadow:
-      0 0 0 1px color-mix(in oklch, var(--primary) 50%, transparent);
-  }
-  .btn-glow-ring:hover {
-    box-shadow:
-      0 0 0 1px color-mix(in oklch, var(--primary) 50%, transparent),
-      0 0 32px -8px color-mix(in oklch, var(--glow) 60%, transparent);
-  }
-  html.light .btn-glow-ring:hover {
-    box-shadow:
-      0 0 0 1px color-mix(in oklch, var(--primary) 60%, transparent),
-      0 8px 28px -14px oklch(0.3 0 0 / 22%);
-  }
-
-  /* Faint gradient text used for one accent word in the hero. Dark mode:
-     foreground → glow tint. Light mode: foreground → muted-foreground
-     (subtle and clean). */
-  .text-gradient-primary {
-    background: linear-gradient(
-      180deg,
-      var(--foreground) 0%,
-      color-mix(in oklch, var(--foreground) 60%, var(--glow-strong)) 100%
-    );
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
-  }
-  html.light .text-gradient-primary {
-    background: linear-gradient(
-      180deg,
-      var(--foreground) 0%,
-      color-mix(in oklch, var(--foreground) 55%, var(--muted-foreground)) 100%
-    );
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
-  }
-
-  /* Pulsing ring used around the live-status dot. */
-  @keyframes ping-soft {
-    0% {
-      transform: scale(1);
-      opacity: 0.8;
-    }
-    75%,
-    100% {
-      transform: scale(2.2);
-      opacity: 0;
-    }
-  }
-  .animate-ping-soft {
-    animation: ping-soft 1.8s cubic-bezier(0, 0, 0.2, 1) infinite;
-  }
-
-  /* Slow rotation used for the hero ambient orb. */
-  @keyframes spin-slow {
-    from {
-      transform: rotate(0deg);
-    }
-    to {
-      transform: rotate(360deg);
-    }
-  }
-  .animate-spin-slow {
-    animation: spin-slow 30s linear infinite;
+    background-size: 22px 22px;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google"
 import "./globals.css"
 
 import { ThemeProvider } from "@/components/showcase/theme-provider"
+import { SITE } from "@/lib/site"
 import { themePrehydrationScript } from "@/lib/theme"
 
 const geistSans = Geist({
@@ -16,9 +17,24 @@ const geistMono = Geist_Mono({
 })
 
 export const metadata: Metadata = {
-  title: "Sabk — shadcn's missing pieces",
-  description:
-    "A shadcn-compatible registry of the components shadcn doesn't ship. Multi-select, number range, year picker, tag input, and the other components every real product needs.",
+  title: {
+    default: `${SITE.name} — ${SITE.description}`,
+    template: `%s — ${SITE.name}`,
+  },
+  description: SITE.longDescription,
+  authors: [{ name: SITE.author, url: SITE.authorUrl }],
+  creator: SITE.author,
+  openGraph: {
+    type: "website",
+    title: `${SITE.name} — ${SITE.description}`,
+    description: SITE.longDescription,
+    siteName: SITE.name,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${SITE.name} — ${SITE.description}`,
+    description: SITE.longDescription,
+  },
 }
 
 export default function RootLayout({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next"
-import { Geist, Geist_Mono } from "next/font/google"
+import { Fraunces, Geist, Geist_Mono } from "next/font/google"
 import "./globals.css"
 
 import { ThemeProvider } from "@/components/showcase/theme-provider"
@@ -14,6 +14,12 @@ const geistSans = Geist({
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+})
+
+const fraunces = Fraunces({
+  variable: "--font-fraunces",
+  subsets: ["latin"],
+  weight: ["600"],
 })
 
 export const metadata: Metadata = {
@@ -50,7 +56,7 @@ export default function RootLayout({
         />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${fraunces.variable} antialiased`}
       >
         <ThemeProvider>{children}</ThemeProvider>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -99,72 +99,109 @@ function Hero({
   kindsCount: number
 }) {
   return (
-    <section className="relative overflow-hidden border-b border-border">
+    <section className="relative isolate overflow-hidden border-b border-border bg-aurora">
+      {/* Top sheen — a 1px gradient line for premium feel */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 h-px bg-sheen-top"
+      />
+
       {/* Background grid + radial fade */}
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-0 opacity-[0.35] dark:opacity-100"
+        className="pointer-events-none absolute inset-0 opacity-[0.4] dark:opacity-[0.8]"
         style={{
           backgroundImage:
             "linear-gradient(to right, var(--border) 1px, transparent 1px), linear-gradient(to bottom, var(--border) 1px, transparent 1px)",
-          backgroundSize: "48px 48px",
+          backgroundSize: "56px 56px",
           maskImage:
-            "radial-gradient(ellipse 70% 60% at 50% 0%, black 30%, transparent 80%)",
+            "radial-gradient(ellipse 70% 60% at 50% 0%, black 20%, transparent 75%)",
           WebkitMaskImage:
-            "radial-gradient(ellipse 70% 60% at 50% 0%, black 30%, transparent 80%)",
+            "radial-gradient(ellipse 70% 60% at 50% 0%, black 20%, transparent 75%)",
         }}
       />
-      <div className="relative mx-auto flex w-full max-w-5xl flex-col items-center gap-8 px-4 pb-16 pt-16 text-center sm:gap-10 sm:px-6 sm:pb-20 sm:pt-20 md:pb-28 md:pt-24 lg:px-8">
+
+      {/* Ambient orb behind hero */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute left-1/2 top-0 -z-10 size-[640px] -translate-x-1/2 -translate-y-1/3 rounded-full opacity-40 blur-3xl animate-spin-slow"
+        style={{
+          background:
+            "conic-gradient(from 90deg, color-mix(in oklch, var(--primary) 40%, transparent), transparent 30%, color-mix(in oklch, var(--primary) 24%, transparent) 60%, transparent 80%)",
+        }}
+      />
+
+      <div className="relative mx-auto flex w-full max-w-5xl flex-col items-center gap-9 px-4 pb-20 pt-20 text-center sm:gap-11 sm:px-6 sm:pb-28 sm:pt-28 md:pb-36 md:pt-32 lg:px-8">
         <a
           href={SITE.githubUrl}
           target="_blank"
           rel="noreferrer noopener"
-          className="group inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground transition-colors hover:border-foreground/40 hover:bg-accent hover:text-foreground"
+          className="group inline-flex items-center gap-2.5 rounded-full border border-border bg-card/80 px-4 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground backdrop-blur-sm transition-colors hover:border-foreground/40 hover:bg-accent hover:text-foreground"
         >
-          <span className="size-1.5 rounded-full bg-foreground" />
+          <span className="relative flex size-1.5">
+            <span
+              className="absolute inline-flex size-full animate-ping-soft rounded-full opacity-80"
+              style={{ background: "var(--primary)" }}
+            />
+            <span
+              className="relative inline-flex size-1.5 rounded-full"
+              style={{ background: "var(--primary)" }}
+            />
+          </span>
           v{SITE.version} now live
-          <span className="text-foreground">·</span>
-          star on GitHub
+          <span className="text-border">·</span>
+          <span className="text-foreground">star on GitHub</span>
           <ArrowRight className="size-3 transition-transform duration-150 group-hover:translate-x-0.5" />
         </a>
 
-        <h1 className="text-balance text-5xl font-semibold leading-[0.95] tracking-[-0.04em] sm:text-6xl md:text-7xl lg:text-[88px]">
-          shadcn&apos;s
+        <h1 className="text-balance text-5xl font-semibold leading-[0.95] tracking-[-0.045em] sm:text-6xl md:text-7xl lg:text-[96px]">
+          <span className="text-gradient-primary">shadcn&apos;s</span>
           <br />
-          <span className="text-muted-foreground/80">missing pieces.</span>
+          <span className="text-muted-foreground/70">missing pieces.</span>
         </h1>
 
-        <p className="max-w-2xl text-balance text-base text-muted-foreground sm:text-lg">
+        <p className="max-w-2xl text-balance text-base text-muted-foreground sm:text-lg md:text-xl">
           A peer registry of the components every real product needs but shadcn
           doesn&apos;t ship — multi-select, combobox, tag input, currency
           input, file dropzone — plus {blocksCount} section blocks across{" "}
           {kindsCount} categories.
         </p>
 
-        <div className="flex w-full max-w-xl flex-col gap-3">
-          <InstallBlock name="multi-select" />
-          <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
-            One command. Source lands in <span className="text-foreground">@/components/ui</span>.
-          </p>
-        </div>
-
-        <div className="flex flex-wrap items-center justify-center gap-2">
+        <div className="flex flex-wrap items-center justify-center gap-3">
           <Link
             href="/components"
-            className="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+            className="group relative inline-flex h-11 items-center justify-center gap-2 overflow-hidden rounded-md bg-primary px-6 text-sm font-medium text-primary-foreground shadow-[0_0_0_1px_color-mix(in_oklch,var(--primary)_50%,transparent)] transition-all hover:bg-primary/95 hover:shadow-[0_0_36px_-8px_color-mix(in_oklch,var(--primary)_50%,transparent)]"
           >
+            <span
+              aria-hidden
+              className="pointer-events-none absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-primary-foreground/15 to-transparent transition-transform duration-700 ease-out group-hover:translate-x-full"
+            />
             Browse components
-            <ArrowRight className="size-3.5" />
+            <ArrowRight className="size-4 transition-transform duration-150 group-hover:translate-x-0.5" />
           </Link>
           <Link
             href="/blocks"
-            className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-border bg-card px-4 text-sm font-medium text-foreground transition-colors hover:border-foreground/40 hover:bg-accent"
+            className="inline-flex h-11 items-center justify-center gap-2 rounded-md border border-border bg-card/80 px-5 text-sm font-medium text-foreground backdrop-blur-sm transition-colors hover:border-foreground/40 hover:bg-accent"
           >
-            <Layers className="size-3.5" />
+            <Layers className="size-4" />
             See blocks
           </Link>
         </div>
+
+        <div className="flex w-full max-w-2xl flex-col gap-3 pt-2">
+          <InstallBlock name="multi-select" />
+          <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            One command. Source lands in{" "}
+            <span className="text-foreground">@/components/ui</span>.
+          </p>
+        </div>
       </div>
+
+      {/* Bottom fade for smoother transition */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-background to-transparent"
+      />
     </section>
   )
 }
@@ -208,20 +245,36 @@ const FEATURES = [
 
 function Features() {
   return (
-    <section className="border-b border-border">
-      <div className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-        <div className="mb-10 flex flex-col gap-3">
-          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-            ◆ what you get
+    <section className="relative border-b border-border">
+      <div className="mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 sm:py-24 lg:px-8">
+        <div className="mb-12 flex flex-col items-center gap-4 text-center">
+          <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+            <span
+              aria-hidden
+              className="size-1 rounded-full"
+              style={{ background: "var(--primary)" }}
+            />
+            What you get
           </span>
-          <h2 className="max-w-2xl text-balance text-3xl font-semibold tracking-[-0.025em] sm:text-4xl">
-            Production-grade primitives, distributed the shadcn way.
+          <h2 className="max-w-2xl text-balance text-3xl font-semibold tracking-[-0.03em] sm:text-4xl md:text-5xl">
+            Production-grade primitives, <br className="hidden md:inline" />
+            <span className="text-muted-foreground/70">
+              distributed the shadcn way.
+            </span>
           </h2>
         </div>
-        <ul className="grid grid-cols-1 gap-px overflow-hidden rounded-md border border-border bg-border md:grid-cols-2 lg:grid-cols-3">
+        <ul className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-border bg-border md:grid-cols-2 lg:grid-cols-3">
           {FEATURES.map((feature) => (
-            <li key={feature.title} className="flex flex-col gap-3 bg-card p-6">
-              <span className="inline-flex size-9 items-center justify-center rounded-md border border-border bg-background">
+            <li
+              key={feature.title}
+              className="card-glow group relative flex flex-col gap-3 border border-transparent bg-card p-6"
+            >
+              <span className="relative inline-flex size-10 items-center justify-center rounded-md border border-border bg-background">
+                <span
+                  aria-hidden
+                  className="pointer-events-none absolute inset-0 -z-10 rounded-md opacity-0 blur-md transition-opacity duration-300 group-hover:opacity-60"
+                  style={{ background: "var(--primary)" }}
+                />
                 <feature.icon className="size-4 text-foreground" />
               </span>
               <h3 className="text-base font-medium tracking-[-0.01em]">
@@ -261,17 +314,17 @@ function CountersStrip({
   ]
   return (
     <section className="border-b border-border">
-      <div className="mx-auto w-full max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
-        <dl className="grid grid-cols-2 gap-px overflow-hidden rounded-md border border-border bg-border sm:grid-cols-4">
+      <div className="mx-auto w-full max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
+        <dl className="grid grid-cols-2 gap-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-4">
           {items.map((item) => (
             <div
               key={item.label}
-              className="flex flex-col gap-1 bg-card px-4 py-4"
+              className="card-glow group flex flex-col gap-1.5 border border-transparent bg-card px-5 py-5"
             >
               <dt className="font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground">
                 {item.label}
               </dt>
-              <dd className="font-mono text-xl tabular-nums tracking-[-0.01em] text-foreground">
+              <dd className="font-mono text-2xl tabular-nums tracking-[-0.01em] text-foreground">
                 {item.value}
               </dd>
             </div>
@@ -293,24 +346,27 @@ function ComponentsPreview() {
 
   return (
     <section className="border-b border-border">
-      <div className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-        <div className="mb-10 flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-end">
-          <div className="flex flex-col gap-3">
-            <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-              <Boxes className="-mt-0.5 mr-1 inline size-3" />
+      <div className="mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 sm:py-24 lg:px-8">
+        <div className="mb-12 flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-end">
+          <div className="flex flex-col gap-4">
+            <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+              <Boxes className="size-3" />
               components
             </span>
-            <h2 className="max-w-2xl text-balance text-3xl font-semibold tracking-[-0.025em] sm:text-4xl">
-              {totalStable} components shadcn doesn&apos;t ship.
+            <h2 className="max-w-2xl text-balance text-3xl font-semibold tracking-[-0.03em] sm:text-4xl md:text-5xl">
+              {totalStable} components{" "}
+              <span className="text-muted-foreground/70">
+                shadcn doesn&apos;t ship.
+              </span>
             </h2>
-            <p className="max-w-2xl text-sm text-muted-foreground">
+            <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
               Tap any to preview, copy the install command, or browse the
               source.
             </p>
           </div>
           <Link
             href="/components"
-            className="group inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:text-foreground"
+            className="group inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:border-foreground/40 hover:text-foreground"
           >
             See all
             <ArrowRight className="size-3 transition-transform duration-150 group-hover:translate-x-0.5" />
@@ -331,12 +387,12 @@ function ComponentsPreview() {
                     {REGISTRY_BY_CATEGORY[cat].length} total
                   </span>
                 </div>
-                <ul className="grid grid-cols-1 gap-px overflow-hidden rounded-md border border-border bg-border sm:grid-cols-2 lg:grid-cols-3">
+                <ul className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-2 lg:grid-cols-3">
                   {items.map((entry) => (
                     <li key={entry.name}>
                       <Link
                         href={`/${entry.name}`}
-                        className="group flex h-full flex-col justify-between gap-3 bg-card p-4 transition-colors hover:bg-accent"
+                        className="card-glow group flex h-full flex-col justify-between gap-3 border border-transparent bg-card p-4"
                       >
                         <div className="flex flex-col gap-1.5">
                           <div className="flex items-center justify-between gap-2">
@@ -350,7 +406,7 @@ function ComponentsPreview() {
                             ) : (
                               <Check
                                 aria-hidden
-                                className="size-3 text-muted-foreground"
+                                className="size-3 text-muted-foreground transition-colors group-hover:text-foreground"
                               />
                             )}
                           </div>
@@ -358,7 +414,7 @@ function ComponentsPreview() {
                             {entry.description}
                           </p>
                         </div>
-                        <div className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground group-hover:text-foreground">
+                        <div className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground transition-colors group-hover:text-foreground">
                           /{entry.name} →
                         </div>
                       </Link>
@@ -380,16 +436,18 @@ function ComponentsPreview() {
 
 function Composition({ html, code }: { html: string; code: string }) {
   return (
-    <section className="border-b border-border">
-      <div className="mx-auto grid w-full max-w-7xl gap-10 px-4 py-16 sm:px-6 sm:py-20 lg:grid-cols-2 lg:px-8">
-        <div className="flex flex-col gap-3">
-          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-            ◆ composition
+    <section className="relative border-b border-border">
+      <div className="mx-auto grid w-full max-w-7xl items-center gap-10 px-4 py-20 sm:px-6 sm:py-24 lg:grid-cols-2 lg:px-8">
+        <div className="flex flex-col gap-4">
+          <span className="inline-flex w-fit items-center gap-2 rounded-full border border-border bg-card px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+            <Code className="size-3" />
+            composition
           </span>
-          <h2 className="text-balance text-3xl font-semibold tracking-[-0.025em] sm:text-4xl">
-            Composed the shadcn way.
+          <h2 className="text-balance text-3xl font-semibold tracking-[-0.03em] sm:text-4xl md:text-5xl">
+            Composed{" "}
+            <span className="text-muted-foreground/70">the shadcn way.</span>
           </h2>
-          <p className="max-w-md text-sm text-muted-foreground">
+          <p className="max-w-md text-sm text-muted-foreground sm:text-base">
             Every compound component ships as flat top-level exports — no
             namespacing, no convenience wrappers. The bare name is the root
             primitive and holds state; every rendered piece carries a{" "}
@@ -398,7 +456,7 @@ function Composition({ html, code }: { html: string; code: string }) {
             </code>{" "}
             attribute for downstream styling.
           </p>
-          <ul className="mt-2 flex flex-col gap-2">
+          <ul className="mt-2 flex flex-col gap-2.5">
             {[
               "Flat compound exports, no namespacing",
               "data-slot attribute on every rendered part",
@@ -406,15 +464,29 @@ function Composition({ html, code }: { html: string; code: string }) {
             ].map((bullet) => (
               <li
                 key={bullet}
-                className="flex items-start gap-2 text-xs text-muted-foreground"
+                className="flex items-start gap-2.5 text-xs text-muted-foreground sm:text-sm"
               >
-                <Check className="mt-0.5 size-3.5 shrink-0 text-foreground" />
+                <span
+                  aria-hidden
+                  className="mt-1 inline-flex size-4 shrink-0 items-center justify-center rounded-full border border-border bg-card"
+                >
+                  <Check className="size-2.5 text-foreground" />
+                </span>
                 <span>{bullet}</span>
               </li>
             ))}
           </ul>
         </div>
-        <div className="min-w-0">
+        <div className="relative min-w-0">
+          {/* Glow behind code block */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -inset-4 -z-10 rounded-2xl opacity-50 blur-2xl"
+            style={{
+              background:
+                "radial-gradient(ellipse 60% 80% at 50% 50%, color-mix(in oklch, var(--primary) 18%, transparent), transparent 70%)",
+            }}
+          />
           <InlineCodeBlock code={code} html={html} />
         </div>
       </div>
@@ -433,17 +505,20 @@ function BlocksPreview() {
 
   return (
     <section className="border-b border-border">
-      <div className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-        <div className="mb-10 flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-end">
-          <div className="flex flex-col gap-3">
-            <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-              <Layers className="-mt-0.5 mr-1 inline size-3" />
+      <div className="mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 sm:py-24 lg:px-8">
+        <div className="mb-12 flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-end">
+          <div className="flex flex-col gap-4">
+            <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+              <Layers className="size-3" />
               section blocks
             </span>
-            <h2 className="max-w-2xl text-balance text-3xl font-semibold tracking-[-0.025em] sm:text-4xl">
-              Drop-in compositions for whole sections.
+            <h2 className="max-w-2xl text-balance text-3xl font-semibold tracking-[-0.03em] sm:text-4xl md:text-5xl">
+              Drop-in compositions{" "}
+              <span className="text-muted-foreground/70">
+                for whole sections.
+              </span>
             </h2>
-            <p className="max-w-2xl text-sm text-muted-foreground">
+            <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
               Heroes, features, pricing, testimonials, CTAs, FAQs, auth,
               navigation, errors. Copy a block in one command, then shape it
               like any other source file in your repo.
@@ -451,26 +526,26 @@ function BlocksPreview() {
           </div>
           <Link
             href="/blocks"
-            className="group inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:text-foreground"
+            className="group inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:border-foreground/40 hover:text-foreground"
           >
             See all blocks
             <ArrowRight className="size-3 transition-transform duration-150 group-hover:translate-x-0.5" />
           </Link>
         </div>
 
-        <ul className="grid grid-cols-1 gap-px overflow-hidden rounded-md border border-border bg-border sm:grid-cols-2 lg:grid-cols-3">
+        <ul className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-2 lg:grid-cols-3">
           {featured.map((entry) => (
             <li key={entry.name}>
               <Link
                 href={`/blocks/${entry.name}`}
-                className="group flex h-full flex-col justify-between gap-3 bg-card p-4 transition-colors hover:bg-accent"
+                className="card-glow group flex h-full flex-col justify-between gap-3 border border-transparent bg-card p-5"
               >
                 <div className="flex flex-col gap-1.5">
                   <div className="flex items-center justify-between gap-2">
                     <h3 className="text-sm font-medium tracking-[-0.01em]">
                       {entry.title}
                     </h3>
-                    <span className="font-mono text-[9px] uppercase tracking-[0.08em] text-muted-foreground">
+                    <span className="rounded-sm border border-border px-1.5 py-0 font-mono text-[9px] uppercase tracking-[0.08em] text-muted-foreground">
                       {entry.blockKind}
                     </span>
                   </div>
@@ -480,7 +555,7 @@ function BlocksPreview() {
                     </p>
                   )}
                 </div>
-                <div className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground group-hover:text-foreground">
+                <div className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground transition-colors group-hover:text-foreground">
                   /blocks/{entry.name} →
                 </div>
               </Link>
@@ -499,43 +574,73 @@ function BlocksPreview() {
 function BottomCta({ blocksCount }: { blocksCount: number }) {
   return (
     <section>
-      <div className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 sm:py-24 lg:px-8">
-        <div className="relative overflow-hidden rounded-lg border border-border bg-card">
+      <div className="mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 sm:py-28 lg:px-8">
+        <div className="relative overflow-hidden rounded-2xl border border-border bg-card bg-aurora">
+          {/* Top sheen */}
           <div
             aria-hidden
-            className="pointer-events-none absolute inset-0 opacity-[0.4]"
+            className="pointer-events-none absolute inset-x-0 top-0 h-px bg-sheen-top"
+          />
+
+          {/* Grid bg */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 opacity-[0.5]"
             style={{
               backgroundImage:
                 "linear-gradient(to right, var(--border) 1px, transparent 1px), linear-gradient(to bottom, var(--border) 1px, transparent 1px)",
               backgroundSize: "32px 32px",
               maskImage:
-                "radial-gradient(ellipse 80% 70% at 50% 50%, black 30%, transparent 80%)",
+                "radial-gradient(ellipse 80% 70% at 50% 50%, black 20%, transparent 75%)",
               WebkitMaskImage:
-                "radial-gradient(ellipse 80% 70% at 50% 50%, black 30%, transparent 80%)",
+                "radial-gradient(ellipse 80% 70% at 50% 50%, black 20%, transparent 75%)",
             }}
           />
-          <div className="relative flex flex-col items-center gap-5 px-6 py-12 text-center sm:px-12 sm:py-16">
-            <h2 className="max-w-2xl text-balance text-3xl font-semibold tracking-[-0.025em] sm:text-4xl">
-              Ready to ship the components you keep building from scratch?
+
+          {/* Spinning orb */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute left-1/2 top-1/2 -z-0 size-[500px] -translate-x-1/2 -translate-y-1/2 rounded-full opacity-30 blur-3xl animate-spin-slow"
+            style={{
+              background:
+                "conic-gradient(from 0deg, color-mix(in oklch, var(--primary) 40%, transparent), transparent 50%, color-mix(in oklch, var(--primary) 30%, transparent))",
+            }}
+          />
+
+          <div className="relative flex flex-col items-center gap-6 px-6 py-16 text-center sm:px-12 sm:py-24">
+            <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card/80 px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground backdrop-blur-sm">
+              <Sparkles className="size-3" />
+              ready when you are
+            </span>
+            <h2 className="max-w-3xl text-balance text-4xl font-semibold tracking-[-0.035em] sm:text-5xl md:text-6xl">
+              <span className="text-gradient-primary">Stop rebuilding</span>{" "}
+              <br className="hidden sm:inline" />
+              <span className="text-muted-foreground/70">
+                the same components.
+              </span>
             </h2>
-            <p className="max-w-xl text-balance text-sm text-muted-foreground">
+            <p className="max-w-xl text-balance text-sm text-muted-foreground sm:text-base">
               {blocksCount} blocks, dozens of components, zero runtime
               dependencies. Distributed via the shadcn CLI — copy what you
               need, leave the rest.
             </p>
-            <div className="flex flex-wrap items-center justify-center gap-2">
+            <div className="flex flex-wrap items-center justify-center gap-3 pt-2">
               <Link
                 href="/components"
-                className="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+                className="group relative inline-flex h-11 items-center justify-center gap-2 overflow-hidden rounded-md bg-primary px-6 text-sm font-medium text-primary-foreground shadow-[0_0_0_1px_color-mix(in_oklch,var(--primary)_50%,transparent)] transition-all hover:bg-primary/95 hover:shadow-[0_0_36px_-8px_color-mix(in_oklch,var(--primary)_50%,transparent)]"
               >
+                <span
+                  aria-hidden
+                  className="pointer-events-none absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-primary-foreground/15 to-transparent transition-transform duration-700 ease-out group-hover:translate-x-full"
+                />
                 Browse components
-                <ArrowRight className="size-3.5" />
+                <ArrowRight className="size-4 transition-transform duration-150 group-hover:translate-x-0.5" />
               </Link>
               <a
                 href={SITE.githubUrl}
                 target="_blank"
                 rel="noreferrer noopener"
-                className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-border bg-background px-4 text-sm font-medium text-foreground transition-colors hover:border-foreground/40 hover:bg-accent"
+                className="inline-flex h-11 items-center justify-center gap-2 rounded-md border border-border bg-background/80 px-5 text-sm font-medium text-foreground backdrop-blur-sm transition-colors hover:border-foreground/40 hover:bg-accent"
               >
                 Star on GitHub
               </a>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,28 +1,21 @@
 import Link from "next/link"
 import type { Metadata } from "next"
-import { ArrowRight, Check, Github } from "lucide-react"
+import { ArrowRight, ArrowUpRight, Github } from "lucide-react"
 
 import { InstallBlock } from "@/components/showcase/install-block"
 import { SiteFooter } from "@/components/showcase/site-footer"
 import { SiteHeader } from "@/components/showcase/site-header"
+import { cn } from "@/lib/utils"
 import { SITE } from "@/lib/site"
 import {
   BLOCK_KIND_LABELS,
-  BLOCK_KIND_ORDER,
   BLOCKS_BY_KIND,
   CATEGORY_LABELS,
   REGISTRY,
   REGISTRY_BY_CATEGORY,
+  type BlockKind,
   type ComponentCategory,
 } from "@/registry/sabk/registry-meta"
-
-const CATEGORY_ORDER: ComponentCategory[] = [
-  "inputs",
-  "pickers",
-  "files",
-  "data",
-  "display",
-]
 
 export const metadata: Metadata = {
   title: `${SITE.name} — ${SITE.description}`,
@@ -35,21 +28,12 @@ export const metadata: Metadata = {
 }
 
 export default function LandingPage() {
-  const components = REGISTRY.filter((r) => r.category !== "blocks")
-  const blocks = REGISTRY_BY_CATEGORY.blocks
-  const stableComponents = components.filter((r) => r.status === "stable")
-
   return (
     <div className="flex min-h-svh flex-col">
       <SiteHeader />
       <main className="flex-1">
-        <Hero
-          stable={stableComponents.length}
-          total={components.length}
-          blocks={blocks.length}
-        />
-        <ComponentsGrid />
-        <BlocksList />
+        <Hero />
+        <CategoryGrid />
       </main>
       <SiteFooter />
     </div>
@@ -57,180 +41,100 @@ export default function LandingPage() {
 }
 
 /* -------------------------------------------------------------------------- */
-/* Hero — compact, info-first                                                 */
+/* Hero                                                                       */
 /* -------------------------------------------------------------------------- */
 
-function Hero({
-  stable,
-  total,
-  blocks,
-}: {
-  stable: number
-  total: number
-  blocks: number
-}) {
-  const stats: { label: string; value: string }[] = [
-    { label: "stable", value: `${stable} / ${total}` },
-    { label: "blocks", value: `${blocks}` },
-    { label: "runtime deps", value: "0" },
-    { label: "license", value: "MIT" },
-  ]
+function CornerMarks() {
+  return (
+    <>
+      <span aria-hidden className="corner-mark -left-1.5 -top-1.5" />
+      <span aria-hidden className="corner-mark -right-1.5 -top-1.5" />
+      <span aria-hidden className="corner-mark -bottom-1.5 -left-1.5" />
+      <span aria-hidden className="corner-mark -bottom-1.5 -right-1.5" />
+    </>
+  )
+}
+
+function Hero() {
+  const components = REGISTRY.filter((r) => r.category !== "blocks")
+  const stable = components.filter((r) => r.status === "stable").length
+  const blocks = REGISTRY_BY_CATEGORY.blocks.length
 
   return (
-    <section className="relative border-b border-border">
+    <section className="relative">
       <div
         aria-hidden
-        className="bg-dot-grid pointer-events-none absolute inset-0 opacity-50"
+        className="bg-dot-grid pointer-events-none absolute inset-0 opacity-40"
         style={{
           maskImage:
-            "radial-gradient(ellipse 70% 60% at 50% 0%, black 30%, transparent 80%)",
+            "radial-gradient(ellipse 70% 60% at 50% 30%, black 20%, transparent 75%)",
           WebkitMaskImage:
-            "radial-gradient(ellipse 70% 60% at 50% 0%, black 30%, transparent 80%)",
+            "radial-gradient(ellipse 70% 60% at 50% 30%, black 20%, transparent 75%)",
         }}
       />
-      <div className="relative mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 pb-12 pt-12 sm:px-6 sm:pb-16 sm:pt-16 lg:px-8">
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="inline-flex items-center gap-2 rounded-sm border border-border bg-card px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-              <span
-                aria-hidden
-                className="size-1 rounded-full bg-foreground"
-              />
+
+      <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6 sm:py-16 lg:px-8">
+        <div className="relative mx-auto flex max-w-3xl flex-col items-center gap-6 border border-border bg-background/30 px-6 py-14 text-center sm:gap-7 sm:py-20 md:py-24">
+          <CornerMarks />
+
+          <div className="inline-flex items-center gap-1 rounded-full border border-border bg-card p-1 font-mono text-[10px] uppercase tracking-[0.12em]">
+            <span className="rounded-full bg-foreground px-2.5 py-0.5 text-background">
               v{SITE.version}
             </span>
-            <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-              peer of shadcn · not a replacement
-            </span>
+            <a
+              href={`${SITE.githubUrl}/releases`}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex items-center gap-1 px-2.5 py-0.5 text-muted-foreground transition-colors hover:text-foreground"
+            >
+              View changelog
+              <ArrowUpRight className="size-2.5" />
+            </a>
           </div>
 
-          <h1 className="text-balance text-4xl font-semibold leading-[1.05] tracking-[-0.035em] sm:text-5xl">
-            shadcn&apos;s missing pieces.
+          <h1
+            className="text-balance text-3xl leading-[1.05] tracking-[-0.025em] sm:text-4xl md:text-5xl lg:text-6xl"
+            style={{ fontFamily: "var(--font-fraunces), ui-serif, serif" }}
+          >
+            <span className="font-normal text-muted-foreground">
+              Production-grade
+            </span>{" "}
+            <span className="font-semibold">shadcn pieces</span>
+            <br />
+            <span className="font-normal text-muted-foreground">for</span>{" "}
+            <span className="font-semibold">real</span>{" "}
+            <span className="font-normal text-muted-foreground">&amp;</span>{" "}
+            <span className="font-semibold">shipped</span>{" "}
+            <span className="font-normal text-muted-foreground">products.</span>
           </h1>
 
-          <p className="max-w-2xl text-balance text-base text-muted-foreground">
-            {stable} production-grade components shadcn doesn&apos;t ship —
-            multi-select, combobox, tag input, currency input, file dropzone —
-            plus {blocks} section blocks. Distributed via the shadcn CLI:
-            source lands in your repo, zero runtime dependency.
+          <p className="max-w-xl text-balance text-sm text-muted-foreground sm:text-base">
+            The {stable} components shadcn doesn&apos;t ship plus {blocks}{" "}
+            section blocks — distributed via the shadcn CLI, copied straight
+            into your repo. Zero runtime dependency.
           </p>
-        </div>
 
-        <div className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-center">
-          <InstallBlock name="multi-select" className="min-w-0" />
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center justify-center gap-2">
             <Link
               href="/components"
-              className="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+              className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-border bg-card px-4 text-sm font-medium text-foreground transition-colors hover:border-foreground/40 hover:bg-accent"
             >
-              Browse components
-              <ArrowRight className="size-3.5" />
+              Explore
             </Link>
             <a
               href={SITE.githubUrl}
               target="_blank"
               rel="noreferrer noopener"
-              className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-border bg-card px-3 text-sm font-medium text-foreground transition-colors hover:border-foreground/40 hover:bg-accent"
+              className="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
             >
               <Github className="size-3.5" />
-              GitHub
+              Star on GitHub
             </a>
           </div>
-        </div>
 
-        <dl className="grid grid-cols-2 gap-px overflow-hidden rounded-md border border-border bg-border sm:grid-cols-4">
-          {stats.map((item) => (
-            <div
-              key={item.label}
-              className="flex flex-col gap-0.5 bg-card px-3 py-2.5"
-            >
-              <dt className="font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground">
-                {item.label}
-              </dt>
-              <dd className="font-mono text-sm tabular-nums text-foreground">
-                {item.value}
-              </dd>
-            </div>
-          ))}
-        </dl>
-      </div>
-    </section>
-  )
-}
-
-/* -------------------------------------------------------------------------- */
-/* Components — every category, full list, dense                              */
-/* -------------------------------------------------------------------------- */
-
-function ComponentsGrid() {
-  const total = REGISTRY.filter((r) => r.category !== "blocks").length
-  const stable = REGISTRY.filter(
-    (r) => r.category !== "blocks" && r.status === "stable"
-  ).length
-
-  return (
-    <section className="border-b border-border">
-      <div className="mx-auto w-full max-w-5xl px-4 py-12 sm:px-6 sm:py-14 lg:px-8">
-        <div className="mb-6 flex items-baseline justify-between">
-          <h2 className="font-mono text-xs uppercase tracking-[0.12em] text-foreground">
-            Components
-          </h2>
-          <span className="font-mono text-[10px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
-            {stable} / {total} stable
-          </span>
-        </div>
-
-        <div className="flex flex-col gap-6">
-          {CATEGORY_ORDER.map((cat) => {
-            const items = REGISTRY_BY_CATEGORY[cat]
-            if (!items.length) return null
-            return (
-              <div key={cat} className="flex flex-col gap-2">
-                <div className="flex items-baseline justify-between">
-                  <h3 className="font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
-                    {CATEGORY_LABELS[cat]}
-                  </h3>
-                  <span className="font-mono text-[10px] tabular-nums text-muted-foreground">
-                    {items.filter((i) => i.status === "stable").length} /{" "}
-                    {items.length}
-                  </span>
-                </div>
-                <ul className="grid grid-cols-1 gap-px overflow-hidden rounded-md border border-border bg-border sm:grid-cols-2 lg:grid-cols-3">
-                  {items.map((entry) => (
-                    <li key={entry.name}>
-                      <Link
-                        href={`/${entry.name}`}
-                        className="group flex h-full flex-col justify-between gap-2 bg-card p-3 transition-colors hover:bg-accent"
-                      >
-                        <div className="flex flex-col gap-1">
-                          <div className="flex items-center justify-between gap-2">
-                            <h4 className="text-sm font-medium tracking-[-0.01em]">
-                              {entry.title}
-                            </h4>
-                            {entry.status === "planned" ? (
-                              <span className="rounded-sm border border-border px-1.5 font-mono text-[9px] uppercase tracking-[0.08em] text-muted-foreground">
-                                soon
-                              </span>
-                            ) : (
-                              <Check
-                                aria-hidden
-                                className="size-3 text-muted-foreground"
-                              />
-                            )}
-                          </div>
-                          <p className="text-[11px] leading-snug text-muted-foreground line-clamp-2">
-                            {entry.description}
-                          </p>
-                        </div>
-                        <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground group-hover:text-foreground">
-                          /{entry.name} →
-                        </span>
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )
-          })}
+          <div className="w-full max-w-md pt-2">
+            <InstallBlock name="multi-select" />
+          </div>
         </div>
       </div>
     </section>
@@ -238,64 +142,381 @@ function ComponentsGrid() {
 }
 
 /* -------------------------------------------------------------------------- */
-/* Blocks — kind-by-kind, dense                                               */
+/* Category grid — every category is a card with a wireframe preview          */
 /* -------------------------------------------------------------------------- */
 
-function BlocksList() {
-  const blocksCount = REGISTRY_BY_CATEGORY.blocks.length
+const COMPONENT_CATEGORY_ORDER: ComponentCategory[] = [
+  "inputs",
+  "pickers",
+  "files",
+  "data",
+  "display",
+]
+
+const BLOCK_ORDER: BlockKind[] = [
+  "hero",
+  "feature",
+  "pricing",
+  "testimonial",
+  "cta",
+  "faq",
+  "login",
+  "header",
+  "footer",
+  "not-found",
+]
+
+type CardLayout = {
+  /** Where the title sits relative to the preview */
+  align: "left" | "right" | "top" | "bottom" | "center"
+}
+
+const COMPONENT_LAYOUT: Record<ComponentCategory, CardLayout> = {
+  inputs: { align: "left" },
+  pickers: { align: "right" },
+  files: { align: "top" },
+  data: { align: "bottom" },
+  display: { align: "left" },
+  blocks: { align: "left" },
+}
+
+const BLOCK_LAYOUT: Record<BlockKind, CardLayout> = {
+  hero: { align: "top" },
+  feature: { align: "top" },
+  pricing: { align: "right" },
+  testimonial: { align: "top" },
+  cta: { align: "left" },
+  faq: { align: "bottom" },
+  login: { align: "left" },
+  header: { align: "center" },
+  footer: { align: "top" },
+  "not-found": { align: "center" },
+}
+
+function CategoryGrid() {
+  const componentCards = COMPONENT_CATEGORY_ORDER.map((cat) => ({
+    key: `c-${cat}`,
+    href: "/components",
+    title: CATEGORY_LABELS[cat],
+    count: REGISTRY_BY_CATEGORY[cat].length,
+    suffix: "components",
+    layout: COMPONENT_LAYOUT[cat],
+    preview: <ComponentPreview category={cat} />,
+  }))
+
+  const blockCards = BLOCK_ORDER.map((kind) => ({
+    key: `b-${kind}`,
+    href: `/blocks#${kind}`,
+    title: BLOCK_KIND_LABELS[kind],
+    count: BLOCKS_BY_KIND[kind].length,
+    suffix: "blocks",
+    layout: BLOCK_LAYOUT[kind],
+    preview: <BlockPreview kind={kind} />,
+  }))
+
+  const cards = [...componentCards, ...blockCards]
 
   return (
-    <section className="border-b border-border">
-      <div className="mx-auto w-full max-w-5xl px-4 py-12 sm:px-6 sm:py-14 lg:px-8">
+    <section className="border-t border-border">
+      <div className="mx-auto w-full max-w-6xl px-4 py-12 sm:px-6 sm:py-14 lg:px-8">
         <div className="mb-6 flex items-baseline justify-between">
           <h2 className="font-mono text-xs uppercase tracking-[0.12em] text-foreground">
-            Section blocks
+            Browse the catalog
           </h2>
           <Link
-            href="/blocks"
+            href="/components"
             className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground transition-colors hover:text-foreground"
           >
-            {blocksCount} blocks · view all
+            See everything
             <ArrowRight className="size-3" />
           </Link>
         </div>
 
-        <div className="flex flex-col gap-px overflow-hidden rounded-md border border-border bg-border">
-          {BLOCK_KIND_ORDER.map((kind) => {
-            const items = BLOCKS_BY_KIND[kind]
-            if (!items.length) return null
-            return (
-              <div
-                key={kind}
-                className="flex flex-col gap-2 bg-card px-3 py-2.5 sm:flex-row sm:items-center sm:justify-between"
+        <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {cards.map((card) => (
+            <li key={card.key} className="h-32">
+              <Link
+                href={card.href}
+                className="group relative flex h-full w-full overflow-hidden rounded-md border border-border bg-card p-4 transition-colors hover:border-foreground/40 hover:bg-accent"
               >
-                <div className="flex items-baseline gap-3">
-                  <h3 className="font-mono text-[11px] uppercase tracking-[0.12em] text-foreground">
-                    {BLOCK_KIND_LABELS[kind]}
-                  </h3>
-                  <span className="font-mono text-[10px] tabular-nums text-muted-foreground">
-                    {items.length}
-                  </span>
-                </div>
-                <ul className="flex flex-wrap gap-1.5">
-                  {items.map((entry) => (
-                    <li key={entry.name}>
-                      <Link
-                        href={`/blocks/${entry.name}`}
-                        className="group inline-flex items-center gap-1.5 rounded-sm border border-border bg-background px-2 py-0.5 font-mono text-[11px] tracking-tight transition-colors hover:border-foreground/40 hover:bg-accent"
-                        title={entry.title}
-                      >
-                        <span className="text-foreground">{entry.name}</span>
-                        <ArrowRight className="size-3 text-muted-foreground transition-transform duration-150 group-hover:translate-x-0.5 group-hover:text-foreground" />
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )
-          })}
-        </div>
+                <CardBody
+                  title={card.title}
+                  count={card.count}
+                  suffix={card.suffix}
+                  layout={card.layout}
+                  preview={card.preview}
+                />
+              </Link>
+            </li>
+          ))}
+        </ul>
       </div>
     </section>
   )
+}
+
+function CardBody({
+  title,
+  count,
+  suffix,
+  layout,
+  preview,
+}: {
+  title: string
+  count: number
+  suffix: string
+  layout: CardLayout
+  preview: React.ReactNode
+}) {
+  const meta = (
+    <div className="flex flex-col gap-0.5 leading-tight">
+      <h3 className="text-sm font-semibold tracking-[-0.01em] text-foreground">
+        {title}
+      </h3>
+      <p className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+        {count} {suffix}
+      </p>
+    </div>
+  )
+
+  switch (layout.align) {
+    case "left":
+      return (
+        <>
+          <div className="flex shrink-0 flex-col justify-between">{meta}</div>
+          <div className="ml-auto flex w-1/2 items-center justify-end">
+            {preview}
+          </div>
+        </>
+      )
+    case "right":
+      return (
+        <>
+          <div className="flex w-1/2 items-center">{preview}</div>
+          <div className="ml-auto flex shrink-0 flex-col justify-between text-right">
+            {meta}
+          </div>
+        </>
+      )
+    case "top":
+      return (
+        <div className="flex w-full flex-col gap-3">
+          <div className="text-center">{meta}</div>
+          <div className="flex flex-1 items-end justify-center">{preview}</div>
+        </div>
+      )
+    case "bottom":
+      return (
+        <div className="flex w-full flex-col gap-3">
+          <div className="flex flex-1 items-start justify-center">
+            {preview}
+          </div>
+          <div className="text-center">{meta}</div>
+        </div>
+      )
+    case "center":
+    default:
+      return (
+        <div className="relative flex w-full items-center justify-center">
+          <div className="absolute inset-x-0 flex justify-center">{preview}</div>
+          <div className="relative z-10 rounded-sm bg-card px-2 py-0.5">
+            {meta}
+          </div>
+        </div>
+      )
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Wireframe skeletons                                                        */
+/* -------------------------------------------------------------------------- */
+
+const SKEL_DARK = "rounded-sm bg-foreground/15"
+const SKEL_BORDER = "rounded-sm border border-border bg-background"
+
+function ComponentPreview({ category }: { category: ComponentCategory }) {
+  switch (category) {
+    case "inputs":
+      return (
+        <div className="flex w-full max-w-[140px] flex-col gap-1.5">
+          <div className={cn(SKEL_BORDER, "h-5 w-full px-1.5 py-1")}>
+            <div className={cn(SKEL_DARK, "h-2 w-12")} />
+          </div>
+          <div className="flex gap-1">
+            <span className={cn(SKEL_DARK, "h-3.5 w-10 rounded-full")} />
+            <span className={cn(SKEL_DARK, "h-3.5 w-8 rounded-full")} />
+            <span className={cn(SKEL_DARK, "h-3.5 w-6 rounded-full")} />
+          </div>
+        </div>
+      )
+    case "pickers":
+      return (
+        <div className={cn(SKEL_BORDER, "grid grid-cols-4 gap-0.5 p-1.5")}>
+          {Array.from({ length: 12 }).map((_, i) => (
+            <span
+              key={i}
+              className={cn(
+                "size-2.5 rounded-[2px]",
+                i === 6 ? "bg-foreground" : "bg-muted"
+              )}
+            />
+          ))}
+        </div>
+      )
+    case "files":
+      return (
+        <div
+          className={cn(
+            "flex h-14 w-24 flex-col items-center justify-center gap-1 rounded-md border border-dashed border-border bg-background"
+          )}
+        >
+          <span className={cn(SKEL_DARK, "h-1.5 w-10")} />
+          <span className={cn(SKEL_DARK, "h-1 w-6 opacity-60")} />
+        </div>
+      )
+    case "data":
+      return (
+        <div className="flex w-full max-w-[160px] flex-col gap-0.5">
+          {[0, 1, 2, 3].map((i) => (
+            <div key={i} className="flex items-center gap-1.5">
+              <span className={cn(SKEL_DARK, "h-1.5 w-8")} />
+              <span className={cn(SKEL_DARK, "h-1.5 flex-1 opacity-60")} />
+              <span className={cn(SKEL_DARK, "h-1.5 w-6 opacity-60")} />
+            </div>
+          ))}
+        </div>
+      )
+    case "display":
+    default:
+      return (
+        <div className={cn(SKEL_BORDER, "flex w-32 flex-col gap-1.5 p-2")}>
+          <div className="flex items-center gap-1">
+            <span className="size-3 rounded-full bg-foreground/80" />
+            <span className={cn(SKEL_DARK, "h-1.5 w-12")} />
+          </div>
+          <span className={cn(SKEL_DARK, "h-1 w-full opacity-60")} />
+          <span className={cn(SKEL_DARK, "h-1 w-3/4 opacity-60")} />
+        </div>
+      )
+  }
+}
+
+function BlockPreview({ kind }: { kind: BlockKind }) {
+  switch (kind) {
+    case "hero":
+      return (
+        <div className="flex w-full max-w-[180px] flex-col items-center gap-1.5">
+          <span className={cn(SKEL_DARK, "h-2 w-32")} />
+          <span className={cn(SKEL_DARK, "h-1.5 w-24 opacity-60")} />
+          <div className="mt-1 flex gap-1">
+            <span className="h-3.5 w-10 rounded-sm bg-foreground" />
+            <span className={cn(SKEL_BORDER, "h-3.5 w-10")} />
+          </div>
+        </div>
+      )
+    case "feature":
+      return (
+        <div className="flex gap-2">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="flex flex-col items-center gap-0.5">
+              <span className={cn(SKEL_BORDER, "size-5")} />
+              <span className={cn(SKEL_DARK, "h-1 w-5 opacity-60")} />
+            </div>
+          ))}
+        </div>
+      )
+    case "pricing":
+      return (
+        <div className="flex items-end gap-1">
+          <div className={cn(SKEL_BORDER, "h-10 w-9")} />
+          <div
+            className={cn(SKEL_BORDER, "h-12 w-9 border-foreground/40")}
+          />
+          <div className={cn(SKEL_BORDER, "h-10 w-9")} />
+        </div>
+      )
+    case "testimonial":
+      return (
+        <div className={cn(SKEL_BORDER, "flex w-full max-w-[180px] flex-col gap-1 p-2")}>
+          <span className={cn(SKEL_DARK, "h-1 w-full opacity-50")} />
+          <span className={cn(SKEL_DARK, "h-1 w-4/5 opacity-50")} />
+          <div className="mt-1 flex items-center gap-1">
+            <span className="size-3 rounded-full bg-foreground/70" />
+            <span className={cn(SKEL_DARK, "h-1 w-10")} />
+          </div>
+        </div>
+      )
+    case "cta":
+      return (
+        <div className="flex w-full max-w-[140px] items-center gap-1.5">
+          <div className="flex flex-1 flex-col gap-1">
+            <span className={cn(SKEL_DARK, "h-1.5 w-20")} />
+            <span className={cn(SKEL_DARK, "h-1 w-16 opacity-60")} />
+          </div>
+          <span className="h-4 w-12 rounded-sm bg-foreground" />
+        </div>
+      )
+    case "faq":
+      return (
+        <div className="flex w-full max-w-[180px] flex-col divide-y divide-border rounded-sm border border-border">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="flex items-center justify-between px-1.5 py-1">
+              <span className={cn(SKEL_DARK, "h-1.5 w-16 opacity-70")} />
+              <span className={cn(SKEL_DARK, "size-1.5 rounded-full")} />
+            </div>
+          ))}
+        </div>
+      )
+    case "login":
+      return (
+        <div className={cn(SKEL_BORDER, "flex w-32 flex-col gap-1 p-2")}>
+          <span className={cn(SKEL_DARK, "h-2 w-full")} />
+          <span className={cn(SKEL_DARK, "h-2 w-full")} />
+          <span className="h-2 w-full rounded-sm bg-foreground" />
+        </div>
+      )
+    case "header":
+      return (
+        <div
+          className={cn(SKEL_BORDER, "flex w-44 items-center gap-1 px-2 py-1")}
+        >
+          <span className="size-2 rounded-sm bg-foreground" />
+          <div className="flex flex-1 items-center justify-center gap-1.5">
+            <span className={cn(SKEL_DARK, "h-1 w-4 opacity-60")} />
+            <span className={cn(SKEL_DARK, "h-1 w-4 opacity-60")} />
+            <span className={cn(SKEL_DARK, "h-1 w-4 opacity-60")} />
+          </div>
+          <span className="h-2.5 w-7 rounded-sm bg-foreground" />
+        </div>
+      )
+    case "footer":
+      return (
+        <div className="grid w-full max-w-[200px] grid-cols-4 gap-2">
+          {[0, 1, 2, 3].map((col) => (
+            <div key={col} className="flex flex-col gap-0.5">
+              <span className={cn(SKEL_DARK, "h-1 w-full")} />
+              <span className={cn(SKEL_DARK, "h-1 w-3/4 opacity-60")} />
+              <span className={cn(SKEL_DARK, "h-1 w-3/4 opacity-60")} />
+            </div>
+          ))}
+        </div>
+      )
+    case "not-found":
+      return (
+        <div className="flex items-baseline gap-1">
+          <span
+            className="font-semibold text-muted-foreground/40"
+            style={{
+              fontFamily: "var(--font-fraunces), ui-serif, serif",
+              fontSize: 42,
+              lineHeight: 1,
+            }}
+          >
+            404
+          </span>
+        </div>
+      )
+    default:
+      return null
+  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -124,11 +124,7 @@ function Hero({
       {/* Ambient orb behind hero */}
       <div
         aria-hidden
-        className="pointer-events-none absolute left-1/2 top-0 -z-10 size-[640px] -translate-x-1/2 -translate-y-1/3 rounded-full opacity-40 blur-3xl animate-spin-slow"
-        style={{
-          background:
-            "conic-gradient(from 90deg, color-mix(in oklch, var(--primary) 40%, transparent), transparent 30%, color-mix(in oklch, var(--primary) 24%, transparent) 60%, transparent 80%)",
-        }}
+        className="bg-glow-orb pointer-events-none absolute left-1/2 top-0 -z-10 size-[640px] -translate-x-1/2 -translate-y-1/3 rounded-full opacity-50 blur-3xl animate-spin-slow light:opacity-30"
       />
 
       <div className="relative mx-auto flex w-full max-w-5xl flex-col items-center gap-9 px-4 pb-20 pt-20 text-center sm:gap-11 sm:px-6 sm:pb-28 sm:pt-28 md:pb-36 md:pt-32 lg:px-8">
@@ -170,7 +166,7 @@ function Hero({
         <div className="flex flex-wrap items-center justify-center gap-3">
           <Link
             href="/components"
-            className="group relative inline-flex h-11 items-center justify-center gap-2 overflow-hidden rounded-md bg-primary px-6 text-sm font-medium text-primary-foreground shadow-[0_0_0_1px_color-mix(in_oklch,var(--primary)_50%,transparent)] transition-all hover:bg-primary/95 hover:shadow-[0_0_36px_-8px_color-mix(in_oklch,var(--primary)_50%,transparent)]"
+            className="btn-glow-ring group relative inline-flex h-11 items-center justify-center gap-2 overflow-hidden rounded-md bg-primary px-6 text-sm font-medium text-primary-foreground transition-all hover:bg-primary/95"
           >
             <span
               aria-hidden
@@ -272,8 +268,8 @@ function Features() {
               <span className="relative inline-flex size-10 items-center justify-center rounded-md border border-border bg-background">
                 <span
                   aria-hidden
-                  className="pointer-events-none absolute inset-0 -z-10 rounded-md opacity-0 blur-md transition-opacity duration-300 group-hover:opacity-60"
-                  style={{ background: "var(--primary)" }}
+                  className="pointer-events-none absolute inset-0 -z-10 rounded-md opacity-0 blur-md transition-opacity duration-300 group-hover:opacity-60 light:group-hover:opacity-40"
+                  style={{ background: "var(--glow)" }}
                 />
                 <feature.icon className="size-4 text-foreground" />
               </span>
@@ -478,13 +474,14 @@ function Composition({ html, code }: { html: string; code: string }) {
           </ul>
         </div>
         <div className="relative min-w-0">
-          {/* Glow behind code block */}
+          {/* Glow behind code block — uses --glow so light mode reads as a
+              soft cream wash rather than a dark splotch. */}
           <div
             aria-hidden
-            className="pointer-events-none absolute -inset-4 -z-10 rounded-2xl opacity-50 blur-2xl"
+            className="pointer-events-none absolute -inset-4 -z-10 rounded-2xl opacity-50 blur-2xl light:opacity-40"
             style={{
               background:
-                "radial-gradient(ellipse 60% 80% at 50% 50%, color-mix(in oklch, var(--primary) 18%, transparent), transparent 70%)",
+                "radial-gradient(ellipse 60% 80% at 50% 50%, color-mix(in oklch, var(--glow) 22%, transparent), transparent 70%)",
             }}
           />
           <InlineCodeBlock code={code} html={html} />
@@ -597,14 +594,11 @@ function BottomCta({ blocksCount }: { blocksCount: number }) {
             }}
           />
 
-          {/* Spinning orb */}
+          {/* Spinning orb — theme-aware via .bg-glow-orb (cream wash in
+              light, warm amber in dark). */}
           <div
             aria-hidden
-            className="pointer-events-none absolute left-1/2 top-1/2 -z-0 size-[500px] -translate-x-1/2 -translate-y-1/2 rounded-full opacity-30 blur-3xl animate-spin-slow"
-            style={{
-              background:
-                "conic-gradient(from 0deg, color-mix(in oklch, var(--primary) 40%, transparent), transparent 50%, color-mix(in oklch, var(--primary) 30%, transparent))",
-            }}
+            className="bg-glow-orb pointer-events-none absolute left-1/2 top-1/2 -z-0 size-[500px] -translate-x-1/2 -translate-y-1/2 rounded-full opacity-40 blur-3xl animate-spin-slow light:opacity-25"
           />
 
           <div className="relative flex flex-col items-center gap-6 px-6 py-16 text-center sm:px-12 sm:py-24">
@@ -627,7 +621,7 @@ function BottomCta({ blocksCount }: { blocksCount: number }) {
             <div className="flex flex-wrap items-center justify-center gap-3 pt-2">
               <Link
                 href="/components"
-                className="group relative inline-flex h-11 items-center justify-center gap-2 overflow-hidden rounded-md bg-primary px-6 text-sm font-medium text-primary-foreground shadow-[0_0_0_1px_color-mix(in_oklch,var(--primary)_50%,transparent)] transition-all hover:bg-primary/95 hover:shadow-[0_0_36px_-8px_color-mix(in_oklch,var(--primary)_50%,transparent)]"
+                className="btn-glow-ring group relative inline-flex h-11 items-center justify-center gap-2 overflow-hidden rounded-md bg-primary px-6 text-sm font-medium text-primary-foreground transition-all hover:bg-primary/95"
               >
                 <span
                   aria-hidden

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,6 @@ import { ArrowRight, ArrowUpRight, Github } from "lucide-react"
 import { InstallBlock } from "@/components/showcase/install-block"
 import { SiteFooter } from "@/components/showcase/site-footer"
 import { SiteHeader } from "@/components/showcase/site-header"
-import { cn } from "@/lib/utils"
 import { SITE } from "@/lib/site"
 import {
   BLOCK_KIND_LABELS,
@@ -142,7 +141,7 @@ function Hero() {
 }
 
 /* -------------------------------------------------------------------------- */
-/* Category grid — every category is a card with a wireframe preview          */
+/* Catalog — just names                                                       */
 /* -------------------------------------------------------------------------- */
 
 const COMPONENT_CATEGORY_ORDER: ComponentCategory[] = [
@@ -166,33 +165,11 @@ const BLOCK_ORDER: BlockKind[] = [
   "not-found",
 ]
 
-type CardLayout = {
-  /** Where the title sits relative to the preview */
-  align: "left" | "right" | "top" | "bottom" | "center"
-  /** Tailwind col-span class for wide cards */
-  span?: "1" | "2"
-}
-
-const COMPONENT_LAYOUT: Record<ComponentCategory, CardLayout> = {
-  inputs: { align: "left", span: "2" },
-  pickers: { align: "right" },
-  files: { align: "top" },
-  data: { align: "left", span: "2" },
-  display: { align: "right" },
-  blocks: { align: "left" },
-}
-
-const BLOCK_LAYOUT: Record<BlockKind, CardLayout> = {
-  hero: { align: "top", span: "2" },
-  feature: { align: "top" },
-  pricing: { align: "top" },
-  testimonial: { align: "right" },
-  cta: { align: "left" },
-  faq: { align: "bottom" },
-  login: { align: "right" },
-  header: { align: "top", span: "2" },
-  footer: { align: "top", span: "2" },
-  "not-found": { align: "center" },
+type CatalogItem = {
+  key: string
+  href: string
+  title: string
+  count: number
 }
 
 function CategoryGrid() {
@@ -232,21 +209,17 @@ function CategoryGrid() {
           </Link>
         </header>
 
-        <CatalogGroup
-          label="Components"
-          count={componentTotal}
-          items={COMPONENT_CATEGORY_ORDER.map((cat) => ({
-            key: `c-${cat}`,
-            href: "/components",
-            title: CATEGORY_LABELS[cat],
-            count: REGISTRY_BY_CATEGORY[cat].length,
-            suffix: "components",
-            layout: COMPONENT_LAYOUT[cat],
-            preview: <ComponentPreview category={cat} />,
-          }))}
-        />
-
-        <div className="mt-10">
+        <div className="flex flex-col gap-8">
+          <CatalogGroup
+            label="Components"
+            count={componentTotal}
+            items={COMPONENT_CATEGORY_ORDER.map((cat) => ({
+              key: `c-${cat}`,
+              href: "/components",
+              title: CATEGORY_LABELS[cat],
+              count: REGISTRY_BY_CATEGORY[cat].length,
+            }))}
+          />
           <CatalogGroup
             label="Section blocks"
             count={blocksTotal}
@@ -255,25 +228,12 @@ function CategoryGrid() {
               href: `/blocks#${kind}`,
               title: BLOCK_KIND_LABELS[kind],
               count: BLOCKS_BY_KIND[kind].length,
-              suffix: "blocks",
-              layout: BLOCK_LAYOUT[kind],
-              preview: <BlockPreview kind={kind} />,
             }))}
           />
         </div>
       </div>
     </section>
   )
-}
-
-type CatalogItem = {
-  key: string
-  href: string
-  title: string
-  count: number
-  suffix: string
-  layout: CardLayout
-  preview: React.ReactNode
 }
 
 function CatalogGroup({
@@ -295,618 +255,26 @@ function CatalogGroup({
           {count} total
         </span>
       </div>
-      <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        {items.map((card) => (
-          <li
-            key={card.key}
-            className={cn(
-              "h-44",
-              card.layout.span === "2" && "sm:col-span-2"
-            )}
-          >
+      <ul className="grid grid-cols-2 gap-px overflow-hidden rounded-md border border-border bg-border sm:grid-cols-3 lg:grid-cols-5">
+        {items.map((item) => (
+          <li key={item.key}>
             <Link
-              href={card.href}
-              className="group relative flex h-full w-full overflow-hidden rounded-md border border-border bg-card transition-colors hover:border-foreground/40 hover:bg-accent"
+              href={item.href}
+              className="group flex h-full items-center justify-between gap-3 bg-card px-4 py-3 transition-colors hover:bg-accent"
             >
-              <CardBody
-                title={card.title}
-                count={card.count}
-                suffix={card.suffix}
-                layout={card.layout}
-                preview={card.preview}
-              />
+              <div className="flex flex-col gap-0.5 leading-tight">
+                <span className="text-sm font-medium tracking-[-0.01em] text-foreground">
+                  {item.title}
+                </span>
+                <span className="font-mono text-[10px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
+                  {item.count}
+                </span>
+              </div>
+              <ArrowRight className="size-3.5 text-muted-foreground transition-transform duration-150 group-hover:translate-x-0.5 group-hover:text-foreground" />
             </Link>
           </li>
         ))}
       </ul>
     </div>
   )
-}
-
-function CardBody({
-  title,
-  count,
-  suffix,
-  layout,
-  preview,
-}: {
-  title: string
-  count: number
-  suffix: string
-  layout: CardLayout
-  preview: React.ReactNode
-}) {
-  const meta = (
-    <div className="flex flex-col gap-0.5 leading-tight">
-      <h3 className="text-sm font-semibold tracking-[-0.01em] text-foreground">
-        {title}
-      </h3>
-      <p className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
-        {count} {suffix}
-      </p>
-    </div>
-  )
-
-  const previewWrap = (
-    <div className="relative flex h-full w-full items-center justify-center transition-transform duration-300 ease-out group-hover:scale-[1.03]">
-      {preview}
-    </div>
-  )
-
-  switch (layout.align) {
-    case "left":
-      return (
-        <div className="grid h-full w-full grid-cols-[auto_1fr] items-stretch">
-          <div className="z-10 flex shrink-0 flex-col justify-between p-4">
-            {meta}
-            <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground/80 group-hover:text-foreground">
-              browse →
-            </span>
-          </div>
-          <div className="relative overflow-hidden">{previewWrap}</div>
-        </div>
-      )
-    case "right":
-      return (
-        <div className="grid h-full w-full grid-cols-[1fr_auto] items-stretch">
-          <div className="relative overflow-hidden">{previewWrap}</div>
-          <div className="z-10 flex shrink-0 flex-col items-end justify-between p-4 text-right">
-            {meta}
-            <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground/80 group-hover:text-foreground">
-              browse →
-            </span>
-          </div>
-        </div>
-      )
-    case "top":
-      return (
-        <div className="grid h-full w-full grid-rows-[auto_1fr]">
-          <div className="z-10 flex items-center justify-between gap-3 px-4 pt-4">
-            {meta}
-            <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground/80 group-hover:text-foreground">
-              browse →
-            </span>
-          </div>
-          <div className="relative overflow-hidden px-4 pb-4 pt-3">
-            {previewWrap}
-          </div>
-        </div>
-      )
-    case "bottom":
-      return (
-        <div className="grid h-full w-full grid-rows-[1fr_auto]">
-          <div className="relative overflow-hidden px-4 pb-3 pt-4">
-            {previewWrap}
-          </div>
-          <div className="z-10 flex items-center justify-between gap-3 px-4 pb-4">
-            {meta}
-            <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground/80 group-hover:text-foreground">
-              browse →
-            </span>
-          </div>
-        </div>
-      )
-    case "center":
-    default:
-      return (
-        <div className="relative flex h-full w-full items-center justify-center overflow-hidden">
-          <div className="absolute inset-0 flex items-center justify-center">
-            {previewWrap}
-          </div>
-          <div className="relative z-10 rounded-md border border-border bg-card/90 px-3 py-1.5 backdrop-blur-sm">
-            {meta}
-          </div>
-        </div>
-      )
-  }
-}
-
-/* -------------------------------------------------------------------------- */
-/* Wireframe skeletons                                                        */
-/* -------------------------------------------------------------------------- */
-
-const SKEL_BORDER = "rounded-sm border border-border bg-background"
-const SKEL_SOLID = "rounded-sm bg-foreground"
-
-function Bar({
-  w,
-  className,
-}: {
-  w: string
-  className?: string
-}) {
-  return (
-    <span
-      className={cn("block h-1.5 rounded-full bg-foreground/15", className)}
-      style={{ width: w }}
-    />
-  )
-}
-
-function ComponentPreview({ category }: { category: ComponentCategory }) {
-  switch (category) {
-    case "inputs":
-      return (
-        <div className="flex w-full max-w-[260px] flex-col gap-2">
-          {/* MultiSelect trigger with chips */}
-          <div
-            className={cn(SKEL_BORDER, "flex items-center gap-1 px-2 py-1.5")}
-          >
-            <span className="rounded-sm bg-foreground/10 px-1.5 py-0.5 text-[8px] font-medium text-foreground">
-              react
-            </span>
-            <span className="rounded-sm bg-foreground/10 px-1.5 py-0.5 text-[8px] font-medium text-foreground">
-              tailwind
-            </span>
-            <span className="rounded-sm bg-foreground/10 px-1.5 py-0.5 text-[8px] font-medium text-foreground">
-              shadcn
-            </span>
-            <span className="ml-auto text-[10px] text-muted-foreground">
-              ⌄
-            </span>
-          </div>
-          {/* Popover dropdown */}
-          <div
-            className={cn(
-              SKEL_BORDER,
-              "flex flex-col gap-1 px-2 py-1.5 shadow-sm"
-            )}
-          >
-            {["Next.js", "Radix", "Lucide"].map((label, i) => (
-              <div key={label} className="flex items-center gap-1.5">
-                <span
-                  className={cn(
-                    "size-2.5 shrink-0 rounded-[2px] border border-border",
-                    i < 2 && "bg-foreground"
-                  )}
-                />
-                <span className="text-[9px] text-muted-foreground">
-                  {label}
-                </span>
-              </div>
-            ))}
-          </div>
-        </div>
-      )
-    case "pickers":
-      return (
-        <div
-          className={cn(SKEL_BORDER, "flex w-[150px] flex-col gap-1.5 p-2")}
-        >
-          <div className="flex items-center justify-between">
-            <span className="text-[8px] font-medium text-foreground">May</span>
-            <span className="text-[8px] text-muted-foreground">2026</span>
-          </div>
-          <div className="grid grid-cols-7 gap-[2px]">
-            {["M", "T", "W", "T", "F", "S", "S"].map((d, i) => (
-              <span
-                key={i}
-                className="text-center text-[7px] text-muted-foreground/70"
-              >
-                {d}
-              </span>
-            ))}
-            {Array.from({ length: 28 }).map((_, i) => {
-              const inRange = i >= 9 && i <= 15
-              const isStart = i === 9
-              const isEnd = i === 15
-              return (
-                <span
-                  key={i}
-                  className={cn(
-                    "flex h-3 items-center justify-center text-[7px]",
-                    inRange ? "bg-foreground/15" : "",
-                    isStart || isEnd
-                      ? "rounded-sm bg-foreground text-background"
-                      : "text-foreground/70"
-                  )}
-                >
-                  {i + 1}
-                </span>
-              )
-            })}
-          </div>
-        </div>
-      )
-    case "files":
-      return (
-        <div className="flex w-full max-w-[200px] flex-col items-center gap-1.5">
-          <div className="flex h-16 w-full flex-col items-center justify-center gap-1 rounded-md border border-dashed border-border bg-background">
-            <span className="text-[10px] text-muted-foreground">↑</span>
-            <span className="text-[8px] font-medium text-foreground">
-              Drop files here
-            </span>
-            <span className="text-[7px] text-muted-foreground/70">
-              or click to browse
-            </span>
-          </div>
-          <div
-            className={cn(
-              SKEL_BORDER,
-              "flex w-full items-center gap-1.5 px-1.5 py-1"
-            )}
-          >
-            <span className="size-3 rounded-sm bg-foreground/20" />
-            <Bar w="50%" className="opacity-70" />
-            <span className="ml-auto text-[8px] text-muted-foreground">
-              82%
-            </span>
-          </div>
-        </div>
-      )
-    case "data":
-      return (
-        <div
-          className={cn(SKEL_BORDER, "flex w-full max-w-[320px] flex-col p-1.5")}
-        >
-          {/* table header */}
-          <div className="flex items-center gap-3 border-b border-border px-1 pb-1">
-            {["Name", "Status", "Updated"].map((h, i) => (
-              <span
-                key={h}
-                className={cn(
-                  "text-[8px] font-medium uppercase tracking-wider text-muted-foreground",
-                  i === 0 && "flex-1"
-                )}
-              >
-                {h}
-              </span>
-            ))}
-          </div>
-          {/* rows */}
-          {[
-            { name: "MultiSelect", status: "stable" },
-            { name: "YearPicker", status: "stable" },
-            { name: "TagInput", status: "stable" },
-            { name: "ColorPicker", status: "soon" },
-          ].map((row) => (
-            <div
-              key={row.name}
-              className="flex items-center gap-3 border-b border-border/60 px-1 py-1 last:border-0"
-            >
-              <span className="flex-1 text-[8px] font-medium text-foreground">
-                {row.name}
-              </span>
-              <span
-                className={cn(
-                  "rounded-sm px-1 text-[7px] uppercase tracking-wider",
-                  row.status === "stable"
-                    ? "bg-foreground/10 text-foreground"
-                    : "border border-border text-muted-foreground"
-                )}
-              >
-                {row.status}
-              </span>
-              <Bar w="2rem" className="opacity-60" />
-            </div>
-          ))}
-        </div>
-      )
-    case "display":
-    default:
-      return (
-        <div
-          className={cn(SKEL_BORDER, "flex w-[180px] flex-col gap-1.5 p-2")}
-        >
-          <div className="flex items-center gap-1.5">
-            <span className="size-5 rounded-full bg-foreground/80" />
-            <div className="flex flex-1 flex-col gap-0.5">
-              <Bar w="55%" className="!h-1" />
-              <Bar w="40%" className="!h-1 opacity-60" />
-            </div>
-            <span className="text-[9px] font-medium text-foreground">
-              42 ↑
-            </span>
-          </div>
-          <div className="h-px bg-border" />
-          <div className="flex items-center justify-between">
-            <span className="rounded-sm bg-foreground/10 px-1.5 py-0.5 text-[8px] text-foreground">
-              feature
-            </span>
-            <span className="text-[8px] text-muted-foreground">just now</span>
-          </div>
-        </div>
-      )
-  }
-}
-
-function BlockPreview({ kind }: { kind: BlockKind }) {
-  switch (kind) {
-    case "hero":
-      return (
-        <div className="flex w-full max-w-[360px] flex-col items-center gap-2">
-          <span className="rounded-full border border-border bg-background px-2 py-0.5 text-[8px] uppercase tracking-wider text-muted-foreground">
-            v1 · live
-          </span>
-          <span
-            className="font-semibold text-foreground"
-            style={{
-              fontFamily: "var(--font-fraunces), ui-serif, serif",
-              fontSize: 22,
-              lineHeight: 1.05,
-            }}
-          >
-            Big serif headline
-          </span>
-          <div className="flex flex-col items-center gap-0.5">
-            <Bar w="180px" className="opacity-60" />
-            <Bar w="140px" className="opacity-50" />
-          </div>
-          <div className="flex gap-1.5">
-            <span className={cn(SKEL_SOLID, "h-4 w-16")} />
-            <span className={cn(SKEL_BORDER, "h-4 w-16")} />
-          </div>
-        </div>
-      )
-    case "feature":
-      return (
-        <div className="flex w-full max-w-[260px] items-stretch gap-1.5">
-          {[0, 1, 2].map((i) => (
-            <div
-              key={i}
-              className={cn(
-                SKEL_BORDER,
-                "flex flex-1 flex-col items-center gap-1 p-1.5"
-              )}
-            >
-              <span className="flex size-5 items-center justify-center rounded-md border border-border bg-card">
-                <span className="size-2 rounded-sm bg-foreground/40" />
-              </span>
-              <Bar w="80%" className="!h-1" />
-              <Bar w="60%" className="!h-1 opacity-60" />
-            </div>
-          ))}
-        </div>
-      )
-    case "pricing":
-      return (
-        <div className="flex items-end gap-1.5">
-          {[
-            { tall: false, label: "Free" },
-            { tall: true, label: "Pro" },
-            { tall: false, label: "Team" },
-          ].map((tier, i) => (
-            <div
-              key={i}
-              className={cn(
-                SKEL_BORDER,
-                "flex flex-col items-center gap-1 px-2 py-2",
-                tier.tall && "border-foreground/40",
-                tier.tall ? "h-24 w-16" : "h-20 w-14"
-              )}
-            >
-              <span className="text-[8px] font-medium uppercase tracking-wider text-muted-foreground">
-                {tier.label}
-              </span>
-              <span
-                className={cn(
-                  "font-semibold text-foreground",
-                  tier.tall ? "text-base" : "text-sm"
-                )}
-                style={{
-                  fontFamily: "var(--font-fraunces), ui-serif, serif",
-                }}
-              >
-                ${tier.tall ? 29 : i === 0 ? 0 : 99}
-              </span>
-              <div className="flex w-full flex-col items-center gap-0.5">
-                <Bar w="80%" className="!h-0.5 opacity-60" />
-                <Bar w="60%" className="!h-0.5 opacity-60" />
-                <Bar w="70%" className="!h-0.5 opacity-60" />
-              </div>
-              {tier.tall && (
-                <span
-                  className={cn(SKEL_SOLID, "mt-auto h-2 w-full rounded-sm")}
-                />
-              )}
-            </div>
-          ))}
-        </div>
-      )
-    case "testimonial":
-      return (
-        <div
-          className={cn(SKEL_BORDER, "flex w-[220px] flex-col gap-2 p-2.5")}
-        >
-          <div className="flex gap-0.5">
-            {[0, 1, 2, 3, 4].map((i) => (
-              <span
-                key={i}
-                className="text-[10px] leading-none text-foreground"
-              >
-                ★
-              </span>
-            ))}
-          </div>
-          <div className="flex flex-col gap-0.5">
-            <Bar w="100%" className="!h-1 opacity-60" />
-            <Bar w="90%" className="!h-1 opacity-60" />
-            <Bar w="60%" className="!h-1 opacity-60" />
-          </div>
-          <div className="flex items-center gap-1.5">
-            <span className="size-5 rounded-full bg-foreground/70" />
-            <div className="flex flex-col gap-0.5">
-              <Bar w="60px" className="!h-1" />
-              <Bar w="40px" className="!h-0.5 opacity-60" />
-            </div>
-          </div>
-        </div>
-      )
-    case "cta":
-      return (
-        <div
-          className={cn(SKEL_BORDER, "flex w-full max-w-[200px] flex-col items-center gap-1.5 p-2")}
-        >
-          <span
-            className="font-semibold text-foreground"
-            style={{
-              fontFamily: "var(--font-fraunces), ui-serif, serif",
-              fontSize: 14,
-              lineHeight: 1.1,
-            }}
-          >
-            Ready to ship?
-          </span>
-          <Bar w="80%" className="!h-1 opacity-60" />
-          <div className="mt-0.5 flex gap-1">
-            <span className={cn(SKEL_SOLID, "h-3.5 w-12")} />
-            <span className={cn(SKEL_BORDER, "h-3.5 w-10")} />
-          </div>
-        </div>
-      )
-    case "faq":
-      return (
-        <div className="flex w-full max-w-[260px] flex-col divide-y divide-border rounded-md border border-border bg-background">
-          {[
-            { q: "What is msh ui?", open: true },
-            { q: "How do I install?", open: false },
-            { q: "Is it free?", open: false },
-          ].map((item, i) => (
-            <div key={i} className="px-2 py-1.5">
-              <div className="flex items-center justify-between">
-                <span className="text-[9px] font-medium text-foreground">
-                  {item.q}
-                </span>
-                <span className="text-[10px] text-muted-foreground">
-                  {item.open ? "−" : "+"}
-                </span>
-              </div>
-              {item.open && (
-                <div className="mt-1 flex flex-col gap-0.5">
-                  <Bar w="100%" className="!h-1 opacity-60" />
-                  <Bar w="70%" className="!h-1 opacity-60" />
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
-      )
-    case "login":
-      return (
-        <div
-          className={cn(SKEL_BORDER, "flex w-[180px] flex-col gap-1.5 p-2.5")}
-        >
-          <span
-            className="text-center font-semibold text-foreground"
-            style={{
-              fontFamily: "var(--font-fraunces), ui-serif, serif",
-              fontSize: 12,
-            }}
-          >
-            Sign in
-          </span>
-          <div className={cn(SKEL_BORDER, "h-4 px-1.5")}>
-            <Bar w="40%" className="mt-1 !h-1 opacity-60" />
-          </div>
-          <div className={cn(SKEL_BORDER, "h-4 px-1.5")}>
-            <Bar w="60%" className="mt-1 !h-1 opacity-60" />
-          </div>
-          <span className={cn(SKEL_SOLID, "h-4 w-full")} />
-          <div className="flex items-center gap-1">
-            <span className="h-px flex-1 bg-border" />
-            <span className="text-[7px] uppercase text-muted-foreground">
-              or
-            </span>
-            <span className="h-px flex-1 bg-border" />
-          </div>
-          <div className="flex gap-1">
-            <span className={cn(SKEL_BORDER, "h-3.5 flex-1")} />
-            <span className={cn(SKEL_BORDER, "h-3.5 flex-1")} />
-          </div>
-        </div>
-      )
-    case "header":
-      return (
-        <div
-          className={cn(
-            SKEL_BORDER,
-            "flex w-full max-w-[440px] items-center gap-2 px-3 py-2"
-          )}
-        >
-          <span
-            className="font-semibold text-foreground"
-            style={{
-              fontFamily: "var(--font-fraunces), ui-serif, serif",
-              fontSize: 12,
-              lineHeight: 1,
-            }}
-          >
-            Brand
-          </span>
-          <div className="ml-4 flex flex-1 items-center gap-3">
-            {["Home", "Docs", "Pricing", "About"].map((l) => (
-              <span key={l} className="text-[9px] text-muted-foreground">
-                {l}
-              </span>
-            ))}
-          </div>
-          <span className={cn(SKEL_BORDER, "h-4 w-12")} />
-          <span className={cn(SKEL_SOLID, "h-4 w-14")} />
-        </div>
-      )
-    case "footer":
-      return (
-        <div className="flex w-full max-w-[460px] flex-col gap-2">
-          <div className="grid grid-cols-4 gap-3 border-b border-border pb-2">
-            {["Product", "Resources", "Company", "Legal"].map((col) => (
-              <div key={col} className="flex flex-col gap-1">
-                <span className="text-[8px] font-semibold uppercase tracking-wider text-foreground">
-                  {col}
-                </span>
-                <Bar w="80%" className="!h-1 opacity-60" />
-                <Bar w="60%" className="!h-1 opacity-60" />
-                <Bar w="70%" className="!h-1 opacity-60" />
-              </div>
-            ))}
-          </div>
-          <div className="flex items-center justify-between">
-            <span className="text-[8px] uppercase tracking-wider text-muted-foreground">
-              © 2026
-            </span>
-            <div className="flex gap-1">
-              <span className="size-3 rounded-full bg-foreground/15" />
-              <span className="size-3 rounded-full bg-foreground/15" />
-              <span className="size-3 rounded-full bg-foreground/15" />
-            </div>
-          </div>
-        </div>
-      )
-    case "not-found":
-      return (
-        <div className="flex flex-col items-center gap-1">
-          <span
-            className="leading-none text-foreground/15"
-            style={{
-              fontFamily: "var(--font-fraunces), ui-serif, serif",
-              fontSize: 84,
-              fontWeight: 600,
-            }}
-          >
-            404
-          </span>
-        </div>
-      )
-    default:
-      return null
-  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -74,7 +74,7 @@ function Hero() {
       />
 
       <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6 sm:py-16 lg:px-8">
-        <div className="relative mx-auto flex max-w-3xl flex-col items-center gap-6 border border-border bg-background/30 px-6 py-14 text-center sm:gap-7 sm:py-20 md:py-24">
+        <div className="relative mx-auto flex flex-col items-center gap-6 border border-border bg-background/30 px-6 py-14 text-center sm:gap-7 sm:py-20 md:py-24">
           <CornerMarks />
 
           <div className="inline-flex items-center gap-1 rounded-full border border-border bg-card p-1 font-mono text-[10px] uppercase tracking-[0.12em]">
@@ -169,89 +169,157 @@ const BLOCK_ORDER: BlockKind[] = [
 type CardLayout = {
   /** Where the title sits relative to the preview */
   align: "left" | "right" | "top" | "bottom" | "center"
+  /** Tailwind col-span class for wide cards */
+  span?: "1" | "2"
 }
 
 const COMPONENT_LAYOUT: Record<ComponentCategory, CardLayout> = {
-  inputs: { align: "left" },
+  inputs: { align: "left", span: "2" },
   pickers: { align: "right" },
   files: { align: "top" },
-  data: { align: "bottom" },
-  display: { align: "left" },
+  data: { align: "left", span: "2" },
+  display: { align: "right" },
   blocks: { align: "left" },
 }
 
 const BLOCK_LAYOUT: Record<BlockKind, CardLayout> = {
-  hero: { align: "top" },
+  hero: { align: "top", span: "2" },
   feature: { align: "top" },
-  pricing: { align: "right" },
-  testimonial: { align: "top" },
+  pricing: { align: "top" },
+  testimonial: { align: "right" },
   cta: { align: "left" },
   faq: { align: "bottom" },
-  login: { align: "left" },
-  header: { align: "center" },
-  footer: { align: "top" },
+  login: { align: "right" },
+  header: { align: "top", span: "2" },
+  footer: { align: "top", span: "2" },
   "not-found": { align: "center" },
 }
 
 function CategoryGrid() {
-  const componentCards = COMPONENT_CATEGORY_ORDER.map((cat) => ({
-    key: `c-${cat}`,
-    href: "/components",
-    title: CATEGORY_LABELS[cat],
-    count: REGISTRY_BY_CATEGORY[cat].length,
-    suffix: "components",
-    layout: COMPONENT_LAYOUT[cat],
-    preview: <ComponentPreview category={cat} />,
-  }))
-
-  const blockCards = BLOCK_ORDER.map((kind) => ({
-    key: `b-${kind}`,
-    href: `/blocks#${kind}`,
-    title: BLOCK_KIND_LABELS[kind],
-    count: BLOCKS_BY_KIND[kind].length,
-    suffix: "blocks",
-    layout: BLOCK_LAYOUT[kind],
-    preview: <BlockPreview kind={kind} />,
-  }))
-
-  const cards = [...componentCards, ...blockCards]
+  const componentTotal = COMPONENT_CATEGORY_ORDER.reduce(
+    (sum, c) => sum + REGISTRY_BY_CATEGORY[c].length,
+    0
+  )
+  const blocksTotal = BLOCK_ORDER.reduce(
+    (sum, k) => sum + BLOCKS_BY_KIND[k].length,
+    0
+  )
 
   return (
     <section className="border-t border-border">
-      <div className="mx-auto w-full max-w-6xl px-4 py-12 sm:px-6 sm:py-14 lg:px-8">
-        <div className="mb-6 flex items-baseline justify-between">
-          <h2 className="font-mono text-xs uppercase tracking-[0.12em] text-foreground">
-            Browse the catalog
-          </h2>
+      <div className="mx-auto w-full max-w-6xl px-4 py-12 sm:px-6 sm:py-16 lg:px-8">
+        <header className="mb-8 flex flex-col gap-2 sm:mb-10 sm:flex-row sm:items-end sm:justify-between">
+          <div className="flex flex-col gap-2">
+            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+              ◆ Catalog
+            </span>
+            <h2
+              className="text-balance text-2xl tracking-[-0.02em] sm:text-3xl"
+              style={{ fontFamily: "var(--font-fraunces), ui-serif, serif" }}
+            >
+              <span className="font-semibold">Everything</span>{" "}
+              <span className="font-normal text-muted-foreground">
+                we ship.
+              </span>
+            </h2>
+          </div>
           <Link
             href="/components"
-            className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground transition-colors hover:text-foreground"
+            className="inline-flex items-center gap-1 self-start font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground transition-colors hover:text-foreground sm:self-auto"
           >
             See everything
             <ArrowRight className="size-3" />
           </Link>
-        </div>
+        </header>
 
-        <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          {cards.map((card) => (
-            <li key={card.key} className="h-32">
-              <Link
-                href={card.href}
-                className="group relative flex h-full w-full overflow-hidden rounded-md border border-border bg-card p-4 transition-colors hover:border-foreground/40 hover:bg-accent"
-              >
-                <CardBody
-                  title={card.title}
-                  count={card.count}
-                  suffix={card.suffix}
-                  layout={card.layout}
-                  preview={card.preview}
-                />
-              </Link>
-            </li>
-          ))}
-        </ul>
+        <CatalogGroup
+          label="Components"
+          count={componentTotal}
+          items={COMPONENT_CATEGORY_ORDER.map((cat) => ({
+            key: `c-${cat}`,
+            href: "/components",
+            title: CATEGORY_LABELS[cat],
+            count: REGISTRY_BY_CATEGORY[cat].length,
+            suffix: "components",
+            layout: COMPONENT_LAYOUT[cat],
+            preview: <ComponentPreview category={cat} />,
+          }))}
+        />
+
+        <div className="mt-10">
+          <CatalogGroup
+            label="Section blocks"
+            count={blocksTotal}
+            items={BLOCK_ORDER.map((kind) => ({
+              key: `b-${kind}`,
+              href: `/blocks#${kind}`,
+              title: BLOCK_KIND_LABELS[kind],
+              count: BLOCKS_BY_KIND[kind].length,
+              suffix: "blocks",
+              layout: BLOCK_LAYOUT[kind],
+              preview: <BlockPreview kind={kind} />,
+            }))}
+          />
+        </div>
       </div>
     </section>
+  )
+}
+
+type CatalogItem = {
+  key: string
+  href: string
+  title: string
+  count: number
+  suffix: string
+  layout: CardLayout
+  preview: React.ReactNode
+}
+
+function CatalogGroup({
+  label,
+  count,
+  items,
+}: {
+  label: string
+  count: number
+  items: CatalogItem[]
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-baseline justify-between">
+        <h3 className="font-mono text-[11px] uppercase tracking-[0.14em] text-foreground">
+          {label}
+        </h3>
+        <span className="font-mono text-[10px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
+          {count} total
+        </span>
+      </div>
+      <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {items.map((card) => (
+          <li
+            key={card.key}
+            className={cn(
+              "h-44",
+              card.layout.span === "2" && "sm:col-span-2"
+            )}
+          >
+            <Link
+              href={card.href}
+              className="group relative flex h-full w-full overflow-hidden rounded-md border border-border bg-card transition-colors hover:border-foreground/40 hover:bg-accent"
+            >
+              <CardBody
+                title={card.title}
+                count={card.count}
+                suffix={card.suffix}
+                layout={card.layout}
+                preview={card.preview}
+              />
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
   )
 }
 
@@ -279,47 +347,73 @@ function CardBody({
     </div>
   )
 
+  const previewWrap = (
+    <div className="relative flex h-full w-full items-center justify-center transition-transform duration-300 ease-out group-hover:scale-[1.03]">
+      {preview}
+    </div>
+  )
+
   switch (layout.align) {
     case "left":
       return (
-        <>
-          <div className="flex shrink-0 flex-col justify-between">{meta}</div>
-          <div className="ml-auto flex w-1/2 items-center justify-end">
-            {preview}
+        <div className="grid h-full w-full grid-cols-[auto_1fr] items-stretch">
+          <div className="z-10 flex shrink-0 flex-col justify-between p-4">
+            {meta}
+            <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground/80 group-hover:text-foreground">
+              browse →
+            </span>
           </div>
-        </>
+          <div className="relative overflow-hidden">{previewWrap}</div>
+        </div>
       )
     case "right":
       return (
-        <>
-          <div className="flex w-1/2 items-center">{preview}</div>
-          <div className="ml-auto flex shrink-0 flex-col justify-between text-right">
+        <div className="grid h-full w-full grid-cols-[1fr_auto] items-stretch">
+          <div className="relative overflow-hidden">{previewWrap}</div>
+          <div className="z-10 flex shrink-0 flex-col items-end justify-between p-4 text-right">
             {meta}
+            <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground/80 group-hover:text-foreground">
+              browse →
+            </span>
           </div>
-        </>
+        </div>
       )
     case "top":
       return (
-        <div className="flex w-full flex-col gap-3">
-          <div className="text-center">{meta}</div>
-          <div className="flex flex-1 items-end justify-center">{preview}</div>
+        <div className="grid h-full w-full grid-rows-[auto_1fr]">
+          <div className="z-10 flex items-center justify-between gap-3 px-4 pt-4">
+            {meta}
+            <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground/80 group-hover:text-foreground">
+              browse →
+            </span>
+          </div>
+          <div className="relative overflow-hidden px-4 pb-4 pt-3">
+            {previewWrap}
+          </div>
         </div>
       )
     case "bottom":
       return (
-        <div className="flex w-full flex-col gap-3">
-          <div className="flex flex-1 items-start justify-center">
-            {preview}
+        <div className="grid h-full w-full grid-rows-[1fr_auto]">
+          <div className="relative overflow-hidden px-4 pb-3 pt-4">
+            {previewWrap}
           </div>
-          <div className="text-center">{meta}</div>
+          <div className="z-10 flex items-center justify-between gap-3 px-4 pb-4">
+            {meta}
+            <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground/80 group-hover:text-foreground">
+              browse →
+            </span>
+          </div>
         </div>
       )
     case "center":
     default:
       return (
-        <div className="relative flex w-full items-center justify-center">
-          <div className="absolute inset-x-0 flex justify-center">{preview}</div>
-          <div className="relative z-10 rounded-sm bg-card px-2 py-0.5">
+        <div className="relative flex h-full w-full items-center justify-center overflow-hidden">
+          <div className="absolute inset-0 flex items-center justify-center">
+            {previewWrap}
+          </div>
+          <div className="relative z-10 rounded-md border border-border bg-card/90 px-3 py-1.5 backdrop-blur-sm">
             {meta}
           </div>
         </div>
@@ -331,57 +425,179 @@ function CardBody({
 /* Wireframe skeletons                                                        */
 /* -------------------------------------------------------------------------- */
 
-const SKEL_DARK = "rounded-sm bg-foreground/15"
 const SKEL_BORDER = "rounded-sm border border-border bg-background"
+const SKEL_SOLID = "rounded-sm bg-foreground"
+
+function Bar({
+  w,
+  className,
+}: {
+  w: string
+  className?: string
+}) {
+  return (
+    <span
+      className={cn("block h-1.5 rounded-full bg-foreground/15", className)}
+      style={{ width: w }}
+    />
+  )
+}
 
 function ComponentPreview({ category }: { category: ComponentCategory }) {
   switch (category) {
     case "inputs":
       return (
-        <div className="flex w-full max-w-[140px] flex-col gap-1.5">
-          <div className={cn(SKEL_BORDER, "h-5 w-full px-1.5 py-1")}>
-            <div className={cn(SKEL_DARK, "h-2 w-12")} />
+        <div className="flex w-full max-w-[260px] flex-col gap-2">
+          {/* MultiSelect trigger with chips */}
+          <div
+            className={cn(SKEL_BORDER, "flex items-center gap-1 px-2 py-1.5")}
+          >
+            <span className="rounded-sm bg-foreground/10 px-1.5 py-0.5 text-[8px] font-medium text-foreground">
+              react
+            </span>
+            <span className="rounded-sm bg-foreground/10 px-1.5 py-0.5 text-[8px] font-medium text-foreground">
+              tailwind
+            </span>
+            <span className="rounded-sm bg-foreground/10 px-1.5 py-0.5 text-[8px] font-medium text-foreground">
+              shadcn
+            </span>
+            <span className="ml-auto text-[10px] text-muted-foreground">
+              ⌄
+            </span>
           </div>
-          <div className="flex gap-1">
-            <span className={cn(SKEL_DARK, "h-3.5 w-10 rounded-full")} />
-            <span className={cn(SKEL_DARK, "h-3.5 w-8 rounded-full")} />
-            <span className={cn(SKEL_DARK, "h-3.5 w-6 rounded-full")} />
+          {/* Popover dropdown */}
+          <div
+            className={cn(
+              SKEL_BORDER,
+              "flex flex-col gap-1 px-2 py-1.5 shadow-sm"
+            )}
+          >
+            {["Next.js", "Radix", "Lucide"].map((label, i) => (
+              <div key={label} className="flex items-center gap-1.5">
+                <span
+                  className={cn(
+                    "size-2.5 shrink-0 rounded-[2px] border border-border",
+                    i < 2 && "bg-foreground"
+                  )}
+                />
+                <span className="text-[9px] text-muted-foreground">
+                  {label}
+                </span>
+              </div>
+            ))}
           </div>
         </div>
       )
     case "pickers":
       return (
-        <div className={cn(SKEL_BORDER, "grid grid-cols-4 gap-0.5 p-1.5")}>
-          {Array.from({ length: 12 }).map((_, i) => (
-            <span
-              key={i}
-              className={cn(
-                "size-2.5 rounded-[2px]",
-                i === 6 ? "bg-foreground" : "bg-muted"
-              )}
-            />
-          ))}
+        <div
+          className={cn(SKEL_BORDER, "flex w-[150px] flex-col gap-1.5 p-2")}
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-[8px] font-medium text-foreground">May</span>
+            <span className="text-[8px] text-muted-foreground">2026</span>
+          </div>
+          <div className="grid grid-cols-7 gap-[2px]">
+            {["M", "T", "W", "T", "F", "S", "S"].map((d, i) => (
+              <span
+                key={i}
+                className="text-center text-[7px] text-muted-foreground/70"
+              >
+                {d}
+              </span>
+            ))}
+            {Array.from({ length: 28 }).map((_, i) => {
+              const inRange = i >= 9 && i <= 15
+              const isStart = i === 9
+              const isEnd = i === 15
+              return (
+                <span
+                  key={i}
+                  className={cn(
+                    "flex h-3 items-center justify-center text-[7px]",
+                    inRange ? "bg-foreground/15" : "",
+                    isStart || isEnd
+                      ? "rounded-sm bg-foreground text-background"
+                      : "text-foreground/70"
+                  )}
+                >
+                  {i + 1}
+                </span>
+              )
+            })}
+          </div>
         </div>
       )
     case "files":
       return (
-        <div
-          className={cn(
-            "flex h-14 w-24 flex-col items-center justify-center gap-1 rounded-md border border-dashed border-border bg-background"
-          )}
-        >
-          <span className={cn(SKEL_DARK, "h-1.5 w-10")} />
-          <span className={cn(SKEL_DARK, "h-1 w-6 opacity-60")} />
+        <div className="flex w-full max-w-[200px] flex-col items-center gap-1.5">
+          <div className="flex h-16 w-full flex-col items-center justify-center gap-1 rounded-md border border-dashed border-border bg-background">
+            <span className="text-[10px] text-muted-foreground">↑</span>
+            <span className="text-[8px] font-medium text-foreground">
+              Drop files here
+            </span>
+            <span className="text-[7px] text-muted-foreground/70">
+              or click to browse
+            </span>
+          </div>
+          <div
+            className={cn(
+              SKEL_BORDER,
+              "flex w-full items-center gap-1.5 px-1.5 py-1"
+            )}
+          >
+            <span className="size-3 rounded-sm bg-foreground/20" />
+            <Bar w="50%" className="opacity-70" />
+            <span className="ml-auto text-[8px] text-muted-foreground">
+              82%
+            </span>
+          </div>
         </div>
       )
     case "data":
       return (
-        <div className="flex w-full max-w-[160px] flex-col gap-0.5">
-          {[0, 1, 2, 3].map((i) => (
-            <div key={i} className="flex items-center gap-1.5">
-              <span className={cn(SKEL_DARK, "h-1.5 w-8")} />
-              <span className={cn(SKEL_DARK, "h-1.5 flex-1 opacity-60")} />
-              <span className={cn(SKEL_DARK, "h-1.5 w-6 opacity-60")} />
+        <div
+          className={cn(SKEL_BORDER, "flex w-full max-w-[320px] flex-col p-1.5")}
+        >
+          {/* table header */}
+          <div className="flex items-center gap-3 border-b border-border px-1 pb-1">
+            {["Name", "Status", "Updated"].map((h, i) => (
+              <span
+                key={h}
+                className={cn(
+                  "text-[8px] font-medium uppercase tracking-wider text-muted-foreground",
+                  i === 0 && "flex-1"
+                )}
+              >
+                {h}
+              </span>
+            ))}
+          </div>
+          {/* rows */}
+          {[
+            { name: "MultiSelect", status: "stable" },
+            { name: "YearPicker", status: "stable" },
+            { name: "TagInput", status: "stable" },
+            { name: "ColorPicker", status: "soon" },
+          ].map((row) => (
+            <div
+              key={row.name}
+              className="flex items-center gap-3 border-b border-border/60 px-1 py-1 last:border-0"
+            >
+              <span className="flex-1 text-[8px] font-medium text-foreground">
+                {row.name}
+              </span>
+              <span
+                className={cn(
+                  "rounded-sm px-1 text-[7px] uppercase tracking-wider",
+                  row.status === "stable"
+                    ? "bg-foreground/10 text-foreground"
+                    : "border border-border text-muted-foreground"
+                )}
+              >
+                {row.status}
+              </span>
+              <Bar w="2rem" className="opacity-60" />
             </div>
           ))}
         </div>
@@ -389,13 +605,26 @@ function ComponentPreview({ category }: { category: ComponentCategory }) {
     case "display":
     default:
       return (
-        <div className={cn(SKEL_BORDER, "flex w-32 flex-col gap-1.5 p-2")}>
-          <div className="flex items-center gap-1">
-            <span className="size-3 rounded-full bg-foreground/80" />
-            <span className={cn(SKEL_DARK, "h-1.5 w-12")} />
+        <div
+          className={cn(SKEL_BORDER, "flex w-[180px] flex-col gap-1.5 p-2")}
+        >
+          <div className="flex items-center gap-1.5">
+            <span className="size-5 rounded-full bg-foreground/80" />
+            <div className="flex flex-1 flex-col gap-0.5">
+              <Bar w="55%" className="!h-1" />
+              <Bar w="40%" className="!h-1 opacity-60" />
+            </div>
+            <span className="text-[9px] font-medium text-foreground">
+              42 ↑
+            </span>
           </div>
-          <span className={cn(SKEL_DARK, "h-1 w-full opacity-60")} />
-          <span className={cn(SKEL_DARK, "h-1 w-3/4 opacity-60")} />
+          <div className="h-px bg-border" />
+          <div className="flex items-center justify-between">
+            <span className="rounded-sm bg-foreground/10 px-1.5 py-0.5 text-[8px] text-foreground">
+              feature
+            </span>
+            <span className="text-[8px] text-muted-foreground">just now</span>
+          </div>
         </div>
       )
   }
@@ -405,111 +634,272 @@ function BlockPreview({ kind }: { kind: BlockKind }) {
   switch (kind) {
     case "hero":
       return (
-        <div className="flex w-full max-w-[180px] flex-col items-center gap-1.5">
-          <span className={cn(SKEL_DARK, "h-2 w-32")} />
-          <span className={cn(SKEL_DARK, "h-1.5 w-24 opacity-60")} />
-          <div className="mt-1 flex gap-1">
-            <span className="h-3.5 w-10 rounded-sm bg-foreground" />
-            <span className={cn(SKEL_BORDER, "h-3.5 w-10")} />
+        <div className="flex w-full max-w-[360px] flex-col items-center gap-2">
+          <span className="rounded-full border border-border bg-background px-2 py-0.5 text-[8px] uppercase tracking-wider text-muted-foreground">
+            v1 · live
+          </span>
+          <span
+            className="font-semibold text-foreground"
+            style={{
+              fontFamily: "var(--font-fraunces), ui-serif, serif",
+              fontSize: 22,
+              lineHeight: 1.05,
+            }}
+          >
+            Big serif headline
+          </span>
+          <div className="flex flex-col items-center gap-0.5">
+            <Bar w="180px" className="opacity-60" />
+            <Bar w="140px" className="opacity-50" />
+          </div>
+          <div className="flex gap-1.5">
+            <span className={cn(SKEL_SOLID, "h-4 w-16")} />
+            <span className={cn(SKEL_BORDER, "h-4 w-16")} />
           </div>
         </div>
       )
     case "feature":
       return (
-        <div className="flex gap-2">
+        <div className="flex w-full max-w-[260px] items-stretch gap-1.5">
           {[0, 1, 2].map((i) => (
-            <div key={i} className="flex flex-col items-center gap-0.5">
-              <span className={cn(SKEL_BORDER, "size-5")} />
-              <span className={cn(SKEL_DARK, "h-1 w-5 opacity-60")} />
+            <div
+              key={i}
+              className={cn(
+                SKEL_BORDER,
+                "flex flex-1 flex-col items-center gap-1 p-1.5"
+              )}
+            >
+              <span className="flex size-5 items-center justify-center rounded-md border border-border bg-card">
+                <span className="size-2 rounded-sm bg-foreground/40" />
+              </span>
+              <Bar w="80%" className="!h-1" />
+              <Bar w="60%" className="!h-1 opacity-60" />
             </div>
           ))}
         </div>
       )
     case "pricing":
       return (
-        <div className="flex items-end gap-1">
-          <div className={cn(SKEL_BORDER, "h-10 w-9")} />
-          <div
-            className={cn(SKEL_BORDER, "h-12 w-9 border-foreground/40")}
-          />
-          <div className={cn(SKEL_BORDER, "h-10 w-9")} />
+        <div className="flex items-end gap-1.5">
+          {[
+            { tall: false, label: "Free" },
+            { tall: true, label: "Pro" },
+            { tall: false, label: "Team" },
+          ].map((tier, i) => (
+            <div
+              key={i}
+              className={cn(
+                SKEL_BORDER,
+                "flex flex-col items-center gap-1 px-2 py-2",
+                tier.tall && "border-foreground/40",
+                tier.tall ? "h-24 w-16" : "h-20 w-14"
+              )}
+            >
+              <span className="text-[8px] font-medium uppercase tracking-wider text-muted-foreground">
+                {tier.label}
+              </span>
+              <span
+                className={cn(
+                  "font-semibold text-foreground",
+                  tier.tall ? "text-base" : "text-sm"
+                )}
+                style={{
+                  fontFamily: "var(--font-fraunces), ui-serif, serif",
+                }}
+              >
+                ${tier.tall ? 29 : i === 0 ? 0 : 99}
+              </span>
+              <div className="flex w-full flex-col items-center gap-0.5">
+                <Bar w="80%" className="!h-0.5 opacity-60" />
+                <Bar w="60%" className="!h-0.5 opacity-60" />
+                <Bar w="70%" className="!h-0.5 opacity-60" />
+              </div>
+              {tier.tall && (
+                <span
+                  className={cn(SKEL_SOLID, "mt-auto h-2 w-full rounded-sm")}
+                />
+              )}
+            </div>
+          ))}
         </div>
       )
     case "testimonial":
       return (
-        <div className={cn(SKEL_BORDER, "flex w-full max-w-[180px] flex-col gap-1 p-2")}>
-          <span className={cn(SKEL_DARK, "h-1 w-full opacity-50")} />
-          <span className={cn(SKEL_DARK, "h-1 w-4/5 opacity-50")} />
-          <div className="mt-1 flex items-center gap-1">
-            <span className="size-3 rounded-full bg-foreground/70" />
-            <span className={cn(SKEL_DARK, "h-1 w-10")} />
+        <div
+          className={cn(SKEL_BORDER, "flex w-[220px] flex-col gap-2 p-2.5")}
+        >
+          <div className="flex gap-0.5">
+            {[0, 1, 2, 3, 4].map((i) => (
+              <span
+                key={i}
+                className="text-[10px] leading-none text-foreground"
+              >
+                ★
+              </span>
+            ))}
+          </div>
+          <div className="flex flex-col gap-0.5">
+            <Bar w="100%" className="!h-1 opacity-60" />
+            <Bar w="90%" className="!h-1 opacity-60" />
+            <Bar w="60%" className="!h-1 opacity-60" />
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="size-5 rounded-full bg-foreground/70" />
+            <div className="flex flex-col gap-0.5">
+              <Bar w="60px" className="!h-1" />
+              <Bar w="40px" className="!h-0.5 opacity-60" />
+            </div>
           </div>
         </div>
       )
     case "cta":
       return (
-        <div className="flex w-full max-w-[140px] items-center gap-1.5">
-          <div className="flex flex-1 flex-col gap-1">
-            <span className={cn(SKEL_DARK, "h-1.5 w-20")} />
-            <span className={cn(SKEL_DARK, "h-1 w-16 opacity-60")} />
+        <div
+          className={cn(SKEL_BORDER, "flex w-full max-w-[200px] flex-col items-center gap-1.5 p-2")}
+        >
+          <span
+            className="font-semibold text-foreground"
+            style={{
+              fontFamily: "var(--font-fraunces), ui-serif, serif",
+              fontSize: 14,
+              lineHeight: 1.1,
+            }}
+          >
+            Ready to ship?
+          </span>
+          <Bar w="80%" className="!h-1 opacity-60" />
+          <div className="mt-0.5 flex gap-1">
+            <span className={cn(SKEL_SOLID, "h-3.5 w-12")} />
+            <span className={cn(SKEL_BORDER, "h-3.5 w-10")} />
           </div>
-          <span className="h-4 w-12 rounded-sm bg-foreground" />
         </div>
       )
     case "faq":
       return (
-        <div className="flex w-full max-w-[180px] flex-col divide-y divide-border rounded-sm border border-border">
-          {[0, 1, 2].map((i) => (
-            <div key={i} className="flex items-center justify-between px-1.5 py-1">
-              <span className={cn(SKEL_DARK, "h-1.5 w-16 opacity-70")} />
-              <span className={cn(SKEL_DARK, "size-1.5 rounded-full")} />
+        <div className="flex w-full max-w-[260px] flex-col divide-y divide-border rounded-md border border-border bg-background">
+          {[
+            { q: "What is msh ui?", open: true },
+            { q: "How do I install?", open: false },
+            { q: "Is it free?", open: false },
+          ].map((item, i) => (
+            <div key={i} className="px-2 py-1.5">
+              <div className="flex items-center justify-between">
+                <span className="text-[9px] font-medium text-foreground">
+                  {item.q}
+                </span>
+                <span className="text-[10px] text-muted-foreground">
+                  {item.open ? "−" : "+"}
+                </span>
+              </div>
+              {item.open && (
+                <div className="mt-1 flex flex-col gap-0.5">
+                  <Bar w="100%" className="!h-1 opacity-60" />
+                  <Bar w="70%" className="!h-1 opacity-60" />
+                </div>
+              )}
             </div>
           ))}
         </div>
       )
     case "login":
       return (
-        <div className={cn(SKEL_BORDER, "flex w-32 flex-col gap-1 p-2")}>
-          <span className={cn(SKEL_DARK, "h-2 w-full")} />
-          <span className={cn(SKEL_DARK, "h-2 w-full")} />
-          <span className="h-2 w-full rounded-sm bg-foreground" />
+        <div
+          className={cn(SKEL_BORDER, "flex w-[180px] flex-col gap-1.5 p-2.5")}
+        >
+          <span
+            className="text-center font-semibold text-foreground"
+            style={{
+              fontFamily: "var(--font-fraunces), ui-serif, serif",
+              fontSize: 12,
+            }}
+          >
+            Sign in
+          </span>
+          <div className={cn(SKEL_BORDER, "h-4 px-1.5")}>
+            <Bar w="40%" className="mt-1 !h-1 opacity-60" />
+          </div>
+          <div className={cn(SKEL_BORDER, "h-4 px-1.5")}>
+            <Bar w="60%" className="mt-1 !h-1 opacity-60" />
+          </div>
+          <span className={cn(SKEL_SOLID, "h-4 w-full")} />
+          <div className="flex items-center gap-1">
+            <span className="h-px flex-1 bg-border" />
+            <span className="text-[7px] uppercase text-muted-foreground">
+              or
+            </span>
+            <span className="h-px flex-1 bg-border" />
+          </div>
+          <div className="flex gap-1">
+            <span className={cn(SKEL_BORDER, "h-3.5 flex-1")} />
+            <span className={cn(SKEL_BORDER, "h-3.5 flex-1")} />
+          </div>
         </div>
       )
     case "header":
       return (
         <div
-          className={cn(SKEL_BORDER, "flex w-44 items-center gap-1 px-2 py-1")}
+          className={cn(
+            SKEL_BORDER,
+            "flex w-full max-w-[440px] items-center gap-2 px-3 py-2"
+          )}
         >
-          <span className="size-2 rounded-sm bg-foreground" />
-          <div className="flex flex-1 items-center justify-center gap-1.5">
-            <span className={cn(SKEL_DARK, "h-1 w-4 opacity-60")} />
-            <span className={cn(SKEL_DARK, "h-1 w-4 opacity-60")} />
-            <span className={cn(SKEL_DARK, "h-1 w-4 opacity-60")} />
+          <span
+            className="font-semibold text-foreground"
+            style={{
+              fontFamily: "var(--font-fraunces), ui-serif, serif",
+              fontSize: 12,
+              lineHeight: 1,
+            }}
+          >
+            Brand
+          </span>
+          <div className="ml-4 flex flex-1 items-center gap-3">
+            {["Home", "Docs", "Pricing", "About"].map((l) => (
+              <span key={l} className="text-[9px] text-muted-foreground">
+                {l}
+              </span>
+            ))}
           </div>
-          <span className="h-2.5 w-7 rounded-sm bg-foreground" />
+          <span className={cn(SKEL_BORDER, "h-4 w-12")} />
+          <span className={cn(SKEL_SOLID, "h-4 w-14")} />
         </div>
       )
     case "footer":
       return (
-        <div className="grid w-full max-w-[200px] grid-cols-4 gap-2">
-          {[0, 1, 2, 3].map((col) => (
-            <div key={col} className="flex flex-col gap-0.5">
-              <span className={cn(SKEL_DARK, "h-1 w-full")} />
-              <span className={cn(SKEL_DARK, "h-1 w-3/4 opacity-60")} />
-              <span className={cn(SKEL_DARK, "h-1 w-3/4 opacity-60")} />
+        <div className="flex w-full max-w-[460px] flex-col gap-2">
+          <div className="grid grid-cols-4 gap-3 border-b border-border pb-2">
+            {["Product", "Resources", "Company", "Legal"].map((col) => (
+              <div key={col} className="flex flex-col gap-1">
+                <span className="text-[8px] font-semibold uppercase tracking-wider text-foreground">
+                  {col}
+                </span>
+                <Bar w="80%" className="!h-1 opacity-60" />
+                <Bar w="60%" className="!h-1 opacity-60" />
+                <Bar w="70%" className="!h-1 opacity-60" />
+              </div>
+            ))}
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-[8px] uppercase tracking-wider text-muted-foreground">
+              © 2026
+            </span>
+            <div className="flex gap-1">
+              <span className="size-3 rounded-full bg-foreground/15" />
+              <span className="size-3 rounded-full bg-foreground/15" />
+              <span className="size-3 rounded-full bg-foreground/15" />
             </div>
-          ))}
+          </div>
         </div>
       )
     case "not-found":
       return (
-        <div className="flex items-baseline gap-1">
+        <div className="flex flex-col items-center gap-1">
           <span
-            className="font-semibold text-muted-foreground/40"
+            className="leading-none text-foreground/15"
             style={{
               fontFamily: "var(--font-fraunces), ui-serif, serif",
-              fontSize: 42,
-              lineHeight: 1,
+              fontSize: 84,
+              fontWeight: 600,
             }}
           >
             404

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,548 @@
+import Link from "next/link"
+import type { Metadata } from "next"
+import {
+  ArrowRight,
+  Boxes,
+  Check,
+  Code,
+  GitBranch,
+  Layers,
+  Palette,
+  Shield,
+  Sparkles,
+  Zap,
+} from "lucide-react"
+
+import { InlineCodeBlock } from "@/components/showcase/code-block"
+import { InstallBlock } from "@/components/showcase/install-block"
+import { SiteFooter } from "@/components/showcase/site-footer"
+import { SiteHeader } from "@/components/showcase/site-header"
+import { highlightCode } from "@/lib/highlight"
+import { SITE } from "@/lib/site"
+import {
+  BLOCK_KIND_ORDER,
+  CATEGORY_LABELS,
+  REGISTRY,
+  REGISTRY_BY_CATEGORY,
+  type ComponentCategory,
+} from "@/registry/sabk/registry-meta"
+
+const FEATURED_CATEGORIES: ComponentCategory[] = ["inputs", "pickers", "data"]
+
+const FEATURED_BLOCKS = [
+  "hero-01",
+  "feature-01",
+  "pricing-01",
+  "testimonial-01",
+  "cta-01",
+  "faq-01",
+]
+
+const COMPOSE_SNIPPET = `import {
+  MultiSelect,
+  MultiSelectContent,
+  MultiSelectTrigger,
+} from "@/components/ui/multi-select"
+
+<MultiSelect value={value} onValueChange={setValue} options={options}>
+  <MultiSelectTrigger placeholder="Pick…" />
+  <MultiSelectContent searchPlaceholder="Filter…" />
+</MultiSelect>`
+
+export const metadata: Metadata = {
+  title: `${SITE.name} — ${SITE.description}`,
+  description: SITE.longDescription,
+  openGraph: {
+    title: `${SITE.name} — ${SITE.description}`,
+    description: SITE.longDescription,
+    type: "website",
+  },
+}
+
+export default async function LandingPage() {
+  const components = REGISTRY.filter((r) => r.category !== "blocks")
+  const blocks = REGISTRY_BY_CATEGORY.blocks
+  const stableComponents = components.filter((r) => r.status === "stable")
+  const composeHtml = await highlightCode(COMPOSE_SNIPPET, "tsx")
+
+  return (
+    <div className="flex min-h-svh flex-col">
+      <SiteHeader />
+      <main className="flex-1">
+        <Hero blocksCount={blocks.length} kindsCount={BLOCK_KIND_ORDER.length} />
+        <Features />
+        <CountersStrip
+          components={components.length}
+          stableComponents={stableComponents.length}
+          blocks={blocks.length}
+          blockKinds={BLOCK_KIND_ORDER.length}
+        />
+        <ComponentsPreview />
+        <Composition html={composeHtml} code={COMPOSE_SNIPPET} />
+        <BlocksPreview />
+        <BottomCta blocksCount={blocks.length} />
+      </main>
+      <SiteFooter />
+    </div>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Hero                                                                       */
+/* -------------------------------------------------------------------------- */
+
+function Hero({
+  blocksCount,
+  kindsCount,
+}: {
+  blocksCount: number
+  kindsCount: number
+}) {
+  return (
+    <section className="relative overflow-hidden border-b border-border">
+      {/* Background grid + radial fade */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-[0.35] dark:opacity-100"
+        style={{
+          backgroundImage:
+            "linear-gradient(to right, var(--border) 1px, transparent 1px), linear-gradient(to bottom, var(--border) 1px, transparent 1px)",
+          backgroundSize: "48px 48px",
+          maskImage:
+            "radial-gradient(ellipse 70% 60% at 50% 0%, black 30%, transparent 80%)",
+          WebkitMaskImage:
+            "radial-gradient(ellipse 70% 60% at 50% 0%, black 30%, transparent 80%)",
+        }}
+      />
+      <div className="relative mx-auto flex w-full max-w-5xl flex-col items-center gap-8 px-4 pb-16 pt-16 text-center sm:gap-10 sm:px-6 sm:pb-20 sm:pt-20 md:pb-28 md:pt-24 lg:px-8">
+        <a
+          href={SITE.githubUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="group inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground transition-colors hover:border-foreground/40 hover:bg-accent hover:text-foreground"
+        >
+          <span className="size-1.5 rounded-full bg-foreground" />
+          v{SITE.version} now live
+          <span className="text-foreground">·</span>
+          star on GitHub
+          <ArrowRight className="size-3 transition-transform duration-150 group-hover:translate-x-0.5" />
+        </a>
+
+        <h1 className="text-balance text-5xl font-semibold leading-[0.95] tracking-[-0.04em] sm:text-6xl md:text-7xl lg:text-[88px]">
+          shadcn&apos;s
+          <br />
+          <span className="text-muted-foreground/80">missing pieces.</span>
+        </h1>
+
+        <p className="max-w-2xl text-balance text-base text-muted-foreground sm:text-lg">
+          A peer registry of the components every real product needs but shadcn
+          doesn&apos;t ship — multi-select, combobox, tag input, currency
+          input, file dropzone — plus {blocksCount} section blocks across{" "}
+          {kindsCount} categories.
+        </p>
+
+        <div className="flex w-full max-w-xl flex-col gap-3">
+          <InstallBlock name="multi-select" />
+          <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+            One command. Source lands in <span className="text-foreground">@/components/ui</span>.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          <Link
+            href="/components"
+            className="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            Browse components
+            <ArrowRight className="size-3.5" />
+          </Link>
+          <Link
+            href="/blocks"
+            className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-border bg-card px-4 text-sm font-medium text-foreground transition-colors hover:border-foreground/40 hover:bg-accent"
+          >
+            <Layers className="size-3.5" />
+            See blocks
+          </Link>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Features                                                                   */
+/* -------------------------------------------------------------------------- */
+
+const FEATURES = [
+  {
+    icon: Zap,
+    title: "Copy-paste, not a dependency",
+    body: "Distributed via the shadcn CLI. Source lands in your repo — no msh ui runtime, no breaking version bumps.",
+  },
+  {
+    icon: GitBranch,
+    title: "Peer of shadcn",
+    body: "Composes on top of shadcn's primitives. If you have shadcn, you have everything you need to install.",
+  },
+  {
+    icon: Shield,
+    title: "Accessible by default",
+    body: "Keyboard navigation, ARIA, focus rings, motion-reduce. Built on Radix where it matters.",
+  },
+  {
+    icon: Palette,
+    title: "Theme-first",
+    body: "Every color comes from CSS tokens. Paste any shadcn theme generator output and watch the whole registry re-skin.",
+  },
+  {
+    icon: Code,
+    title: "Composable APIs",
+    body: "Flat compound exports with data-slot attributes. Compose the way you compose shadcn's own primitives.",
+  },
+  {
+    icon: Sparkles,
+    title: "Production polish",
+    body: "1px soft borders, 0.65rem radius scale, zinc neutrals, Geist Sans + Mono. Designed to ship.",
+  },
+] as const
+
+function Features() {
+  return (
+    <section className="border-b border-border">
+      <div className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
+        <div className="mb-10 flex flex-col gap-3">
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            ◆ what you get
+          </span>
+          <h2 className="max-w-2xl text-balance text-3xl font-semibold tracking-[-0.025em] sm:text-4xl">
+            Production-grade primitives, distributed the shadcn way.
+          </h2>
+        </div>
+        <ul className="grid grid-cols-1 gap-px overflow-hidden rounded-md border border-border bg-border md:grid-cols-2 lg:grid-cols-3">
+          {FEATURES.map((feature) => (
+            <li key={feature.title} className="flex flex-col gap-3 bg-card p-6">
+              <span className="inline-flex size-9 items-center justify-center rounded-md border border-border bg-background">
+                <feature.icon className="size-4 text-foreground" />
+              </span>
+              <h3 className="text-base font-medium tracking-[-0.01em]">
+                {feature.title}
+              </h3>
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                {feature.body}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Counters                                                                   */
+/* -------------------------------------------------------------------------- */
+
+function CountersStrip({
+  components,
+  stableComponents,
+  blocks,
+  blockKinds,
+}: {
+  components: number
+  stableComponents: number
+  blocks: number
+  blockKinds: number
+}) {
+  const items: { label: string; value: string }[] = [
+    { label: "components", value: `${stableComponents} / ${components}` },
+    { label: "blocks", value: `${blocks}` },
+    { label: "block categories", value: `${blockKinds}` },
+    { label: "runtime deps", value: "0" },
+  ]
+  return (
+    <section className="border-b border-border">
+      <div className="mx-auto w-full max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
+        <dl className="grid grid-cols-2 gap-px overflow-hidden rounded-md border border-border bg-border sm:grid-cols-4">
+          {items.map((item) => (
+            <div
+              key={item.label}
+              className="flex flex-col gap-1 bg-card px-4 py-4"
+            >
+              <dt className="font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground">
+                {item.label}
+              </dt>
+              <dd className="font-mono text-xl tabular-nums tracking-[-0.01em] text-foreground">
+                {item.value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </section>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Components preview                                                         */
+/* -------------------------------------------------------------------------- */
+
+function ComponentsPreview() {
+  const totalStable = REGISTRY.filter(
+    (r) => r.category !== "blocks" && r.status === "stable"
+  ).length
+
+  return (
+    <section className="border-b border-border">
+      <div className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
+        <div className="mb-10 flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-end">
+          <div className="flex flex-col gap-3">
+            <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+              <Boxes className="-mt-0.5 mr-1 inline size-3" />
+              components
+            </span>
+            <h2 className="max-w-2xl text-balance text-3xl font-semibold tracking-[-0.025em] sm:text-4xl">
+              {totalStable} components shadcn doesn&apos;t ship.
+            </h2>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              Tap any to preview, copy the install command, or browse the
+              source.
+            </p>
+          </div>
+          <Link
+            href="/components"
+            className="group inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:text-foreground"
+          >
+            See all
+            <ArrowRight className="size-3 transition-transform duration-150 group-hover:translate-x-0.5" />
+          </Link>
+        </div>
+
+        <div className="flex flex-col gap-10">
+          {FEATURED_CATEGORIES.map((cat) => {
+            const items = REGISTRY_BY_CATEGORY[cat].slice(0, 6)
+            if (!items.length) return null
+            return (
+              <div key={cat} className="flex flex-col gap-3">
+                <div className="flex items-baseline justify-between">
+                  <h3 className="font-mono text-[11px] uppercase tracking-[0.12em] text-foreground">
+                    {CATEGORY_LABELS[cat]}
+                  </h3>
+                  <span className="font-mono text-[10px] tabular-nums text-muted-foreground">
+                    {REGISTRY_BY_CATEGORY[cat].length} total
+                  </span>
+                </div>
+                <ul className="grid grid-cols-1 gap-px overflow-hidden rounded-md border border-border bg-border sm:grid-cols-2 lg:grid-cols-3">
+                  {items.map((entry) => (
+                    <li key={entry.name}>
+                      <Link
+                        href={`/${entry.name}`}
+                        className="group flex h-full flex-col justify-between gap-3 bg-card p-4 transition-colors hover:bg-accent"
+                      >
+                        <div className="flex flex-col gap-1.5">
+                          <div className="flex items-center justify-between gap-2">
+                            <h4 className="text-sm font-medium tracking-[-0.01em]">
+                              {entry.title}
+                            </h4>
+                            {entry.status === "planned" ? (
+                              <span className="rounded-sm border border-border px-1.5 py-0 font-mono text-[9px] uppercase tracking-[0.08em] text-muted-foreground">
+                                soon
+                              </span>
+                            ) : (
+                              <Check
+                                aria-hidden
+                                className="size-3 text-muted-foreground"
+                              />
+                            )}
+                          </div>
+                          <p className="text-[11px] leading-relaxed text-muted-foreground line-clamp-2">
+                            {entry.description}
+                          </p>
+                        </div>
+                        <div className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground group-hover:text-foreground">
+                          /{entry.name} →
+                        </div>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Composition                                                                */
+/* -------------------------------------------------------------------------- */
+
+function Composition({ html, code }: { html: string; code: string }) {
+  return (
+    <section className="border-b border-border">
+      <div className="mx-auto grid w-full max-w-7xl gap-10 px-4 py-16 sm:px-6 sm:py-20 lg:grid-cols-2 lg:px-8">
+        <div className="flex flex-col gap-3">
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            ◆ composition
+          </span>
+          <h2 className="text-balance text-3xl font-semibold tracking-[-0.025em] sm:text-4xl">
+            Composed the shadcn way.
+          </h2>
+          <p className="max-w-md text-sm text-muted-foreground">
+            Every compound component ships as flat top-level exports — no
+            namespacing, no convenience wrappers. The bare name is the root
+            primitive and holds state; every rendered piece carries a{" "}
+            <code className="rounded-sm bg-muted px-1 py-0.5 font-mono text-[11px] text-foreground">
+              data-slot
+            </code>{" "}
+            attribute for downstream styling.
+          </p>
+          <ul className="mt-2 flex flex-col gap-2">
+            {[
+              "Flat compound exports, no namespacing",
+              "data-slot attribute on every rendered part",
+              "Tokens from --background, --foreground, --primary — never hard-coded",
+            ].map((bullet) => (
+              <li
+                key={bullet}
+                className="flex items-start gap-2 text-xs text-muted-foreground"
+              >
+                <Check className="mt-0.5 size-3.5 shrink-0 text-foreground" />
+                <span>{bullet}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="min-w-0">
+          <InlineCodeBlock code={code} html={html} />
+        </div>
+      </div>
+    </section>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Blocks preview                                                             */
+/* -------------------------------------------------------------------------- */
+
+function BlocksPreview() {
+  const featured = FEATURED_BLOCKS.map((name) =>
+    REGISTRY_BY_CATEGORY.blocks.find((b) => b.name === name)
+  ).filter((b): b is NonNullable<typeof b> => Boolean(b))
+
+  return (
+    <section className="border-b border-border">
+      <div className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
+        <div className="mb-10 flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-end">
+          <div className="flex flex-col gap-3">
+            <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+              <Layers className="-mt-0.5 mr-1 inline size-3" />
+              section blocks
+            </span>
+            <h2 className="max-w-2xl text-balance text-3xl font-semibold tracking-[-0.025em] sm:text-4xl">
+              Drop-in compositions for whole sections.
+            </h2>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              Heroes, features, pricing, testimonials, CTAs, FAQs, auth,
+              navigation, errors. Copy a block in one command, then shape it
+              like any other source file in your repo.
+            </p>
+          </div>
+          <Link
+            href="/blocks"
+            className="group inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:text-foreground"
+          >
+            See all blocks
+            <ArrowRight className="size-3 transition-transform duration-150 group-hover:translate-x-0.5" />
+          </Link>
+        </div>
+
+        <ul className="grid grid-cols-1 gap-px overflow-hidden rounded-md border border-border bg-border sm:grid-cols-2 lg:grid-cols-3">
+          {featured.map((entry) => (
+            <li key={entry.name}>
+              <Link
+                href={`/blocks/${entry.name}`}
+                className="group flex h-full flex-col justify-between gap-3 bg-card p-4 transition-colors hover:bg-accent"
+              >
+                <div className="flex flex-col gap-1.5">
+                  <div className="flex items-center justify-between gap-2">
+                    <h3 className="text-sm font-medium tracking-[-0.01em]">
+                      {entry.title}
+                    </h3>
+                    <span className="font-mono text-[9px] uppercase tracking-[0.08em] text-muted-foreground">
+                      {entry.blockKind}
+                    </span>
+                  </div>
+                  {entry.blockTagline && (
+                    <p className="text-[11px] leading-relaxed text-muted-foreground line-clamp-2">
+                      {entry.blockTagline}
+                    </p>
+                  )}
+                </div>
+                <div className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground group-hover:text-foreground">
+                  /blocks/{entry.name} →
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Bottom CTA                                                                 */
+/* -------------------------------------------------------------------------- */
+
+function BottomCta({ blocksCount }: { blocksCount: number }) {
+  return (
+    <section>
+      <div className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 sm:py-24 lg:px-8">
+        <div className="relative overflow-hidden rounded-lg border border-border bg-card">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 opacity-[0.4]"
+            style={{
+              backgroundImage:
+                "linear-gradient(to right, var(--border) 1px, transparent 1px), linear-gradient(to bottom, var(--border) 1px, transparent 1px)",
+              backgroundSize: "32px 32px",
+              maskImage:
+                "radial-gradient(ellipse 80% 70% at 50% 50%, black 30%, transparent 80%)",
+              WebkitMaskImage:
+                "radial-gradient(ellipse 80% 70% at 50% 50%, black 30%, transparent 80%)",
+            }}
+          />
+          <div className="relative flex flex-col items-center gap-5 px-6 py-12 text-center sm:px-12 sm:py-16">
+            <h2 className="max-w-2xl text-balance text-3xl font-semibold tracking-[-0.025em] sm:text-4xl">
+              Ready to ship the components you keep building from scratch?
+            </h2>
+            <p className="max-w-xl text-balance text-sm text-muted-foreground">
+              {blocksCount} blocks, dozens of components, zero runtime
+              dependencies. Distributed via the shadcn CLI — copy what you
+              need, leave the rest.
+            </p>
+            <div className="flex flex-wrap items-center justify-center gap-2">
+              <Link
+                href="/components"
+                className="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+              >
+                Browse components
+                <ArrowRight className="size-3.5" />
+              </Link>
+              <a
+                href={SITE.githubUrl}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-border bg-background px-4 text-sm font-medium text-foreground transition-colors hover:border-foreground/40 hover:bg-accent"
+              >
+                Star on GitHub
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,53 +1,28 @@
 import Link from "next/link"
 import type { Metadata } from "next"
-import {
-  ArrowRight,
-  Boxes,
-  Check,
-  Code,
-  GitBranch,
-  Layers,
-  Palette,
-  Shield,
-  Sparkles,
-  Zap,
-} from "lucide-react"
+import { ArrowRight, Check, Github } from "lucide-react"
 
-import { InlineCodeBlock } from "@/components/showcase/code-block"
 import { InstallBlock } from "@/components/showcase/install-block"
 import { SiteFooter } from "@/components/showcase/site-footer"
 import { SiteHeader } from "@/components/showcase/site-header"
-import { highlightCode } from "@/lib/highlight"
 import { SITE } from "@/lib/site"
 import {
+  BLOCK_KIND_LABELS,
   BLOCK_KIND_ORDER,
+  BLOCKS_BY_KIND,
   CATEGORY_LABELS,
   REGISTRY,
   REGISTRY_BY_CATEGORY,
   type ComponentCategory,
 } from "@/registry/sabk/registry-meta"
 
-const FEATURED_CATEGORIES: ComponentCategory[] = ["inputs", "pickers", "data"]
-
-const FEATURED_BLOCKS = [
-  "hero-01",
-  "feature-01",
-  "pricing-01",
-  "testimonial-01",
-  "cta-01",
-  "faq-01",
+const CATEGORY_ORDER: ComponentCategory[] = [
+  "inputs",
+  "pickers",
+  "files",
+  "data",
+  "display",
 ]
-
-const COMPOSE_SNIPPET = `import {
-  MultiSelect,
-  MultiSelectContent,
-  MultiSelectTrigger,
-} from "@/components/ui/multi-select"
-
-<MultiSelect value={value} onValueChange={setValue} options={options}>
-  <MultiSelectTrigger placeholder="Pick…" />
-  <MultiSelectContent searchPlaceholder="Filter…" />
-</MultiSelect>`
 
 export const metadata: Metadata = {
   title: `${SITE.name} — ${SITE.description}`,
@@ -59,28 +34,22 @@ export const metadata: Metadata = {
   },
 }
 
-export default async function LandingPage() {
+export default function LandingPage() {
   const components = REGISTRY.filter((r) => r.category !== "blocks")
   const blocks = REGISTRY_BY_CATEGORY.blocks
   const stableComponents = components.filter((r) => r.status === "stable")
-  const composeHtml = await highlightCode(COMPOSE_SNIPPET, "tsx")
 
   return (
     <div className="flex min-h-svh flex-col">
       <SiteHeader />
       <main className="flex-1">
-        <Hero blocksCount={blocks.length} kindsCount={BLOCK_KIND_ORDER.length} />
-        <Features />
-        <CountersStrip
-          components={components.length}
-          stableComponents={stableComponents.length}
+        <Hero
+          stable={stableComponents.length}
+          total={components.length}
           blocks={blocks.length}
-          blockKinds={BLOCK_KIND_ORDER.length}
         />
-        <ComponentsPreview />
-        <Composition html={composeHtml} code={COMPOSE_SNIPPET} />
-        <BlocksPreview />
-        <BottomCta blocksCount={blocks.length} />
+        <ComponentsGrid />
+        <BlocksList />
       </main>
       <SiteFooter />
     </div>
@@ -88,239 +57,96 @@ export default async function LandingPage() {
 }
 
 /* -------------------------------------------------------------------------- */
-/* Hero                                                                       */
+/* Hero — compact, info-first                                                 */
 /* -------------------------------------------------------------------------- */
 
 function Hero({
-  blocksCount,
-  kindsCount,
+  stable,
+  total,
+  blocks,
 }: {
-  blocksCount: number
-  kindsCount: number
+  stable: number
+  total: number
+  blocks: number
 }) {
-  return (
-    <section className="relative isolate overflow-hidden border-b border-border bg-aurora">
-      {/* Top sheen — a 1px gradient line for premium feel */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-x-0 top-0 h-px bg-sheen-top"
-      />
+  const stats: { label: string; value: string }[] = [
+    { label: "stable", value: `${stable} / ${total}` },
+    { label: "blocks", value: `${blocks}` },
+    { label: "runtime deps", value: "0" },
+    { label: "license", value: "MIT" },
+  ]
 
-      {/* Background grid + radial fade */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 opacity-[0.4] dark:opacity-[0.8]"
-        style={{
-          backgroundImage:
-            "linear-gradient(to right, var(--border) 1px, transparent 1px), linear-gradient(to bottom, var(--border) 1px, transparent 1px)",
-          backgroundSize: "56px 56px",
-          maskImage:
-            "radial-gradient(ellipse 70% 60% at 50% 0%, black 20%, transparent 75%)",
-          WebkitMaskImage:
-            "radial-gradient(ellipse 70% 60% at 50% 0%, black 20%, transparent 75%)",
-        }}
-      />
-
-      {/* Ambient orb behind hero */}
-      <div
-        aria-hidden
-        className="bg-glow-orb pointer-events-none absolute left-1/2 top-0 -z-10 size-[640px] -translate-x-1/2 -translate-y-1/3 rounded-full opacity-50 blur-3xl animate-spin-slow light:opacity-30"
-      />
-
-      <div className="relative mx-auto flex w-full max-w-5xl flex-col items-center gap-9 px-4 pb-20 pt-20 text-center sm:gap-11 sm:px-6 sm:pb-28 sm:pt-28 md:pb-36 md:pt-32 lg:px-8">
-        <a
-          href={SITE.githubUrl}
-          target="_blank"
-          rel="noreferrer noopener"
-          className="group inline-flex items-center gap-2.5 rounded-full border border-border bg-card/80 px-4 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground backdrop-blur-sm transition-colors hover:border-foreground/40 hover:bg-accent hover:text-foreground"
-        >
-          <span className="relative flex size-1.5">
-            <span
-              className="absolute inline-flex size-full animate-ping-soft rounded-full opacity-80"
-              style={{ background: "var(--primary)" }}
-            />
-            <span
-              className="relative inline-flex size-1.5 rounded-full"
-              style={{ background: "var(--primary)" }}
-            />
-          </span>
-          v{SITE.version} now live
-          <span className="text-border">·</span>
-          <span className="text-foreground">star on GitHub</span>
-          <ArrowRight className="size-3 transition-transform duration-150 group-hover:translate-x-0.5" />
-        </a>
-
-        <h1 className="text-balance text-5xl font-semibold leading-[0.95] tracking-[-0.045em] sm:text-6xl md:text-7xl lg:text-[96px]">
-          <span className="text-gradient-primary">shadcn&apos;s</span>
-          <br />
-          <span className="text-muted-foreground/70">missing pieces.</span>
-        </h1>
-
-        <p className="max-w-2xl text-balance text-base text-muted-foreground sm:text-lg md:text-xl">
-          A peer registry of the components every real product needs but shadcn
-          doesn&apos;t ship — multi-select, combobox, tag input, currency
-          input, file dropzone — plus {blocksCount} section blocks across{" "}
-          {kindsCount} categories.
-        </p>
-
-        <div className="flex flex-wrap items-center justify-center gap-3">
-          <Link
-            href="/components"
-            className="btn-glow-ring group relative inline-flex h-11 items-center justify-center gap-2 overflow-hidden rounded-md bg-primary px-6 text-sm font-medium text-primary-foreground transition-all hover:bg-primary/95"
-          >
-            <span
-              aria-hidden
-              className="pointer-events-none absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-primary-foreground/15 to-transparent transition-transform duration-700 ease-out group-hover:translate-x-full"
-            />
-            Browse components
-            <ArrowRight className="size-4 transition-transform duration-150 group-hover:translate-x-0.5" />
-          </Link>
-          <Link
-            href="/blocks"
-            className="inline-flex h-11 items-center justify-center gap-2 rounded-md border border-border bg-card/80 px-5 text-sm font-medium text-foreground backdrop-blur-sm transition-colors hover:border-foreground/40 hover:bg-accent"
-          >
-            <Layers className="size-4" />
-            See blocks
-          </Link>
-        </div>
-
-        <div className="flex w-full max-w-2xl flex-col gap-3 pt-2">
-          <InstallBlock name="multi-select" />
-          <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-            One command. Source lands in{" "}
-            <span className="text-foreground">@/components/ui</span>.
-          </p>
-        </div>
-      </div>
-
-      {/* Bottom fade for smoother transition */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-background to-transparent"
-      />
-    </section>
-  )
-}
-
-/* -------------------------------------------------------------------------- */
-/* Features                                                                   */
-/* -------------------------------------------------------------------------- */
-
-const FEATURES = [
-  {
-    icon: Zap,
-    title: "Copy-paste, not a dependency",
-    body: "Distributed via the shadcn CLI. Source lands in your repo — no msh ui runtime, no breaking version bumps.",
-  },
-  {
-    icon: GitBranch,
-    title: "Peer of shadcn",
-    body: "Composes on top of shadcn's primitives. If you have shadcn, you have everything you need to install.",
-  },
-  {
-    icon: Shield,
-    title: "Accessible by default",
-    body: "Keyboard navigation, ARIA, focus rings, motion-reduce. Built on Radix where it matters.",
-  },
-  {
-    icon: Palette,
-    title: "Theme-first",
-    body: "Every color comes from CSS tokens. Paste any shadcn theme generator output and watch the whole registry re-skin.",
-  },
-  {
-    icon: Code,
-    title: "Composable APIs",
-    body: "Flat compound exports with data-slot attributes. Compose the way you compose shadcn's own primitives.",
-  },
-  {
-    icon: Sparkles,
-    title: "Production polish",
-    body: "1px soft borders, 0.65rem radius scale, zinc neutrals, Geist Sans + Mono. Designed to ship.",
-  },
-] as const
-
-function Features() {
   return (
     <section className="relative border-b border-border">
-      <div className="mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 sm:py-24 lg:px-8">
-        <div className="mb-12 flex flex-col items-center gap-4 text-center">
-          <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-            <span
-              aria-hidden
-              className="size-1 rounded-full"
-              style={{ background: "var(--primary)" }}
-            />
-            What you get
-          </span>
-          <h2 className="max-w-2xl text-balance text-3xl font-semibold tracking-[-0.03em] sm:text-4xl md:text-5xl">
-            Production-grade primitives, <br className="hidden md:inline" />
-            <span className="text-muted-foreground/70">
-              distributed the shadcn way.
+      <div
+        aria-hidden
+        className="bg-dot-grid pointer-events-none absolute inset-0 opacity-50"
+        style={{
+          maskImage:
+            "radial-gradient(ellipse 70% 60% at 50% 0%, black 30%, transparent 80%)",
+          WebkitMaskImage:
+            "radial-gradient(ellipse 70% 60% at 50% 0%, black 30%, transparent 80%)",
+        }}
+      />
+      <div className="relative mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 pb-12 pt-12 sm:px-6 sm:pb-16 sm:pt-16 lg:px-8">
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="inline-flex items-center gap-2 rounded-sm border border-border bg-card px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+              <span
+                aria-hidden
+                className="size-1 rounded-full bg-foreground"
+              />
+              v{SITE.version}
             </span>
-          </h2>
+            <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+              peer of shadcn · not a replacement
+            </span>
+          </div>
+
+          <h1 className="text-balance text-4xl font-semibold leading-[1.05] tracking-[-0.035em] sm:text-5xl">
+            shadcn&apos;s missing pieces.
+          </h1>
+
+          <p className="max-w-2xl text-balance text-base text-muted-foreground">
+            {stable} production-grade components shadcn doesn&apos;t ship —
+            multi-select, combobox, tag input, currency input, file dropzone —
+            plus {blocks} section blocks. Distributed via the shadcn CLI:
+            source lands in your repo, zero runtime dependency.
+          </p>
         </div>
-        <ul className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-border bg-border md:grid-cols-2 lg:grid-cols-3">
-          {FEATURES.map((feature) => (
-            <li
-              key={feature.title}
-              className="card-glow group relative flex flex-col gap-3 border border-transparent bg-card p-6"
+
+        <div className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-center">
+          <InstallBlock name="multi-select" className="min-w-0" />
+          <div className="flex flex-wrap items-center gap-2">
+            <Link
+              href="/components"
+              className="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
             >
-              <span className="relative inline-flex size-10 items-center justify-center rounded-md border border-border bg-background">
-                <span
-                  aria-hidden
-                  className="pointer-events-none absolute inset-0 -z-10 rounded-md opacity-0 blur-md transition-opacity duration-300 group-hover:opacity-60 light:group-hover:opacity-40"
-                  style={{ background: "var(--glow)" }}
-                />
-                <feature.icon className="size-4 text-foreground" />
-              </span>
-              <h3 className="text-base font-medium tracking-[-0.01em]">
-                {feature.title}
-              </h3>
-              <p className="text-xs leading-relaxed text-muted-foreground">
-                {feature.body}
-              </p>
-            </li>
-          ))}
-        </ul>
-      </div>
-    </section>
-  )
-}
+              Browse components
+              <ArrowRight className="size-3.5" />
+            </Link>
+            <a
+              href={SITE.githubUrl}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-border bg-card px-3 text-sm font-medium text-foreground transition-colors hover:border-foreground/40 hover:bg-accent"
+            >
+              <Github className="size-3.5" />
+              GitHub
+            </a>
+          </div>
+        </div>
 
-/* -------------------------------------------------------------------------- */
-/* Counters                                                                   */
-/* -------------------------------------------------------------------------- */
-
-function CountersStrip({
-  components,
-  stableComponents,
-  blocks,
-  blockKinds,
-}: {
-  components: number
-  stableComponents: number
-  blocks: number
-  blockKinds: number
-}) {
-  const items: { label: string; value: string }[] = [
-    { label: "components", value: `${stableComponents} / ${components}` },
-    { label: "blocks", value: `${blocks}` },
-    { label: "block categories", value: `${blockKinds}` },
-    { label: "runtime deps", value: "0" },
-  ]
-  return (
-    <section className="border-b border-border">
-      <div className="mx-auto w-full max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
-        <dl className="grid grid-cols-2 gap-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-4">
-          {items.map((item) => (
+        <dl className="grid grid-cols-2 gap-px overflow-hidden rounded-md border border-border bg-border sm:grid-cols-4">
+          {stats.map((item) => (
             <div
               key={item.label}
-              className="card-glow group flex flex-col gap-1.5 border border-transparent bg-card px-5 py-5"
+              className="flex flex-col gap-0.5 bg-card px-3 py-2.5"
             >
               <dt className="font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground">
                 {item.label}
               </dt>
-              <dd className="font-mono text-2xl tabular-nums tracking-[-0.01em] text-foreground">
+              <dd className="font-mono text-sm tabular-nums text-foreground">
                 {item.value}
               </dd>
             </div>
@@ -332,87 +158,72 @@ function CountersStrip({
 }
 
 /* -------------------------------------------------------------------------- */
-/* Components preview                                                         */
+/* Components — every category, full list, dense                              */
 /* -------------------------------------------------------------------------- */
 
-function ComponentsPreview() {
-  const totalStable = REGISTRY.filter(
+function ComponentsGrid() {
+  const total = REGISTRY.filter((r) => r.category !== "blocks").length
+  const stable = REGISTRY.filter(
     (r) => r.category !== "blocks" && r.status === "stable"
   ).length
 
   return (
     <section className="border-b border-border">
-      <div className="mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 sm:py-24 lg:px-8">
-        <div className="mb-12 flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-end">
-          <div className="flex flex-col gap-4">
-            <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-              <Boxes className="size-3" />
-              components
-            </span>
-            <h2 className="max-w-2xl text-balance text-3xl font-semibold tracking-[-0.03em] sm:text-4xl md:text-5xl">
-              {totalStable} components{" "}
-              <span className="text-muted-foreground/70">
-                shadcn doesn&apos;t ship.
-              </span>
-            </h2>
-            <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
-              Tap any to preview, copy the install command, or browse the
-              source.
-            </p>
-          </div>
-          <Link
-            href="/components"
-            className="group inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:border-foreground/40 hover:text-foreground"
-          >
-            See all
-            <ArrowRight className="size-3 transition-transform duration-150 group-hover:translate-x-0.5" />
-          </Link>
+      <div className="mx-auto w-full max-w-5xl px-4 py-12 sm:px-6 sm:py-14 lg:px-8">
+        <div className="mb-6 flex items-baseline justify-between">
+          <h2 className="font-mono text-xs uppercase tracking-[0.12em] text-foreground">
+            Components
+          </h2>
+          <span className="font-mono text-[10px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
+            {stable} / {total} stable
+          </span>
         </div>
 
-        <div className="flex flex-col gap-10">
-          {FEATURED_CATEGORIES.map((cat) => {
-            const items = REGISTRY_BY_CATEGORY[cat].slice(0, 6)
+        <div className="flex flex-col gap-6">
+          {CATEGORY_ORDER.map((cat) => {
+            const items = REGISTRY_BY_CATEGORY[cat]
             if (!items.length) return null
             return (
-              <div key={cat} className="flex flex-col gap-3">
+              <div key={cat} className="flex flex-col gap-2">
                 <div className="flex items-baseline justify-between">
-                  <h3 className="font-mono text-[11px] uppercase tracking-[0.12em] text-foreground">
+                  <h3 className="font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
                     {CATEGORY_LABELS[cat]}
                   </h3>
                   <span className="font-mono text-[10px] tabular-nums text-muted-foreground">
-                    {REGISTRY_BY_CATEGORY[cat].length} total
+                    {items.filter((i) => i.status === "stable").length} /{" "}
+                    {items.length}
                   </span>
                 </div>
-                <ul className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-2 lg:grid-cols-3">
+                <ul className="grid grid-cols-1 gap-px overflow-hidden rounded-md border border-border bg-border sm:grid-cols-2 lg:grid-cols-3">
                   {items.map((entry) => (
                     <li key={entry.name}>
                       <Link
                         href={`/${entry.name}`}
-                        className="card-glow group flex h-full flex-col justify-between gap-3 border border-transparent bg-card p-4"
+                        className="group flex h-full flex-col justify-between gap-2 bg-card p-3 transition-colors hover:bg-accent"
                       >
-                        <div className="flex flex-col gap-1.5">
+                        <div className="flex flex-col gap-1">
                           <div className="flex items-center justify-between gap-2">
                             <h4 className="text-sm font-medium tracking-[-0.01em]">
                               {entry.title}
                             </h4>
                             {entry.status === "planned" ? (
-                              <span className="rounded-sm border border-border px-1.5 py-0 font-mono text-[9px] uppercase tracking-[0.08em] text-muted-foreground">
+                              <span className="rounded-sm border border-border px-1.5 font-mono text-[9px] uppercase tracking-[0.08em] text-muted-foreground">
                                 soon
                               </span>
                             ) : (
                               <Check
                                 aria-hidden
-                                className="size-3 text-muted-foreground transition-colors group-hover:text-foreground"
+                                className="size-3 text-muted-foreground"
                               />
                             )}
                           </div>
-                          <p className="text-[11px] leading-relaxed text-muted-foreground line-clamp-2">
+                          <p className="text-[11px] leading-snug text-muted-foreground line-clamp-2">
                             {entry.description}
                           </p>
                         </div>
-                        <div className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground transition-colors group-hover:text-foreground">
+                        <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground group-hover:text-foreground">
                           /{entry.name} →
-                        </div>
+                        </span>
                       </Link>
                     </li>
                   ))}
@@ -427,219 +238,62 @@ function ComponentsPreview() {
 }
 
 /* -------------------------------------------------------------------------- */
-/* Composition                                                                */
+/* Blocks — kind-by-kind, dense                                               */
 /* -------------------------------------------------------------------------- */
 
-function Composition({ html, code }: { html: string; code: string }) {
-  return (
-    <section className="relative border-b border-border">
-      <div className="mx-auto grid w-full max-w-7xl items-center gap-10 px-4 py-20 sm:px-6 sm:py-24 lg:grid-cols-2 lg:px-8">
-        <div className="flex flex-col gap-4">
-          <span className="inline-flex w-fit items-center gap-2 rounded-full border border-border bg-card px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-            <Code className="size-3" />
-            composition
-          </span>
-          <h2 className="text-balance text-3xl font-semibold tracking-[-0.03em] sm:text-4xl md:text-5xl">
-            Composed{" "}
-            <span className="text-muted-foreground/70">the shadcn way.</span>
-          </h2>
-          <p className="max-w-md text-sm text-muted-foreground sm:text-base">
-            Every compound component ships as flat top-level exports — no
-            namespacing, no convenience wrappers. The bare name is the root
-            primitive and holds state; every rendered piece carries a{" "}
-            <code className="rounded-sm bg-muted px-1 py-0.5 font-mono text-[11px] text-foreground">
-              data-slot
-            </code>{" "}
-            attribute for downstream styling.
-          </p>
-          <ul className="mt-2 flex flex-col gap-2.5">
-            {[
-              "Flat compound exports, no namespacing",
-              "data-slot attribute on every rendered part",
-              "Tokens from --background, --foreground, --primary — never hard-coded",
-            ].map((bullet) => (
-              <li
-                key={bullet}
-                className="flex items-start gap-2.5 text-xs text-muted-foreground sm:text-sm"
-              >
-                <span
-                  aria-hidden
-                  className="mt-1 inline-flex size-4 shrink-0 items-center justify-center rounded-full border border-border bg-card"
-                >
-                  <Check className="size-2.5 text-foreground" />
-                </span>
-                <span>{bullet}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-        <div className="relative min-w-0">
-          {/* Glow behind code block — uses --glow so light mode reads as a
-              soft cream wash rather than a dark splotch. */}
-          <div
-            aria-hidden
-            className="pointer-events-none absolute -inset-4 -z-10 rounded-2xl opacity-50 blur-2xl light:opacity-40"
-            style={{
-              background:
-                "radial-gradient(ellipse 60% 80% at 50% 50%, color-mix(in oklch, var(--glow) 22%, transparent), transparent 70%)",
-            }}
-          />
-          <InlineCodeBlock code={code} html={html} />
-        </div>
-      </div>
-    </section>
-  )
-}
-
-/* -------------------------------------------------------------------------- */
-/* Blocks preview                                                             */
-/* -------------------------------------------------------------------------- */
-
-function BlocksPreview() {
-  const featured = FEATURED_BLOCKS.map((name) =>
-    REGISTRY_BY_CATEGORY.blocks.find((b) => b.name === name)
-  ).filter((b): b is NonNullable<typeof b> => Boolean(b))
+function BlocksList() {
+  const blocksCount = REGISTRY_BY_CATEGORY.blocks.length
 
   return (
     <section className="border-b border-border">
-      <div className="mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 sm:py-24 lg:px-8">
-        <div className="mb-12 flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-end">
-          <div className="flex flex-col gap-4">
-            <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-              <Layers className="size-3" />
-              section blocks
-            </span>
-            <h2 className="max-w-2xl text-balance text-3xl font-semibold tracking-[-0.03em] sm:text-4xl md:text-5xl">
-              Drop-in compositions{" "}
-              <span className="text-muted-foreground/70">
-                for whole sections.
-              </span>
-            </h2>
-            <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
-              Heroes, features, pricing, testimonials, CTAs, FAQs, auth,
-              navigation, errors. Copy a block in one command, then shape it
-              like any other source file in your repo.
-            </p>
-          </div>
+      <div className="mx-auto w-full max-w-5xl px-4 py-12 sm:px-6 sm:py-14 lg:px-8">
+        <div className="mb-6 flex items-baseline justify-between">
+          <h2 className="font-mono text-xs uppercase tracking-[0.12em] text-foreground">
+            Section blocks
+          </h2>
           <Link
             href="/blocks"
-            className="group inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:border-foreground/40 hover:text-foreground"
+            className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground transition-colors hover:text-foreground"
           >
-            See all blocks
-            <ArrowRight className="size-3 transition-transform duration-150 group-hover:translate-x-0.5" />
+            {blocksCount} blocks · view all
+            <ArrowRight className="size-3" />
           </Link>
         </div>
 
-        <ul className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-2 lg:grid-cols-3">
-          {featured.map((entry) => (
-            <li key={entry.name}>
-              <Link
-                href={`/blocks/${entry.name}`}
-                className="card-glow group flex h-full flex-col justify-between gap-3 border border-transparent bg-card p-5"
+        <div className="flex flex-col gap-px overflow-hidden rounded-md border border-border bg-border">
+          {BLOCK_KIND_ORDER.map((kind) => {
+            const items = BLOCKS_BY_KIND[kind]
+            if (!items.length) return null
+            return (
+              <div
+                key={kind}
+                className="flex flex-col gap-2 bg-card px-3 py-2.5 sm:flex-row sm:items-center sm:justify-between"
               >
-                <div className="flex flex-col gap-1.5">
-                  <div className="flex items-center justify-between gap-2">
-                    <h3 className="text-sm font-medium tracking-[-0.01em]">
-                      {entry.title}
-                    </h3>
-                    <span className="rounded-sm border border-border px-1.5 py-0 font-mono text-[9px] uppercase tracking-[0.08em] text-muted-foreground">
-                      {entry.blockKind}
-                    </span>
-                  </div>
-                  {entry.blockTagline && (
-                    <p className="text-[11px] leading-relaxed text-muted-foreground line-clamp-2">
-                      {entry.blockTagline}
-                    </p>
-                  )}
+                <div className="flex items-baseline gap-3">
+                  <h3 className="font-mono text-[11px] uppercase tracking-[0.12em] text-foreground">
+                    {BLOCK_KIND_LABELS[kind]}
+                  </h3>
+                  <span className="font-mono text-[10px] tabular-nums text-muted-foreground">
+                    {items.length}
+                  </span>
                 </div>
-                <div className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground transition-colors group-hover:text-foreground">
-                  /blocks/{entry.name} →
-                </div>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </div>
-    </section>
-  )
-}
-
-/* -------------------------------------------------------------------------- */
-/* Bottom CTA                                                                 */
-/* -------------------------------------------------------------------------- */
-
-function BottomCta({ blocksCount }: { blocksCount: number }) {
-  return (
-    <section>
-      <div className="mx-auto w-full max-w-7xl px-4 py-20 sm:px-6 sm:py-28 lg:px-8">
-        <div className="relative overflow-hidden rounded-2xl border border-border bg-card bg-aurora">
-          {/* Top sheen */}
-          <div
-            aria-hidden
-            className="pointer-events-none absolute inset-x-0 top-0 h-px bg-sheen-top"
-          />
-
-          {/* Grid bg */}
-          <div
-            aria-hidden
-            className="pointer-events-none absolute inset-0 opacity-[0.5]"
-            style={{
-              backgroundImage:
-                "linear-gradient(to right, var(--border) 1px, transparent 1px), linear-gradient(to bottom, var(--border) 1px, transparent 1px)",
-              backgroundSize: "32px 32px",
-              maskImage:
-                "radial-gradient(ellipse 80% 70% at 50% 50%, black 20%, transparent 75%)",
-              WebkitMaskImage:
-                "radial-gradient(ellipse 80% 70% at 50% 50%, black 20%, transparent 75%)",
-            }}
-          />
-
-          {/* Spinning orb — theme-aware via .bg-glow-orb (cream wash in
-              light, warm amber in dark). */}
-          <div
-            aria-hidden
-            className="bg-glow-orb pointer-events-none absolute left-1/2 top-1/2 -z-0 size-[500px] -translate-x-1/2 -translate-y-1/2 rounded-full opacity-40 blur-3xl animate-spin-slow light:opacity-25"
-          />
-
-          <div className="relative flex flex-col items-center gap-6 px-6 py-16 text-center sm:px-12 sm:py-24">
-            <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card/80 px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground backdrop-blur-sm">
-              <Sparkles className="size-3" />
-              ready when you are
-            </span>
-            <h2 className="max-w-3xl text-balance text-4xl font-semibold tracking-[-0.035em] sm:text-5xl md:text-6xl">
-              <span className="text-gradient-primary">Stop rebuilding</span>{" "}
-              <br className="hidden sm:inline" />
-              <span className="text-muted-foreground/70">
-                the same components.
-              </span>
-            </h2>
-            <p className="max-w-xl text-balance text-sm text-muted-foreground sm:text-base">
-              {blocksCount} blocks, dozens of components, zero runtime
-              dependencies. Distributed via the shadcn CLI — copy what you
-              need, leave the rest.
-            </p>
-            <div className="flex flex-wrap items-center justify-center gap-3 pt-2">
-              <Link
-                href="/components"
-                className="btn-glow-ring group relative inline-flex h-11 items-center justify-center gap-2 overflow-hidden rounded-md bg-primary px-6 text-sm font-medium text-primary-foreground transition-all hover:bg-primary/95"
-              >
-                <span
-                  aria-hidden
-                  className="pointer-events-none absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-primary-foreground/15 to-transparent transition-transform duration-700 ease-out group-hover:translate-x-full"
-                />
-                Browse components
-                <ArrowRight className="size-4 transition-transform duration-150 group-hover:translate-x-0.5" />
-              </Link>
-              <a
-                href={SITE.githubUrl}
-                target="_blank"
-                rel="noreferrer noopener"
-                className="inline-flex h-11 items-center justify-center gap-2 rounded-md border border-border bg-background/80 px-5 text-sm font-medium text-foreground backdrop-blur-sm transition-colors hover:border-foreground/40 hover:bg-accent"
-              >
-                Star on GitHub
-              </a>
-            </div>
-          </div>
+                <ul className="flex flex-wrap gap-1.5">
+                  {items.map((entry) => (
+                    <li key={entry.name}>
+                      <Link
+                        href={`/blocks/${entry.name}`}
+                        className="group inline-flex items-center gap-1.5 rounded-sm border border-border bg-background px-2 py-0.5 font-mono text-[11px] tracking-tight transition-colors hover:border-foreground/40 hover:bg-accent"
+                        title={entry.title}
+                      >
+                        <span className="text-foreground">{entry.name}</span>
+                        <ArrowRight className="size-3 text-muted-foreground transition-transform duration-150 group-hover:translate-x-0.5 group-hover:text-foreground" />
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )
+          })}
         </div>
       </div>
     </section>

--- a/components/showcase/github-stars.tsx
+++ b/components/showcase/github-stars.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+import * as React from "react"
+import { Github, Star } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { SITE } from "@/lib/site"
+
+const STAR_CACHE_KEY = "msh-ui:gh-stars:v1"
+const STAR_CACHE_TTL = 1000 * 60 * 30 // 30 minutes
+
+function readCachedStars(): { value: number; cachedAt: number } | null {
+  if (typeof window === "undefined") return null
+  try {
+    const raw = window.localStorage.getItem(STAR_CACHE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as { value: number; cachedAt: number }
+    if (
+      typeof parsed.value !== "number" ||
+      typeof parsed.cachedAt !== "number"
+    ) {
+      return null
+    }
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function writeCachedStars(value: number) {
+  if (typeof window === "undefined") return
+  try {
+    window.localStorage.setItem(
+      STAR_CACHE_KEY,
+      JSON.stringify({ value, cachedAt: Date.now() })
+    )
+  } catch {
+    // ignore
+  }
+}
+
+function formatCount(n: number): string {
+  if (n < 1000) return `${n}`
+  if (n < 10_000) return `${(n / 1000).toFixed(1).replace(/\.0$/, "")}k`
+  return `${Math.round(n / 1000)}k`
+}
+
+export function GitHubStars({
+  className,
+  compact = false,
+}: {
+  className?: string
+  compact?: boolean
+}) {
+  const [stars, setStars] = React.useState<number | null>(() => {
+    const cached = readCachedStars()
+    return cached?.value ?? null
+  })
+
+  React.useEffect(() => {
+    let cancelled = false
+    const cached = readCachedStars()
+    const fresh = cached && Date.now() - cached.cachedAt < STAR_CACHE_TTL
+    if (fresh) return
+
+    ;(async () => {
+      try {
+        const res = await fetch(
+          `https://api.github.com/repos/${SITE.githubOwner}/${SITE.githubRepo}`,
+          {
+            headers: { Accept: "application/vnd.github+json" },
+          }
+        )
+        if (!res.ok) return
+        const data = (await res.json()) as { stargazers_count?: number }
+        if (cancelled || typeof data.stargazers_count !== "number") return
+        setStars(data.stargazers_count)
+        writeCachedStars(data.stargazers_count)
+      } catch {
+        // network/offline — keep cached or null
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <a
+      href={SITE.githubUrl}
+      target="_blank"
+      rel="noreferrer noopener"
+      aria-label={
+        stars !== null
+          ? `GitHub repository — ${stars} stars`
+          : "GitHub repository"
+      }
+      className={cn(
+        "group inline-flex items-center gap-1.5 rounded-md border border-border bg-card text-foreground transition-colors hover:border-foreground/40 hover:bg-accent",
+        compact ? "h-8 px-2" : "h-8 pl-2 pr-0",
+        className
+      )}
+    >
+      <Github className="size-3.5" aria-hidden />
+      {!compact && (
+        <span className="font-mono text-[11px] uppercase tracking-[0.08em]">
+          star
+        </span>
+      )}
+      {!compact && (
+        <span
+          className="flex h-full items-center gap-1 border-l border-border bg-background px-2 font-mono text-[11px] tabular-nums transition-colors group-hover:bg-accent"
+          aria-hidden
+        >
+          <Star className="size-3 fill-foreground/70 text-foreground/70 transition-colors group-hover:fill-foreground group-hover:text-foreground" />
+          {stars !== null ? formatCount(stars) : "—"}
+        </span>
+      )}
+      {compact && stars !== null && (
+        <span className="font-mono text-[11px] tabular-nums">
+          {formatCount(stars)}
+        </span>
+      )}
+    </a>
+  )
+}

--- a/components/showcase/github-stars.tsx
+++ b/components/showcase/github-stars.tsx
@@ -6,7 +6,7 @@ import { Github, Star } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { SITE } from "@/lib/site"
 
-const STAR_CACHE_KEY = "msh-ui:gh-stars:v1"
+const STAR_CACHE_KEY = "forgecn:gh-stars:v1"
 const STAR_CACHE_TTL = 1000 * 60 * 30 // 30 minutes
 
 function readCachedStars(): { value: number; cachedAt: number } | null {

--- a/components/showcase/install-block.tsx
+++ b/components/showcase/install-block.tsx
@@ -9,6 +9,7 @@ import {
   getShadcnAddCommand,
   usePackageManager,
 } from "@/lib/package-managers"
+import { SITE } from "@/lib/site"
 
 export function InstallBlock({
   name,
@@ -24,7 +25,7 @@ export function InstallBlock({
     setOrigin(process.env.NEXT_PUBLIC_BASE_URL ?? window.location.origin)
   }, [])
 
-  const url = `${origin || "https://sabk.dev"}/r/${name}.json`
+  const url = `${origin || SITE.registry.origin}/r/${name}.json`
   const command = getShadcnAddCommand(pm, url)
 
   return (

--- a/components/showcase/logo.tsx
+++ b/components/showcase/logo.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export const LOGO_URL = "https://mohammadshehadeh.com/images/logo.svg"
+
+export function Logo({
+  className,
+  alt = "msh ui",
+}: {
+  className?: string
+  alt?: string
+}) {
+  const [errored, setErrored] = React.useState(false)
+
+  if (errored) {
+    return (
+      <span
+        aria-hidden
+        className={cn(
+          "inline-flex shrink-0 items-center justify-center rounded-sm bg-foreground font-mono text-[10px] font-semibold text-background",
+          className
+        )}
+      >
+        msh
+      </span>
+    )
+  }
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={LOGO_URL}
+      alt={alt}
+      width={28}
+      height={28}
+      onError={() => setErrored(true)}
+      className={cn("shrink-0 select-none dark:invert", className)}
+      draggable={false}
+    />
+  )
+}
+
+export function LogoMark({ className }: { className?: string }) {
+  return <Logo className={cn("size-6", className)} />
+}
+
+export function LogoLockup({
+  className,
+  showTagline = true,
+}: {
+  className?: string
+  showTagline?: boolean
+}) {
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      <LogoMark />
+      <div className="flex min-w-0 flex-col leading-tight">
+        <span className="text-sm font-semibold tracking-[-0.02em]">
+          msh <span className="text-muted-foreground">ui</span>
+        </span>
+        {showTagline && (
+          <span className="font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground">
+            shadcn&apos;s missing pieces
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/showcase/logo.tsx
+++ b/components/showcase/logo.tsx
@@ -1,61 +1,33 @@
-"use client"
-
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
 /**
- * MSH wordmark, inlined as SVG. The base "MSH" text renders in
- * currentColor (so it follows the active theme) while the "M" letter is
- * clipped to reveal the Palestinian flag (black/white/green/red triangle)
- * underneath.
+ * forgecn brand mark — a bold geometric "F" rendered as three rounded
+ * rectangles in currentColor, so it follows the active text color in
+ * both themes.
  */
 function LogoSvg({ className }: { className?: string }) {
-  const rawId = React.useId()
-  const id = rawId.replace(/:/g, "")
-  const mId = `msh-m-${id}`
-  const allId = `msh-all-${id}`
-  const clipId = `msh-m-clip-${id}`
-
-  const textStyle: React.CSSProperties = {
-    fontFamily: "var(--font-fraunces), ui-serif, Georgia, serif",
-    fontSize: "280px",
-    fontWeight: 600,
-  }
-
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 820 280"
-      aria-hidden="true"
+      viewBox="0 0 24 24"
+      role="img"
+      aria-hidden
       className={className}
+      fill="currentColor"
     >
-      <title>MSH</title>
-      <defs>
-        <text id={mId} style={textStyle} x="10" y="245">
-          M
-        </text>
-        <text id={allId} style={textStyle} x="10" y="245">
-          MSH
-        </text>
-        <clipPath id={clipId}>
-          <use href={`#${mId}`} />
-        </clipPath>
-      </defs>
-      <use href={`#${allId}`} fill="currentColor" />
-      <g clipPath={`url(#${clipId})`}>
-        <rect x="-10" y="-20" width="380" height="120" fill="#000000" />
-        <rect x="-10" y="100" width="380" height="72" fill="#FFFFFF" />
-        <rect x="-10" y="172" width="380" height="128" fill="#007A3D" />
-        <polygon points="-10,-20 -10,300 170,138" fill="#CE1126" />
-      </g>
+      <title>forgecn</title>
+      <rect x="4" y="4" width="16" height="3.5" rx="1" />
+      <rect x="4" y="4" width="3.5" height="16" rx="1" />
+      <rect x="4" y="10.25" width="10" height="3.5" rx="1" />
     </svg>
   )
 }
 
 export function Logo({
   className,
-  title = "msh ui",
+  title = "forgecn",
 }: {
   className?: string
   title?: string
@@ -66,36 +38,39 @@ export function Logo({
       aria-label={title}
       className={cn("inline-flex shrink-0 text-foreground", className)}
     >
-      <LogoSvg className="h-full w-auto" />
+      <LogoSvg className="size-full" />
     </span>
   )
 }
 
-/** Wordmark logo sized by height — width is intrinsic to the 820×280 viewBox. */
 export function LogoMark({ className }: { className?: string }) {
-  return <Logo className={cn("h-8", className)} />
+  return <Logo className={cn("size-6", className)} />
 }
 
 export function BrandLockup({
   className,
   logoClassName,
   textClassName,
+  showText = true,
 }: {
   className?: string
   logoClassName?: string
   textClassName?: string
+  showText?: boolean
 }) {
   return (
     <div className={cn("flex items-center gap-2", className)}>
       <LogoMark className={logoClassName} />
-      <span
-        className={cn(
-          "text-xl font-semibold tracking-[-0.02em] text-muted-foreground",
-          textClassName
-        )}
-      >
-        ui
-      </span>
+      {showText && (
+        <span
+          className={cn(
+            "text-base font-semibold tracking-[-0.02em] text-foreground",
+            textClassName
+          )}
+        >
+          forgecn
+        </span>
+      )}
     </div>
   )
 }

--- a/components/showcase/logo.tsx
+++ b/components/showcase/logo.tsx
@@ -1,45 +1,54 @@
-"use client"
-
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export const LOGO_URL = "https://mohammadshehadeh.com/images/logo.svg"
+/**
+ * msh ui brand mark, inlined as SVG so it inherits the current text color
+ * via `currentColor`. To swap in the canonical mark from
+ * mohammadshehadeh.com/images/logo.svg, replace the contents of <LogoSvg>
+ * with the path data from that file — keep `fill="currentColor"` on every
+ * path so it continues to follow the active text color in both themes.
+ */
+function LogoSvg({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 40 40"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-hidden
+      className={className}
+    >
+      {/* Bold geometric "M" letterform — stroke-based so it scales cleanly */}
+      <path
+        d="M6 32 L6 8 L20 24 L34 8 L34 32"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
 
 export function Logo({
   className,
-  alt = "msh ui",
+  title = "msh ui",
 }: {
   className?: string
-  alt?: string
+  title?: string
 }) {
-  const [errored, setErrored] = React.useState(false)
-
-  if (errored) {
-    return (
-      <span
-        aria-hidden
-        className={cn(
-          "inline-flex shrink-0 items-center justify-center rounded-sm bg-foreground font-mono text-xs font-semibold text-background",
-          className
-        )}
-      >
-        msh
-      </span>
-    )
-  }
-
   return (
-    // eslint-disable-next-line @next/next/no-img-element
-    <img
-      src={LOGO_URL}
-      alt={alt}
-      width={40}
-      height={40}
-      onError={() => setErrored(true)}
-      className={cn("shrink-0 select-none dark:invert", className)}
-      draggable={false}
-    />
+    <span
+      role="img"
+      aria-label={title}
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center text-foreground",
+        className
+      )}
+    >
+      <LogoSvg className="size-full" />
+    </span>
   )
 }
 

--- a/components/showcase/logo.tsx
+++ b/components/showcase/logo.tsx
@@ -20,7 +20,7 @@ export function Logo({
       <span
         aria-hidden
         className={cn(
-          "inline-flex shrink-0 items-center justify-center rounded-sm bg-foreground font-mono text-[10px] font-semibold text-background",
+          "inline-flex shrink-0 items-center justify-center rounded-sm bg-foreground font-mono text-xs font-semibold text-background",
           className
         )}
       >
@@ -34,8 +34,8 @@ export function Logo({
     <img
       src={LOGO_URL}
       alt={alt}
-      width={28}
-      height={28}
+      width={40}
+      height={40}
       onError={() => setErrored(true)}
       className={cn("shrink-0 select-none dark:invert", className)}
       draggable={false}
@@ -44,29 +44,29 @@ export function Logo({
 }
 
 export function LogoMark({ className }: { className?: string }) {
-  return <Logo className={cn("size-6", className)} />
+  return <Logo className={cn("size-10", className)} />
 }
 
-export function LogoLockup({
+export function BrandLockup({
   className,
-  showTagline = true,
+  logoClassName,
+  textClassName,
 }: {
   className?: string
-  showTagline?: boolean
+  logoClassName?: string
+  textClassName?: string
 }) {
   return (
     <div className={cn("flex items-center gap-2", className)}>
-      <LogoMark />
-      <div className="flex min-w-0 flex-col leading-tight">
-        <span className="text-sm font-semibold tracking-[-0.02em]">
-          msh <span className="text-muted-foreground">ui</span>
-        </span>
-        {showTagline && (
-          <span className="font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground">
-            shadcn&apos;s missing pieces
-          </span>
+      <LogoMark className={logoClassName} />
+      <span
+        className={cn(
+          "text-xl font-semibold tracking-[-0.02em] text-muted-foreground",
+          textClassName
         )}
-      </div>
+      >
+        ui
+      </span>
     </div>
   )
 }

--- a/components/showcase/logo.tsx
+++ b/components/showcase/logo.tsx
@@ -1,32 +1,54 @@
+"use client"
+
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
 /**
- * msh ui brand mark, inlined as SVG so it inherits the current text color
- * via `currentColor`. To swap in the canonical mark from
- * mohammadshehadeh.com/images/logo.svg, replace the contents of <LogoSvg>
- * with the path data from that file — keep `fill="currentColor"` on every
- * path so it continues to follow the active text color in both themes.
+ * MSH wordmark, inlined as SVG. The base "MSH" text renders in
+ * currentColor (so it follows the active theme) while the "M" letter is
+ * clipped to reveal the Palestinian flag (black/white/green/red triangle)
+ * underneath.
  */
 function LogoSvg({ className }: { className?: string }) {
+  const rawId = React.useId()
+  const id = rawId.replace(/:/g, "")
+  const mId = `msh-m-${id}`
+  const allId = `msh-all-${id}`
+  const clipId = `msh-m-clip-${id}`
+
+  const textStyle: React.CSSProperties = {
+    fontFamily: "var(--font-fraunces), ui-serif, Georgia, serif",
+    fontSize: "280px",
+    fontWeight: 600,
+  }
+
   return (
     <svg
-      viewBox="0 0 40 40"
       xmlns="http://www.w3.org/2000/svg"
-      role="img"
-      aria-hidden
+      viewBox="0 0 820 280"
+      aria-hidden="true"
       className={className}
     >
-      {/* Bold geometric "M" letterform — stroke-based so it scales cleanly */}
-      <path
-        d="M6 32 L6 8 L20 24 L34 8 L34 32"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
+      <title>MSH</title>
+      <defs>
+        <text id={mId} style={textStyle} x="10" y="245">
+          M
+        </text>
+        <text id={allId} style={textStyle} x="10" y="245">
+          MSH
+        </text>
+        <clipPath id={clipId}>
+          <use href={`#${mId}`} />
+        </clipPath>
+      </defs>
+      <use href={`#${allId}`} fill="currentColor" />
+      <g clipPath={`url(#${clipId})`}>
+        <rect x="-10" y="-20" width="380" height="120" fill="#000000" />
+        <rect x="-10" y="100" width="380" height="72" fill="#FFFFFF" />
+        <rect x="-10" y="172" width="380" height="128" fill="#007A3D" />
+        <polygon points="-10,-20 -10,300 170,138" fill="#CE1126" />
+      </g>
     </svg>
   )
 }
@@ -42,18 +64,16 @@ export function Logo({
     <span
       role="img"
       aria-label={title}
-      className={cn(
-        "inline-flex shrink-0 items-center justify-center text-foreground",
-        className
-      )}
+      className={cn("inline-flex shrink-0 text-foreground", className)}
     >
-      <LogoSvg className="size-full" />
+      <LogoSvg className="h-full w-auto" />
     </span>
   )
 }
 
+/** Wordmark logo sized by height — width is intrinsic to the 820×280 viewBox. */
 export function LogoMark({ className }: { className?: string }) {
-  return <Logo className={cn("size-10", className)} />
+  return <Logo className={cn("h-8", className)} />
 }
 
 export function BrandLockup({

--- a/components/showcase/sidebar.tsx
+++ b/components/showcase/sidebar.tsx
@@ -52,10 +52,10 @@ export function ShowcaseSidebar() {
           className="group/brand flex items-center gap-2 rounded-sm px-2 py-1.5 transition-colors hover:bg-sidebar-accent"
           aria-label={`${SITE.name} — home`}
         >
-          <LogoMark className="h-6 shrink-0 group-data-[collapsible=icon]:h-3" />
+          <LogoMark className="size-6 shrink-0" />
           <div className="flex min-w-0 flex-col leading-tight group-data-[collapsible=icon]:hidden">
-            <span className="text-base font-semibold tracking-[-0.02em] text-muted-foreground">
-              ui
+            <span className="text-base font-semibold tracking-[-0.02em] text-foreground">
+              forgecn
             </span>
             <span className="font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground">
               shadcn&apos;s missing pieces

--- a/components/showcase/sidebar.tsx
+++ b/components/showcase/sidebar.tsx
@@ -49,12 +49,12 @@ export function ShowcaseSidebar() {
       <SidebarHeader>
         <Link
           href="/"
-          className="group/brand flex items-center gap-2.5 rounded-sm px-2 py-2 transition-colors hover:bg-sidebar-accent"
+          className="group/brand flex items-center gap-2 rounded-sm px-2 py-1.5 transition-colors hover:bg-sidebar-accent"
           aria-label={`${SITE.name} — home`}
         >
-          <LogoMark className="size-9 shrink-0" />
+          <LogoMark className="h-6 shrink-0 group-data-[collapsible=icon]:h-3" />
           <div className="flex min-w-0 flex-col leading-tight group-data-[collapsible=icon]:hidden">
-            <span className="text-lg font-semibold tracking-[-0.02em] text-muted-foreground">
+            <span className="text-base font-semibold tracking-[-0.02em] text-muted-foreground">
               ui
             </span>
             <span className="font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground">

--- a/components/showcase/sidebar.tsx
+++ b/components/showcase/sidebar.tsx
@@ -49,13 +49,13 @@ export function ShowcaseSidebar() {
       <SidebarHeader>
         <Link
           href="/"
-          className="group/brand flex items-center gap-2 rounded-sm px-2 py-1.5 transition-colors hover:bg-sidebar-accent"
+          className="group/brand flex items-center gap-2.5 rounded-sm px-2 py-2 transition-colors hover:bg-sidebar-accent"
           aria-label={`${SITE.name} — home`}
         >
-          <LogoMark className="size-6 shrink-0" />
+          <LogoMark className="size-9 shrink-0" />
           <div className="flex min-w-0 flex-col leading-tight group-data-[collapsible=icon]:hidden">
-            <span className="text-sm font-semibold tracking-[-0.02em]">
-              msh <span className="text-muted-foreground">ui</span>
+            <span className="text-lg font-semibold tracking-[-0.02em] text-muted-foreground">
+              ui
             </span>
             <span className="font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground">
               shadcn&apos;s missing pieces

--- a/components/showcase/sidebar.tsx
+++ b/components/showcase/sidebar.tsx
@@ -3,9 +3,11 @@
 import * as React from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { LayoutTemplate, Sparkles } from "lucide-react"
+import { Boxes, LayoutTemplate, Sparkles } from "lucide-react"
 
+import { LogoMark } from "@/components/showcase/logo"
 import { ThemeSheetTrigger } from "@/components/showcase/theme-sheet"
+import { SITE } from "@/lib/site"
 import {
   CATEGORY_LABELS,
   REGISTRY_BY_CATEGORY,
@@ -48,13 +50,12 @@ export function ShowcaseSidebar() {
         <Link
           href="/"
           className="group/brand flex items-center gap-2 rounded-sm px-2 py-1.5 transition-colors hover:bg-sidebar-accent"
+          aria-label={`${SITE.name} — home`}
         >
-          <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-sm bg-sidebar-primary font-mono text-[11px] font-semibold text-sidebar-primary-foreground">
-            ◆
-          </span>
+          <LogoMark className="size-6 shrink-0" />
           <div className="flex min-w-0 flex-col leading-tight group-data-[collapsible=icon]:hidden">
             <span className="text-sm font-semibold tracking-[-0.02em]">
-              sabk
+              msh <span className="text-muted-foreground">ui</span>
             </span>
             <span className="font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground">
               shadcn&apos;s missing pieces
@@ -71,12 +72,12 @@ export function ShowcaseSidebar() {
               <SidebarMenuItem>
                 <SidebarMenuButton
                   asChild
-                  isActive={isActive("/theme")}
-                  tooltip="Theme playground"
+                  isActive={isActive("/components")}
+                  tooltip="All components"
                 >
-                  <Link href="/theme">
-                    <Sparkles />
-                    <span>Theme playground</span>
+                  <Link href="/components">
+                    <Boxes />
+                    <span>All components</span>
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>
@@ -92,6 +93,18 @@ export function ShowcaseSidebar() {
                   </Link>
                 </SidebarMenuButton>
                 <SidebarMenuBadge>{blockCount}</SidebarMenuBadge>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  isActive={isActive("/theme")}
+                  tooltip="Theme playground"
+                >
+                  <Link href="/theme">
+                    <Sparkles />
+                    <span>Theme playground</span>
+                  </Link>
+                </SidebarMenuButton>
               </SidebarMenuItem>
             </SidebarMenu>
           </SidebarGroupContent>
@@ -135,7 +148,7 @@ export function ShowcaseSidebar() {
       <SidebarFooter>
         <div className="flex items-center justify-between gap-2 rounded-sm border border-sidebar-border bg-sidebar-accent/30 px-2 py-1.5 group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:border-0 group-data-[collapsible=icon]:bg-transparent group-data-[collapsible=icon]:p-0">
           <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground group-data-[collapsible=icon]:hidden">
-            v0.1 · peer of shadcn
+            v{SITE.version} · peer of shadcn
           </span>
           <ThemeSheetTrigger />
         </div>

--- a/components/showcase/site-footer.tsx
+++ b/components/showcase/site-footer.tsx
@@ -1,0 +1,132 @@
+import Link from "next/link"
+import { Github } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { SITE } from "@/lib/site"
+import { LogoMark } from "@/components/showcase/logo"
+
+const FOOTER_LINKS: {
+  label: string
+  links: { href: string; label: string; external?: boolean }[]
+}[] = [
+  {
+    label: "Library",
+    links: [
+      { href: "/components", label: "Components" },
+      { href: "/blocks", label: "Blocks" },
+      { href: "/theme", label: "Theme playground" },
+    ],
+  },
+  {
+    label: "Resources",
+    links: [
+      {
+        href: "https://ui.shadcn.com",
+        label: "shadcn/ui",
+        external: true,
+      },
+      {
+        href: `${SITE.githubUrl}#readme`,
+        label: "README",
+        external: true,
+      },
+      {
+        href: `${SITE.githubUrl}/issues`,
+        label: "Issues",
+        external: true,
+      },
+    ],
+  },
+  {
+    label: "Author",
+    links: [
+      { href: SITE.authorUrl, label: "Portfolio", external: true },
+      { href: SITE.githubUrl, label: "GitHub", external: true },
+      { href: SITE.twitterUrl, label: "Twitter / X", external: true },
+    ],
+  },
+]
+
+export function SiteFooter({ className }: { className?: string }) {
+  const year = new Date().getFullYear()
+
+  return (
+    <footer
+      className={cn(
+        "mt-auto border-t border-border bg-background",
+        className
+      )}
+    >
+      <div className="mx-auto w-full max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
+        <div className="grid grid-cols-2 gap-8 sm:grid-cols-3 md:grid-cols-5">
+          <div className="col-span-2 flex flex-col gap-3">
+            <Link
+              href="/"
+              aria-label={`${SITE.name} — home`}
+              className="inline-flex items-center gap-2"
+            >
+              <LogoMark className="size-6" />
+              <span className="text-[15px] font-semibold tracking-[-0.02em]">
+                msh <span className="text-muted-foreground">ui</span>
+              </span>
+            </Link>
+            <p className="max-w-xs text-xs text-muted-foreground">
+              {SITE.longDescription}
+            </p>
+            <div className="mt-1 flex items-center gap-2">
+              <a
+                href={SITE.githubUrl}
+                target="_blank"
+                rel="noreferrer noopener"
+                aria-label="GitHub"
+                className="inline-flex size-8 items-center justify-center rounded-md border border-border bg-card text-muted-foreground transition-colors hover:border-foreground/40 hover:bg-accent hover:text-foreground"
+              >
+                <Github className="size-3.5" />
+              </a>
+            </div>
+          </div>
+
+          {FOOTER_LINKS.map((group) => (
+            <div key={group.label} className="flex flex-col gap-3">
+              <h3 className="font-mono text-[10px] uppercase tracking-[0.12em] text-foreground">
+                {group.label}
+              </h3>
+              <ul className="flex flex-col gap-2">
+                {group.links.map((link) => (
+                  <li key={link.href}>
+                    {link.external ? (
+                      <a
+                        href={link.href}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+                      >
+                        {link.label}
+                      </a>
+                    ) : (
+                      <Link
+                        href={link.href}
+                        className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+                      >
+                        {link.label}
+                      </Link>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-10 flex flex-col items-start justify-between gap-3 border-t border-border pt-6 sm:flex-row sm:items-center">
+          <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+            © {year} {SITE.author} · MIT licensed · built on shadcn
+          </p>
+          <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+            v{SITE.version} · zero runtime deps
+          </p>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/components/showcase/site-footer.tsx
+++ b/components/showcase/site-footer.tsx
@@ -65,7 +65,7 @@ export function SiteFooter({ className }: { className?: string }) {
               aria-label={`${SITE.name} — home`}
               className="inline-flex items-center"
             >
-              <BrandLockup logoClassName="h-9" textClassName="text-2xl" />
+              <BrandLockup logoClassName="size-8" textClassName="text-xl" />
             </Link>
             <p className="max-w-xs text-xs text-muted-foreground">
               {SITE.longDescription}

--- a/components/showcase/site-footer.tsx
+++ b/components/showcase/site-footer.tsx
@@ -65,7 +65,7 @@ export function SiteFooter({ className }: { className?: string }) {
               aria-label={`${SITE.name} — home`}
               className="inline-flex items-center"
             >
-              <BrandLockup logoClassName="size-12" textClassName="text-2xl" />
+              <BrandLockup logoClassName="h-9" textClassName="text-2xl" />
             </Link>
             <p className="max-w-xs text-xs text-muted-foreground">
               {SITE.longDescription}

--- a/components/showcase/site-footer.tsx
+++ b/components/showcase/site-footer.tsx
@@ -3,7 +3,7 @@ import { Github } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { SITE } from "@/lib/site"
-import { LogoMark } from "@/components/showcase/logo"
+import { BrandLockup } from "@/components/showcase/logo"
 
 const FOOTER_LINKS: {
   label: string
@@ -63,12 +63,9 @@ export function SiteFooter({ className }: { className?: string }) {
             <Link
               href="/"
               aria-label={`${SITE.name} — home`}
-              className="inline-flex items-center gap-2"
+              className="inline-flex items-center"
             >
-              <LogoMark className="size-6" />
-              <span className="text-[15px] font-semibold tracking-[-0.02em]">
-                msh <span className="text-muted-foreground">ui</span>
-              </span>
+              <BrandLockup logoClassName="size-12" textClassName="text-2xl" />
             </Link>
             <p className="max-w-xs text-xs text-muted-foreground">
               {SITE.longDescription}

--- a/components/showcase/site-header.tsx
+++ b/components/showcase/site-header.tsx
@@ -46,8 +46,8 @@ export function SiteHeader({
           className="group flex items-center gap-2 rounded-sm py-1 transition-colors"
         >
           <BrandLockup
-            logoClassName="h-7"
-            textClassName="text-lg sm:text-xl"
+            logoClassName="size-6"
+            textClassName="text-base sm:text-lg"
           />
           <span
             aria-hidden

--- a/components/showcase/site-header.tsx
+++ b/components/showcase/site-header.tsx
@@ -1,0 +1,136 @@
+"use client"
+
+import * as React from "react"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { Menu, X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { NAV_LINKS, SITE } from "@/lib/site"
+import { GitHubStars } from "@/components/showcase/github-stars"
+import { LogoMark } from "@/components/showcase/logo"
+import { ThemeToggle } from "@/components/showcase/theme-toggle"
+
+export function SiteHeader({
+  className,
+  withSidebarTrigger,
+}: {
+  className?: string
+  withSidebarTrigger?: React.ReactNode
+}) {
+  const pathname = usePathname()
+  const [mobileOpen, setMobileOpen] = React.useState(false)
+
+  const isActive = (href: string) => {
+    if (href === "/") return pathname === "/"
+    return pathname === href || pathname.startsWith(`${href}/`)
+  }
+
+  React.useEffect(() => {
+    setMobileOpen(false)
+  }, [pathname])
+
+  return (
+    <header
+      className={cn(
+        "sticky top-0 z-40 w-full border-b border-border bg-background/80 backdrop-blur-md supports-[backdrop-filter]:bg-background/60",
+        className
+      )}
+    >
+      <div className="mx-auto flex h-14 w-full max-w-7xl items-center gap-3 px-4 sm:px-6 lg:px-8">
+        {withSidebarTrigger}
+
+        <Link
+          href="/"
+          aria-label={`${SITE.name} — home`}
+          className="group flex items-center gap-2 rounded-sm py-1 pr-1 transition-colors"
+        >
+          <LogoMark className="size-6" />
+          <span className="hidden text-[15px] font-semibold tracking-[-0.02em] sm:inline">
+            msh <span className="text-muted-foreground">ui</span>
+          </span>
+          <span
+            aria-hidden
+            className="ml-1 hidden rounded-sm border border-border px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground sm:inline"
+          >
+            v{SITE.version}
+          </span>
+        </Link>
+
+        <nav className="hidden flex-1 items-center gap-1 px-2 md:flex">
+          {NAV_LINKS.map((link) => {
+            const active = isActive(link.href)
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={cn(
+                  "rounded-sm px-2.5 py-1.5 text-[13px] tracking-tight transition-colors",
+                  active
+                    ? "text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                {link.label}
+              </Link>
+            )
+          })}
+        </nav>
+
+        <div className="ml-auto flex items-center gap-1.5 md:ml-0">
+          <GitHubStars />
+          <ThemeToggle />
+          <button
+            type="button"
+            aria-label={mobileOpen ? "Close menu" : "Open menu"}
+            aria-expanded={mobileOpen}
+            aria-controls="site-mobile-nav"
+            onClick={() => setMobileOpen((v) => !v)}
+            className="inline-flex size-8 items-center justify-center rounded-md border border-border bg-card text-foreground transition-colors hover:border-foreground/40 hover:bg-accent md:hidden"
+          >
+            {mobileOpen ? (
+              <X className="size-3.5" />
+            ) : (
+              <Menu className="size-3.5" />
+            )}
+          </button>
+        </div>
+      </div>
+
+      {mobileOpen && (
+        <div
+          id="site-mobile-nav"
+          className="border-t border-border bg-background/95 backdrop-blur-md md:hidden"
+        >
+          <nav className="mx-auto flex w-full max-w-7xl flex-col gap-0.5 px-4 py-3 sm:px-6">
+            {NAV_LINKS.map((link) => {
+              const active = isActive(link.href)
+              return (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className={cn(
+                    "rounded-sm px-3 py-2 text-sm transition-colors",
+                    active
+                      ? "bg-accent text-foreground"
+                      : "text-muted-foreground hover:bg-accent hover:text-foreground"
+                  )}
+                >
+                  {link.label}
+                </Link>
+              )
+            })}
+            <a
+              href={SITE.githubUrl}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="rounded-sm px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              GitHub
+            </a>
+          </nav>
+        </div>
+      )}
+    </header>
+  )
+}

--- a/components/showcase/site-header.tsx
+++ b/components/showcase/site-header.tsx
@@ -37,17 +37,17 @@ export function SiteHeader({
         className
       )}
     >
-      <div className="mx-auto flex h-16 w-full max-w-7xl items-center gap-3 px-4 sm:px-6 lg:px-8">
+      <div className="mx-auto flex h-14 w-full max-w-7xl items-center gap-3 px-4 sm:px-6 lg:px-8">
         {withSidebarTrigger}
 
         <Link
           href="/"
           aria-label={`${SITE.name} — home`}
-          className="group flex items-center gap-2 rounded-sm py-1 pr-1 transition-colors"
+          className="group flex items-center gap-2 rounded-sm py-1 transition-colors"
         >
           <BrandLockup
-            logoClassName="size-10"
-            textClassName="hidden text-xl sm:inline"
+            logoClassName="h-7"
+            textClassName="text-lg sm:text-xl"
           />
           <span
             aria-hidden

--- a/components/showcase/site-header.tsx
+++ b/components/showcase/site-header.tsx
@@ -8,7 +8,7 @@ import { Menu, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { NAV_LINKS, SITE } from "@/lib/site"
 import { GitHubStars } from "@/components/showcase/github-stars"
-import { LogoMark } from "@/components/showcase/logo"
+import { BrandLockup } from "@/components/showcase/logo"
 import { ThemeToggle } from "@/components/showcase/theme-toggle"
 
 export function SiteHeader({
@@ -33,11 +33,11 @@ export function SiteHeader({
   return (
     <header
       className={cn(
-        "sticky top-0 z-40 w-full border-b border-border bg-background/80 backdrop-blur-md supports-[backdrop-filter]:bg-background/60",
+        "sticky top-0 z-40 w-full border-b border-border/60 bg-background/70 backdrop-blur-xl supports-[backdrop-filter]:bg-background/50",
         className
       )}
     >
-      <div className="mx-auto flex h-14 w-full max-w-7xl items-center gap-3 px-4 sm:px-6 lg:px-8">
+      <div className="mx-auto flex h-16 w-full max-w-7xl items-center gap-3 px-4 sm:px-6 lg:px-8">
         {withSidebarTrigger}
 
         <Link
@@ -45,10 +45,10 @@ export function SiteHeader({
           aria-label={`${SITE.name} — home`}
           className="group flex items-center gap-2 rounded-sm py-1 pr-1 transition-colors"
         >
-          <LogoMark className="size-6" />
-          <span className="hidden text-[15px] font-semibold tracking-[-0.02em] sm:inline">
-            msh <span className="text-muted-foreground">ui</span>
-          </span>
+          <BrandLockup
+            logoClassName="size-10"
+            textClassName="hidden text-xl sm:inline"
+          />
           <span
             aria-hidden
             className="ml-1 hidden rounded-sm border border-border px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground sm:inline"

--- a/components/showcase/theme-sheet.tsx
+++ b/components/showcase/theme-sheet.tsx
@@ -115,7 +115,7 @@ function ThemeSheetBody() {
         </div>
         <SheetTitle>Theme settings</SheetTitle>
         <SheetDescription>
-          Preview msh ui components against your own theme. Paste a CSS
+          Preview forgecn components against your own theme. Paste a CSS
           variable block, pick a preset, or copy the active theme back out.
         </SheetDescription>
       </SheetHeader>

--- a/components/showcase/theme-sheet.tsx
+++ b/components/showcase/theme-sheet.tsx
@@ -115,8 +115,8 @@ function ThemeSheetBody() {
         </div>
         <SheetTitle>Theme settings</SheetTitle>
         <SheetDescription>
-          Preview Sabk components against your own theme. Paste a CSS variable
-          block, pick a preset, or copy the active theme back out.
+          Preview msh ui components against your own theme. Paste a CSS
+          variable block, pick a preset, or copy the active theme back out.
         </SheetDescription>
       </SheetHeader>
 

--- a/components/showcase/theme-toggle.tsx
+++ b/components/showcase/theme-toggle.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import * as React from "react"
+import { Moon, Sun } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { useTheme } from "@/components/showcase/theme-provider"
+
+export function ThemeToggle({ className }: { className?: string }) {
+  const { mode, setMode } = useTheme()
+  const [mounted, setMounted] = React.useState(false)
+  React.useEffect(() => setMounted(true), [])
+
+  const isLight = mode === "light"
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={isLight}
+      aria-label={isLight ? "Switch to dark mode" : "Switch to light mode"}
+      onClick={() => setMode(isLight ? "dark" : "light")}
+      className={cn(
+        "relative inline-flex size-8 items-center justify-center rounded-md border border-border bg-card text-foreground transition-colors hover:border-foreground/40 hover:bg-accent",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className
+      )}
+    >
+      <Sun
+        className={cn(
+          "size-3.5 transition-all duration-200",
+          mounted && isLight
+            ? "rotate-0 scale-100 opacity-100"
+            : "-rotate-90 scale-0 opacity-0"
+        )}
+      />
+      <Moon
+        className={cn(
+          "absolute size-3.5 transition-all duration-200",
+          mounted && !isLight
+            ? "rotate-0 scale-100 opacity-100"
+            : "rotate-90 scale-0 opacity-0"
+        )}
+      />
+    </button>
+  )
+}

--- a/components/showcase/topbar.tsx
+++ b/components/showcase/topbar.tsx
@@ -28,7 +28,7 @@ export function ShowcaseTopbar() {
         className="flex items-center gap-2 rounded-sm py-1 transition-colors md:hidden"
         aria-label="msh ui — home"
       >
-        <BrandLockup logoClassName="size-8" textClassName="text-lg" />
+        <BrandLockup logoClassName="h-6" textClassName="text-base" />
       </Link>
 
       <nav className="hidden flex-1 items-center gap-0.5 md:flex">

--- a/components/showcase/topbar.tsx
+++ b/components/showcase/topbar.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+
+import { cn } from "@/lib/utils"
+import { NAV_LINKS } from "@/lib/site"
+import { GitHubStars } from "@/components/showcase/github-stars"
+import { LogoMark } from "@/components/showcase/logo"
+import { ThemeToggle } from "@/components/showcase/theme-toggle"
+import { Separator } from "@/registry/sabk/ui/separator"
+import { SidebarTrigger } from "@/registry/sabk/ui/sidebar"
+
+export function ShowcaseTopbar() {
+  const pathname = usePathname()
+
+  const isActive = (href: string) => {
+    if (href === "/") return pathname === "/"
+    return pathname === href || pathname.startsWith(`${href}/`)
+  }
+
+  return (
+    <header className="sticky top-0 z-30 flex h-12 shrink-0 items-center gap-2 border-b border-border bg-background/85 px-3 backdrop-blur-md sm:px-4">
+      <SidebarTrigger className="-ml-1" />
+      <Separator orientation="vertical" className="mx-1 h-5" />
+      <Link
+        href="/"
+        className="flex items-center gap-2 rounded-sm py-1 transition-colors md:hidden"
+        aria-label="msh ui — home"
+      >
+        <LogoMark className="size-5" />
+        <span className="text-sm font-semibold tracking-[-0.02em]">
+          msh <span className="text-muted-foreground">ui</span>
+        </span>
+      </Link>
+
+      <nav className="hidden flex-1 items-center gap-0.5 md:flex">
+        {NAV_LINKS.map((link) => {
+          const active = isActive(link.href)
+          return (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={cn(
+                "rounded-sm px-2.5 py-1 text-[13px] tracking-tight transition-colors",
+                active
+                  ? "text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {link.label}
+            </Link>
+          )
+        })}
+      </nav>
+
+      <div className="ml-auto flex items-center gap-1.5">
+        <GitHubStars />
+        <ThemeToggle />
+      </div>
+    </header>
+  )
+}

--- a/components/showcase/topbar.tsx
+++ b/components/showcase/topbar.tsx
@@ -26,9 +26,9 @@ export function ShowcaseTopbar() {
       <Link
         href="/"
         className="flex items-center gap-2 rounded-sm py-1 transition-colors md:hidden"
-        aria-label="msh ui — home"
+        aria-label="forgecn — home"
       >
-        <BrandLockup logoClassName="h-6" textClassName="text-base" />
+        <BrandLockup logoClassName="size-5" textClassName="text-sm" />
       </Link>
 
       <nav className="hidden flex-1 items-center gap-0.5 md:flex">

--- a/components/showcase/topbar.tsx
+++ b/components/showcase/topbar.tsx
@@ -6,7 +6,7 @@ import { usePathname } from "next/navigation"
 import { cn } from "@/lib/utils"
 import { NAV_LINKS } from "@/lib/site"
 import { GitHubStars } from "@/components/showcase/github-stars"
-import { LogoMark } from "@/components/showcase/logo"
+import { BrandLockup } from "@/components/showcase/logo"
 import { ThemeToggle } from "@/components/showcase/theme-toggle"
 import { Separator } from "@/registry/sabk/ui/separator"
 import { SidebarTrigger } from "@/registry/sabk/ui/sidebar"
@@ -20,7 +20,7 @@ export function ShowcaseTopbar() {
   }
 
   return (
-    <header className="sticky top-0 z-30 flex h-12 shrink-0 items-center gap-2 border-b border-border bg-background/85 px-3 backdrop-blur-md sm:px-4">
+    <header className="sticky top-0 z-30 flex h-14 shrink-0 items-center gap-2 border-b border-border bg-background/85 px-3 backdrop-blur-md sm:px-4">
       <SidebarTrigger className="-ml-1" />
       <Separator orientation="vertical" className="mx-1 h-5" />
       <Link
@@ -28,10 +28,7 @@ export function ShowcaseTopbar() {
         className="flex items-center gap-2 rounded-sm py-1 transition-colors md:hidden"
         aria-label="msh ui — home"
       >
-        <LogoMark className="size-5" />
-        <span className="text-sm font-semibold tracking-[-0.02em]">
-          msh <span className="text-muted-foreground">ui</span>
-        </span>
+        <BrandLockup logoClassName="size-8" textClassName="text-lg" />
       </Link>
 
       <nav className="hidden flex-1 items-center gap-0.5 md:flex">

--- a/lib/package-managers.ts
+++ b/lib/package-managers.ts
@@ -11,8 +11,8 @@ export const PACKAGE_MANAGERS: readonly PackageManager[] = [
   "bun",
 ] as const
 
-const STORAGE_KEY = "msh-ui:pm"
-const CHANGE_EVENT = "msh-ui:pm-change"
+const STORAGE_KEY = "forgecn:pm"
+const CHANGE_EVENT = "forgecn:pm-change"
 
 export function getShadcnAddCommand(pm: PackageManager, url: string): string {
   switch (pm) {

--- a/lib/package-managers.ts
+++ b/lib/package-managers.ts
@@ -11,8 +11,8 @@ export const PACKAGE_MANAGERS: readonly PackageManager[] = [
   "bun",
 ] as const
 
-const STORAGE_KEY = "sabk:pm"
-const CHANGE_EVENT = "sabk:pm-change"
+const STORAGE_KEY = "msh-ui:pm"
+const CHANGE_EVENT = "msh-ui:pm-change"
 
 export function getShadcnAddCommand(pm: PackageManager, url: string): string {
   switch (pm) {

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -3,8 +3,8 @@
  */
 
 export const SITE = {
-  name: "msh ui",
-  fullName: "msh ui",
+  name: "forgecn",
+  fullName: "forgecn",
   description: "shadcn's missing pieces",
   longDescription:
     "A peer registry for the components every real product needs but shadcn doesn't ship — multi-select, combobox, tag input, currency input, file dropzone, and more.",
@@ -16,7 +16,7 @@ export const SITE = {
   githubUrl: "https://github.com/MohammadShehadeh/forgecn",
   twitterUrl: "https://x.com/mohammadshhadeh",
   registry: {
-    name: "msh-ui",
+    name: "forgecn",
     /** Public origin used when generating install URLs server-side. */
     origin: "https://forgecn.dev",
   },

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,0 +1,30 @@
+/**
+ * Site-wide brand constants. One source of truth for name, URLs, social links.
+ */
+
+export const SITE = {
+  name: "msh ui",
+  fullName: "msh ui",
+  description: "shadcn's missing pieces",
+  longDescription:
+    "A peer registry for the components every real product needs but shadcn doesn't ship — multi-select, combobox, tag input, currency input, file dropzone, and more.",
+  version: "0.1",
+  author: "Mohammad Shehadeh",
+  authorUrl: "https://mohammadshehadeh.com",
+  githubOwner: "MohammadShehadeh",
+  githubRepo: "forgecn",
+  githubUrl: "https://github.com/MohammadShehadeh/forgecn",
+  twitterUrl: "https://x.com/mohammadshhadeh",
+  registry: {
+    name: "msh-ui",
+    /** Public origin used when generating install URLs server-side. */
+    origin: "https://forgecn.dev",
+  },
+} as const
+
+export const NAV_LINKS: { href: string; label: string; external?: boolean }[] =
+  [
+    { href: "/components", label: "Components" },
+    { href: "/blocks", label: "Blocks" },
+    { href: "/theme", label: "Theme" },
+  ]

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -238,8 +238,8 @@ export const THEME_PRESETS: ThemePreset[] = [
   },
 ]
 
-export const STORAGE_KEY = "sabk.theme.v1"
-export const MODE_STORAGE_KEY = "sabk.theme.mode.v1"
+export const STORAGE_KEY = "msh-ui.theme.v1"
+export const MODE_STORAGE_KEY = "msh-ui.theme.mode.v1"
 
 /**
  * Inline script (stringified) that runs before hydration to apply persisted

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -238,8 +238,8 @@ export const THEME_PRESETS: ThemePreset[] = [
   },
 ]
 
-export const STORAGE_KEY = "msh-ui.theme.v1"
-export const MODE_STORAGE_KEY = "msh-ui.theme.mode.v1"
+export const STORAGE_KEY = "forgecn.theme.v1"
+export const MODE_STORAGE_KEY = "forgecn.theme.mode.v1"
 
 /**
  * Inline script (stringified) that runs before hydration to apply persisted

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,17 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from "next"
 
 const nextConfig: NextConfig = {
-  /* config options here */
-};
+  // The component/block routes read their source TSX off disk at build time
+  // via fs.readFile(path.join(process.cwd(), ...)). Those files aren't
+  // imported by the route, so Next's tracer doesn't include them in the
+  // server bundle by default — which makes `fs.readFile` miss on hosts that
+  // re-evaluate the route at runtime, and the page falls back to the
+  // "// (unable to read source)" stub. Explicitly tracing the registry
+  // source ensures the files travel with the build.
+  outputFileTracingIncludes: {
+    "/[component]": ["./registry/sabk/**/*.{ts,tsx}"],
+    "/blocks/[block]": ["./registry/sabk/**/*.{ts,tsx}"],
+  },
+}
 
-export default nextConfig;
+export default nextConfig

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sabk",
+  "name": "msh-ui",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "msh-ui",
+  "name": "forgecn",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry.json",
-  "name": "sabk",
-  "homepage": "https://sabk.dev",
+  "name": "msh-ui",
+  "homepage": "https://forgecn.dev",
   "items": [
     {
       "name": "multi-select",

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry.json",
-  "name": "msh-ui",
+  "name": "forgecn",
   "homepage": "https://forgecn.dev",
   "items": [
     {

--- a/registry/sabk/blocks/cta-02/cta-02.tsx
+++ b/registry/sabk/blocks/cta-02/cta-02.tsx
@@ -51,7 +51,7 @@ export default function Cta02() {
         </h2>
 
         <p className="max-w-xl text-balance text-base text-muted-foreground">
-          msh ui fills the obvious gaps in shadcn — the components your team
+          forgecn fills the obvious gaps in shadcn — the components your team
           quietly rebuilds project after project — so you can spend that
           time on the work only you can do.
         </p>

--- a/registry/sabk/blocks/cta-02/cta-02.tsx
+++ b/registry/sabk/blocks/cta-02/cta-02.tsx
@@ -51,7 +51,7 @@ export default function Cta02() {
         </h2>
 
         <p className="max-w-xl text-balance text-base text-muted-foreground">
-          Sabk fills the obvious gaps in shadcn — the components your team
+          msh ui fills the obvious gaps in shadcn — the components your team
           quietly rebuilds project after project — so you can spend that
           time on the work only you can do.
         </p>
@@ -76,7 +76,7 @@ export default function Cta02() {
           <code className="whitespace-nowrap text-foreground">
             npx shadcn add{" "}
             <span className="text-muted-foreground">
-              https://sabk.dev/r/multi-select
+              https://forgecn.dev/r/multi-select
             </span>
           </code>
         </div>

--- a/registry/sabk/blocks/faq-01/faq-01.tsx
+++ b/registry/sabk/blocks/faq-01/faq-01.tsx
@@ -13,20 +13,20 @@ import { Button } from "@/registry/sabk/ui/button"
 
 const FAQS = [
   {
-    q: "How is msh ui different from shadcn/ui?",
-    a: "msh ui is a peer, not a replacement. shadcn/ui covers the canonical primitives — Button, Dialog, Select. msh ui ships the dense, real-world components every product still has to build: multi-select, tag input, year picker, combobox with async loading, password strength. Both registries use the same CLI and the same install URL pattern, so you can mix and match.",
+    q: "How is forgecn different from shadcn/ui?",
+    a: "forgecn is a peer, not a replacement. shadcn/ui covers the canonical primitives — Button, Dialog, Select. forgecn ships the dense, real-world components every product still has to build: multi-select, tag input, year picker, combobox with async loading, password strength. Both registries use the same CLI and the same install URL pattern, so you can mix and match.",
   },
   {
-    q: "Is msh ui a dependency I install?",
-    a: "No. msh ui is a registry, not a package. `npx shadcn add` copies the component source straight into your repo at components/ui/*. You own the code, you can edit it, and there is zero runtime dependency on msh ui.",
+    q: "Is forgecn a dependency I install?",
+    a: "No. forgecn is a registry, not a package. `npx shadcn add` copies the component source straight into your repo at components/ui/*. You own the code, you can edit it, and there is zero runtime dependency on forgecn.",
   },
   {
     q: "What is the dual-API contract?",
-    a: "Every msh ui component ships two surface areas in the same file: a compound API (Root + named parts, for full layout control) and a single-prop API (one component, options-as-prop, for the 90% case). They share state — you can drop in either depending on the use case.",
+    a: "Every forgecn component ships two surface areas in the same file: a compound API (Root + named parts, for full layout control) and a single-prop API (one component, options-as-prop, for the 90% case). They share state — you can drop in either depending on the use case.",
   },
   {
     q: "Can I theme it?",
-    a: "Yes. msh ui reads the same CSS variables as shadcn/ui. The /theme playground lets you tune the accent live; every component re-skins in place. Drop-in compatible with any shadcn theme.",
+    a: "Yes. forgecn reads the same CSS variables as shadcn/ui. The /theme playground lets you tune the accent live; every component re-skins in place. Drop-in compatible with any shadcn theme.",
   },
   {
     q: "Does it work with React Server Components?",
@@ -53,7 +53,7 @@ export default function Faq01() {
               <span className="text-foreground">unobvious</span> questions.
             </h2>
             <p className="text-sm text-muted-foreground">
-              The questions teams ask in their first ten minutes with msh ui —
+              The questions teams ask in their first ten minutes with forgecn —
               answered the way we&apos;d want them answered. If something
               isn&apos;t here, the issue tracker is open.
             </p>

--- a/registry/sabk/blocks/faq-01/faq-01.tsx
+++ b/registry/sabk/blocks/faq-01/faq-01.tsx
@@ -13,20 +13,20 @@ import { Button } from "@/registry/sabk/ui/button"
 
 const FAQS = [
   {
-    q: "How is Sabk different from shadcn/ui?",
-    a: "Sabk is a peer, not a replacement. shadcn/ui covers the canonical primitives — Button, Dialog, Select. Sabk ships the dense, real-world components every product still has to build: multi-select, tag input, year picker, combobox with async loading, password strength. Both registries use the same CLI and the same install URL pattern, so you can mix and match.",
+    q: "How is msh ui different from shadcn/ui?",
+    a: "msh ui is a peer, not a replacement. shadcn/ui covers the canonical primitives — Button, Dialog, Select. msh ui ships the dense, real-world components every product still has to build: multi-select, tag input, year picker, combobox with async loading, password strength. Both registries use the same CLI and the same install URL pattern, so you can mix and match.",
   },
   {
-    q: "Is Sabk a dependency I install?",
-    a: "No. Sabk is a registry, not a package. `npx shadcn add` copies the component source straight into your repo at components/ui/*. You own the code, you can edit it, and there is zero runtime dependency on Sabk.",
+    q: "Is msh ui a dependency I install?",
+    a: "No. msh ui is a registry, not a package. `npx shadcn add` copies the component source straight into your repo at components/ui/*. You own the code, you can edit it, and there is zero runtime dependency on msh ui.",
   },
   {
     q: "What is the dual-API contract?",
-    a: "Every Sabk component ships two surface areas in the same file: a compound API (Root + named parts, for full layout control) and a single-prop API (one component, options-as-prop, for the 90% case). They share state — you can drop in either depending on the use case.",
+    a: "Every msh ui component ships two surface areas in the same file: a compound API (Root + named parts, for full layout control) and a single-prop API (one component, options-as-prop, for the 90% case). They share state — you can drop in either depending on the use case.",
   },
   {
     q: "Can I theme it?",
-    a: "Yes. Sabk reads the same CSS variables as shadcn/ui. The /theme playground lets you tune the accent live; every component re-skins in place. Drop-in compatible with any shadcn theme.",
+    a: "Yes. msh ui reads the same CSS variables as shadcn/ui. The /theme playground lets you tune the accent live; every component re-skins in place. Drop-in compatible with any shadcn theme.",
   },
   {
     q: "Does it work with React Server Components?",
@@ -53,7 +53,7 @@ export default function Faq01() {
               <span className="text-foreground">unobvious</span> questions.
             </h2>
             <p className="text-sm text-muted-foreground">
-              The questions teams ask in their first ten minutes with Sabk —
+              The questions teams ask in their first ten minutes with msh ui —
               answered the way we&apos;d want them answered. If something
               isn&apos;t here, the issue tracker is open.
             </p>

--- a/registry/sabk/blocks/faq-02/faq-02.tsx
+++ b/registry/sabk/blocks/faq-02/faq-02.tsx
@@ -12,7 +12,7 @@ import {
 const FAQS = [
   {
     q: "Do I need to install a package?",
-    a: "No. Sabk is a registry — components copy straight into your repo via the shadcn CLI. Zero runtime dependency.",
+    a: "No. msh ui is a registry — components copy straight into your repo via the shadcn CLI. Zero runtime dependency.",
   },
   {
     q: "Will updates break my code?",

--- a/registry/sabk/blocks/faq-02/faq-02.tsx
+++ b/registry/sabk/blocks/faq-02/faq-02.tsx
@@ -12,7 +12,7 @@ import {
 const FAQS = [
   {
     q: "Do I need to install a package?",
-    a: "No. msh ui is a registry — components copy straight into your repo via the shadcn CLI. Zero runtime dependency.",
+    a: "No. forgecn is a registry — components copy straight into your repo via the shadcn CLI. Zero runtime dependency.",
   },
   {
     q: "Will updates break my code?",

--- a/registry/sabk/blocks/feature-01/feature-01.tsx
+++ b/registry/sabk/blocks/feature-01/feature-01.tsx
@@ -17,11 +17,11 @@ const ROWS: readonly FeatureRow[] = [
   {
     eyebrow: "· registry",
     headline: "One CLI command, source in your repo.",
-    body: "msh ui distributes through the same shadcn CLI you already use. The component lands in your codebase as plain TSX — no package pin, no version drift.",
+    body: "forgecn distributes through the same shadcn CLI you already use. The component lands in your codebase as plain TSX — no package pin, no version drift.",
     bullets: [
       "Resolved against your existing tsconfig paths",
       "Drops into components/ui/* by default",
-      "Zero runtime dependency on msh ui",
+      "Zero runtime dependency on forgecn",
     ],
     media: "registry",
   },

--- a/registry/sabk/blocks/feature-01/feature-01.tsx
+++ b/registry/sabk/blocks/feature-01/feature-01.tsx
@@ -17,11 +17,11 @@ const ROWS: readonly FeatureRow[] = [
   {
     eyebrow: "· registry",
     headline: "One CLI command, source in your repo.",
-    body: "Sabk distributes through the same shadcn CLI you already use. The component lands in your codebase as plain TSX — no package pin, no version drift.",
+    body: "msh ui distributes through the same shadcn CLI you already use. The component lands in your codebase as plain TSX — no package pin, no version drift.",
     bullets: [
       "Resolved against your existing tsconfig paths",
       "Drops into components/ui/* by default",
-      "Zero runtime dependency on Sabk",
+      "Zero runtime dependency on msh ui",
     ],
     media: "registry",
   },
@@ -73,7 +73,7 @@ function MediaRegistry() {
             <span className="text-foreground">npx shadcn add</span>
           </span>
           <span className="block text-muted-foreground">
-            {"  "}https://sabk.dev/r/combobox
+            {"  "}https://forgecn.dev/r/combobox
           </span>
           <span className="block">&nbsp;</span>
           <span className="block text-muted-foreground">

--- a/registry/sabk/blocks/feature-02/feature-02.tsx
+++ b/registry/sabk/blocks/feature-02/feature-02.tsx
@@ -62,7 +62,7 @@ export default function Feature02() {
             Everything a real product needs, none of the rest.
           </h2>
           <p className="text-base text-muted-foreground sm:text-lg">
-            Six decisions baked into every Sabk component, so you can stop
+            Six decisions baked into every msh ui component, so you can stop
             making them yourself in every new repo.
           </p>
         </div>

--- a/registry/sabk/blocks/feature-02/feature-02.tsx
+++ b/registry/sabk/blocks/feature-02/feature-02.tsx
@@ -62,7 +62,7 @@ export default function Feature02() {
             Everything a real product needs, none of the rest.
           </h2>
           <p className="text-base text-muted-foreground sm:text-lg">
-            Six decisions baked into every msh ui component, so you can stop
+            Six decisions baked into every forgecn component, so you can stop
             making them yourself in every new repo.
           </p>
         </div>

--- a/registry/sabk/blocks/footer-01/footer-01.tsx
+++ b/registry/sabk/blocks/footer-01/footer-01.tsx
@@ -83,7 +83,7 @@ export default function Footer01() {
 
         <div className="mt-14 flex flex-col items-start justify-between gap-4 border-t border-border pt-6 sm:flex-row sm:items-center">
           <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-            © 2026 msh ui Labs · All rights reserved
+            © 2026 forgecn Labs · All rights reserved
           </p>
           <div className="flex items-center gap-1">
             <a

--- a/registry/sabk/blocks/footer-01/footer-01.tsx
+++ b/registry/sabk/blocks/footer-01/footer-01.tsx
@@ -83,7 +83,7 @@ export default function Footer01() {
 
         <div className="mt-14 flex flex-col items-start justify-between gap-4 border-t border-border pt-6 sm:flex-row sm:items-center">
           <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-            © 2026 Sabk Labs · All rights reserved
+            © 2026 msh ui Labs · All rights reserved
           </p>
           <div className="flex items-center gap-1">
             <a

--- a/registry/sabk/blocks/hero-01/hero-01.tsx
+++ b/registry/sabk/blocks/hero-01/hero-01.tsx
@@ -13,7 +13,7 @@ const STATS = [
 
 const REGISTRY_LINES = [
   { kind: "cmd", text: "npx shadcn add" },
-  { kind: "arg", text: "  https://sabk.dev/r/multi-select" },
+  { kind: "arg", text: "  https://forgecn.dev/r/multi-select" },
   { kind: "out", text: "✓ resolved registry" },
   { kind: "out", text: "✓ checked dependencies" },
   { kind: "out", text: "✓ created multi-select.tsx" },

--- a/registry/sabk/blocks/hero-02/hero-02.tsx
+++ b/registry/sabk/blocks/hero-02/hero-02.tsx
@@ -9,7 +9,7 @@ const WORDMARKS = [
   "ACME / Co.",
   "Helix",
   "Northwind",
-  "msh ◆ Labs",
+  "forgecn ◆ Labs",
   "Vanta",
   "Quartz",
 ] as const
@@ -75,7 +75,7 @@ export default function Hero02() {
         </h1>
 
         <p className="max-w-2xl text-balance text-base text-muted-foreground sm:text-lg">
-          msh ui ships the dense, real-world components every product hits a
+          forgecn ships the dense, real-world components every product hits a
           wall on — tag input, multi-select, combobox, year picker — wired
           with the dual-API contract and an aesthetic that earns
           its place in your codebase.

--- a/registry/sabk/blocks/hero-02/hero-02.tsx
+++ b/registry/sabk/blocks/hero-02/hero-02.tsx
@@ -9,7 +9,7 @@ const WORDMARKS = [
   "ACME / Co.",
   "Helix",
   "Northwind",
-  "Sabk ◆ Labs",
+  "msh ◆ Labs",
   "Vanta",
   "Quartz",
 ] as const
@@ -75,7 +75,7 @@ export default function Hero02() {
         </h1>
 
         <p className="max-w-2xl text-balance text-base text-muted-foreground sm:text-lg">
-          Sabk ships the dense, real-world components every product hits a
+          msh ui ships the dense, real-world components every product hits a
           wall on — tag input, multi-select, combobox, year picker — wired
           with the dual-API contract and an aesthetic that earns
           its place in your codebase.

--- a/registry/sabk/blocks/login-01/login-01.tsx
+++ b/registry/sabk/blocks/login-01/login-01.tsx
@@ -70,7 +70,7 @@ export default function Login01() {
                 Welcome back
               </h1>
               <p className="text-xs text-muted-foreground">
-                Sign in to your msh ui workspace to continue.
+                Sign in to your forgecn workspace to continue.
               </p>
             </div>
           </div>

--- a/registry/sabk/blocks/login-01/login-01.tsx
+++ b/registry/sabk/blocks/login-01/login-01.tsx
@@ -70,7 +70,7 @@ export default function Login01() {
                 Welcome back
               </h1>
               <p className="text-xs text-muted-foreground">
-                Sign in to your Sabk workspace to continue.
+                Sign in to your msh ui workspace to continue.
               </p>
             </div>
           </div>

--- a/registry/sabk/blocks/login-02/login-02.tsx
+++ b/registry/sabk/blocks/login-02/login-02.tsx
@@ -126,7 +126,7 @@ export default function Login02() {
           <Quote className="size-7 text-foreground md:size-8" strokeWidth={1.5} />
 
           <blockquote className="text-balance text-xl font-medium leading-[1.3] tracking-[-0.02em] md:text-2xl lg:text-3xl">
-            Sabk gave us back the week we were going to spend rebuilding
+            msh ui gave us back the week we were going to spend rebuilding
             a <span className="text-foreground">multi-select</span> for the
             fourth time.
           </blockquote>

--- a/registry/sabk/blocks/login-02/login-02.tsx
+++ b/registry/sabk/blocks/login-02/login-02.tsx
@@ -126,7 +126,7 @@ export default function Login02() {
           <Quote className="size-7 text-foreground md:size-8" strokeWidth={1.5} />
 
           <blockquote className="text-balance text-xl font-medium leading-[1.3] tracking-[-0.02em] md:text-2xl lg:text-3xl">
-            msh ui gave us back the week we were going to spend rebuilding
+            forgecn gave us back the week we were going to spend rebuilding
             a <span className="text-foreground">multi-select</span> for the
             fourth time.
           </blockquote>

--- a/registry/sabk/blocks/testimonial-01/testimonial-01.tsx
+++ b/registry/sabk/blocks/testimonial-01/testimonial-01.tsx
@@ -21,7 +21,7 @@ export default function Testimonial01() {
               &ldquo;
             </span>
             <p className="text-balance text-2xl font-medium leading-[1.25] tracking-[-0.02em] sm:text-3xl">
-              We swapped three hand-rolled multi-selects for the msh ui one in an
+              We swapped three hand-rolled multi-selects for the forgecn one in an
               afternoon. The compound API let us keep our existing layout, and
               the keyboard nav was finally not embarrassing.
             </p>

--- a/registry/sabk/blocks/testimonial-01/testimonial-01.tsx
+++ b/registry/sabk/blocks/testimonial-01/testimonial-01.tsx
@@ -21,7 +21,7 @@ export default function Testimonial01() {
               &ldquo;
             </span>
             <p className="text-balance text-2xl font-medium leading-[1.25] tracking-[-0.02em] sm:text-3xl">
-              We swapped three hand-rolled multi-selects for the Sabk one in an
+              We swapped three hand-rolled multi-selects for the msh ui one in an
               afternoon. The compound API let us keep our existing layout, and
               the keyboard nav was finally not embarrassing.
             </p>

--- a/registry/sabk/blocks/testimonial-02/testimonial-02.tsx
+++ b/registry/sabk/blocks/testimonial-02/testimonial-02.tsx
@@ -11,7 +11,7 @@ type Quote = {
 
 const QUOTES: readonly Quote[] = [
   {
-    body: "We swapped three hand-rolled multi-selects for the msh ui one in an afternoon. The compound API let us keep our existing layout, and the keyboard nav was finally not embarrassing in front of users.",
+    body: "We swapped three hand-rolled multi-selects for the forgecn one in an afternoon. The compound API let us keep our existing layout, and the keyboard nav was finally not embarrassing in front of users.",
     initials: "MR",
     name: "Maya Renner",
     role: "Staff engineer · Plinth Labs",
@@ -35,7 +35,7 @@ const QUOTES: readonly Quote[] = [
     role: "Frontend lead · Verbit",
   },
   {
-    body: "We're a tiny team. Stuff that used to be a 'we'll do it right in v2' is now done correctly in v1. msh ui is the reason.",
+    body: "We're a tiny team. Stuff that used to be a 'we'll do it right in v2' is now done correctly in v1. forgecn is the reason.",
     initials: "RP",
     name: "Reema Patel",
     role: "CTO · Lattice & Co.",

--- a/registry/sabk/blocks/testimonial-02/testimonial-02.tsx
+++ b/registry/sabk/blocks/testimonial-02/testimonial-02.tsx
@@ -11,7 +11,7 @@ type Quote = {
 
 const QUOTES: readonly Quote[] = [
   {
-    body: "We swapped three hand-rolled multi-selects for the Sabk one in an afternoon. The compound API let us keep our existing layout, and the keyboard nav was finally not embarrassing in front of users.",
+    body: "We swapped three hand-rolled multi-selects for the msh ui one in an afternoon. The compound API let us keep our existing layout, and the keyboard nav was finally not embarrassing in front of users.",
     initials: "MR",
     name: "Maya Renner",
     role: "Staff engineer · Plinth Labs",
@@ -35,7 +35,7 @@ const QUOTES: readonly Quote[] = [
     role: "Frontend lead · Verbit",
   },
   {
-    body: "We're a tiny team. Stuff that used to be a 'we'll do it right in v2' is now done correctly in v1. Sabk is the reason.",
+    body: "We're a tiny team. Stuff that used to be a 'we'll do it right in v2' is now done correctly in v1. msh ui is the reason.",
     initials: "RP",
     name: "Reema Patel",
     role: "CTO · Lattice & Co.",

--- a/registry/sabk/callout/callout.tsx
+++ b/registry/sabk/callout/callout.tsx
@@ -4,10 +4,6 @@ import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
-/* ============================================================================
- * Variants
- * ========================================================================== */
-
 const calloutVariants = cva(
   "my-4 flex flex-col gap-2 overflow-hidden rounded-md border-l-4 p-4 text-sm",
   {
@@ -38,10 +34,6 @@ const variantIcons: Record<CalloutVariant, React.ElementType> = {
   error: Ban,
   neutral: AlertCircle,
 }
-
-/* ============================================================================
- * Root · single-prop API
- * ========================================================================== */
 
 export type CalloutProps = Omit<React.ComponentProps<"div">, "title"> &
   VariantProps<typeof calloutVariants> & {

--- a/registry/sabk/combobox/combobox.demo.tsx
+++ b/registry/sabk/combobox/combobox.demo.tsx
@@ -20,7 +20,6 @@ const FRAMEWORKS = [
   { value: "tanstack-start", label: "TanStack Start", group: "React" },
 ]
 
-/** Simulates an async API: filters the static list with a small delay. */
 type Pkg = { name: string; description: string }
 async function fakeSearchPackages(q: string): Promise<Pkg[]> {
   await new Promise((r) => setTimeout(r, 250))
@@ -57,7 +56,7 @@ export default function ComboboxDemo() {
 
   return (
     <div className="grid w-full max-w-md gap-8">
-      {/* Basic */}
+      {}
       <div className="grid gap-2">
         <Label>Static options</Label>
         <Combobox
@@ -70,7 +69,7 @@ export default function ComboboxDemo() {
         </Combobox>
       </div>
 
-      {/* Composed */}
+      {}
       <div className="grid gap-2">
         <Label>Async loader (250ms simulated)</Label>
         <Combobox

--- a/registry/sabk/combobox/combobox.tsx
+++ b/registry/sabk/combobox/combobox.tsx
@@ -18,10 +18,6 @@ import {
   CommandList,
 } from "@/registry/sabk/ui/command"
 
-/* ============================================================================
- * Types
- * ========================================================================== */
-
 export type ComboboxOption = {
   value: string
   label: string
@@ -40,7 +36,6 @@ type Ctx = {
   loading?: boolean
   disabled?: boolean
   clearable: boolean
-  /** When true, the consumer is filtering externally (async); cmdk should not filter again. */
   externalFilter: boolean
 }
 
@@ -56,10 +51,6 @@ function useCombobox() {
   return ctx
 }
 
-/* ============================================================================
- * Root
- * ========================================================================== */
-
 export type ComboboxProps = {
   value?: string
   defaultValue?: string
@@ -68,13 +59,10 @@ export type ComboboxProps = {
   open?: boolean
   defaultOpen?: boolean
   onOpenChange?: (open: boolean) => void
-  /** Forwards search input changes (use for async loaders). */
   onSearchChange?: (search: string) => void
-  /** When set, cmdk's internal filtering is disabled — useful for async. */
   externalFilter?: boolean
   loading?: boolean
   disabled?: boolean
-  /** Allow clearing the selection via the trigger's clear button. Default: true. */
   clearable?: boolean
   children?: React.ReactNode
 }
@@ -163,10 +151,6 @@ function Combobox({
   )
 }
 
-/* ============================================================================
- * Trigger
- * ========================================================================== */
-
 type ComboboxTriggerProps = Omit<
   React.ComponentProps<"button">,
   "children"
@@ -248,10 +232,6 @@ function ComboboxTrigger({
   )
 }
 
-/* ============================================================================
- * Content (the dropdown)
- * ========================================================================== */
-
 type ComboboxContentProps = React.ComponentProps<typeof PopoverContent> & {
   searchPlaceholder?: string
   emptyMessage?: string
@@ -322,10 +302,6 @@ function ComboboxContent({
   )
 }
 
-/* ============================================================================
- * Item
- * ========================================================================== */
-
 type ComboboxItemProps = Omit<
   React.ComponentProps<typeof CommandItem>,
   "value" | "onSelect" | "children"
@@ -360,10 +336,6 @@ function ComboboxItem({
     </CommandItem>
   )
 }
-
-/* ============================================================================
- * Async loader hook
- * ========================================================================== */
 
 export function useAsyncComboboxOptions<T>(
   loader: (query: string) => Promise<T[]>,

--- a/registry/sabk/currency-input/currency-input.demo.tsx
+++ b/registry/sabk/currency-input/currency-input.demo.tsx
@@ -15,7 +15,7 @@ export default function CurrencyInputDemo() {
 
   return (
     <div className="grid w-full max-w-md gap-8">
-      {/* Basic */}
+      {}
       <div className="grid gap-2">
         <Label htmlFor="cur-basic">USD</Label>
         <CurrencyInput
@@ -34,7 +34,7 @@ export default function CurrencyInputDemo() {
         </p>
       </div>
 
-      {/* Composed */}
+      {}
       <div className="grid gap-2">
         <Label htmlFor="cur-composed">EUR (de-DE)</Label>
         <CurrencyInput

--- a/registry/sabk/currency-input/currency-input.tsx
+++ b/registry/sabk/currency-input/currency-input.tsx
@@ -4,10 +4,6 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-/* ============================================================================
- * Helpers
- * ========================================================================== */
-
 function resolveCurrencySymbol(currency: string, locale: string): string {
   try {
     const parts = new Intl.NumberFormat(locale, {
@@ -37,13 +33,11 @@ function formatNumber(
   }
 }
 
-/** Strip everything except digits, one decimal point, and an optional leading minus. */
 function sanitizeInput(raw: string, decimals: number): string {
   if (!raw) return ""
   let str = raw.replace(/[^\d.\-]/g, "")
   const negative = str.startsWith("-")
   str = str.replace(/-/g, "")
-  // Keep only first decimal point.
   const firstDot = str.indexOf(".")
   if (firstDot !== -1) {
     str =
@@ -63,10 +57,6 @@ function parseToNumber(view: string): number | null {
   const n = Number(view)
   return Number.isFinite(n) ? n : null
 }
-
-/* ============================================================================
- * Context
- * ========================================================================== */
 
 type Ctx = {
   id: string
@@ -92,13 +82,6 @@ function useCurrencyInput() {
   }
   return ctx
 }
-
-/* ============================================================================
- * Root
- *
- * The root renders the pill-style container. Compose `<CurrencyInputPrefix />`
- * and `<CurrencyInputField />` (or any other content) as children.
- * ========================================================================== */
 
 export type CurrencyInputProps = Omit<
   React.ComponentProps<"div">,
@@ -149,7 +132,6 @@ function CurrencyInput({
       : formatNumber(value, locale, decimals)
   )
 
-  // Sync view when the controlled value changes from outside.
   const lastSeenValue = React.useRef<number | null | undefined>(value)
   React.useEffect(() => {
     if (lastSeenValue.current === value) return
@@ -201,10 +183,6 @@ function CurrencyInput({
   )
 }
 
-/* ============================================================================
- * Prefix
- * ========================================================================== */
-
 type CurrencyInputPrefixProps = Omit<React.ComponentProps<"span">, "children"> & {
   children?: React.ReactNode
 }
@@ -229,10 +207,6 @@ function CurrencyInputPrefix({
     </span>
   )
 }
-
-/* ============================================================================
- * Field
- * ========================================================================== */
 
 type CurrencyInputFieldProps = Omit<
   React.ComponentProps<"input">,
@@ -267,7 +241,6 @@ function CurrencyInputField({
       onFocus={(e) => {
         onFocus?.(e)
         if (ctx.value === null || ctx.value === undefined) return
-        // Show raw editable digits on focus.
         const raw =
           ctx.decimals > 0
             ? ctx.value.toFixed(ctx.decimals)

--- a/registry/sabk/file-dropzone/file-dropzone.demo.tsx
+++ b/registry/sabk/file-dropzone/file-dropzone.demo.tsx
@@ -16,7 +16,7 @@ export default function FileDropzoneDemo() {
 
   return (
     <div className="grid w-full max-w-md gap-8">
-      {/* Basic */}
+      {}
       <div className="grid gap-2">
         <Label>Images & PDFs · up to 5 MB</Label>
         <FileDropzone
@@ -32,7 +32,7 @@ export default function FileDropzoneDemo() {
         </FileDropzone>
       </div>
 
-      {/* Composed */}
+      {}
       <div className="grid gap-2">
         <Label>Data files · custom layout</Label>
         <FileDropzone

--- a/registry/sabk/file-dropzone/file-dropzone.tsx
+++ b/registry/sabk/file-dropzone/file-dropzone.tsx
@@ -5,10 +5,6 @@ import { File as FileIcon, FileText, UploadCloud, X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-/* ============================================================================
- * Helpers
- * ========================================================================== */
-
 function formatBytes(bytes: number): string {
   if (!Number.isFinite(bytes) || bytes < 0) return "0 B"
   const units = ["B", "KB", "MB", "GB", "TB"] as const
@@ -22,7 +18,6 @@ function formatBytes(bytes: number): string {
   return `${fixed} ${units[i]}`
 }
 
-/** Match a file against an accept string ("image/*,.pdf,application/json"). */
 function matchesAccept(file: File, accept?: string): boolean {
   if (!accept) return true
   const tokens = accept
@@ -51,10 +46,6 @@ export type FileDropzoneError = {
   message: string
 }
 
-/* ============================================================================
- * Context
- * ========================================================================== */
-
 type Ctx = {
   files: File[]
   setFiles: (next: File[]) => void
@@ -80,10 +71,6 @@ function useFileDropzone() {
   }
   return ctx
 }
-
-/* ============================================================================
- * Root
- * ========================================================================== */
 
 export type FileDropzoneProps = {
   value?: File[]
@@ -197,10 +184,6 @@ function FileDropzone({
     </FileDropzoneContext.Provider>
   )
 }
-
-/* ============================================================================
- * Zone
- * ========================================================================== */
 
 type FileDropzoneZoneProps = Omit<
   React.ComponentProps<"div">,
@@ -320,10 +303,6 @@ function FileDropzoneZone({
   )
 }
 
-/* ============================================================================
- * List
- * ========================================================================== */
-
 function iconForFile(file: File) {
   if (file.type.startsWith("text/") || /\.(md|txt|csv|json)$/i.test(file.name)) {
     return FileText
@@ -372,10 +351,6 @@ function FileDropzoneList({ className, ...props }: FileDropzoneListProps) {
     </ul>
   )
 }
-
-/* ============================================================================
- * Errors
- * ========================================================================== */
 
 type FileDropzoneErrorsProps = React.ComponentProps<"ul">
 

--- a/registry/sabk/kbd/kbd.demo.tsx
+++ b/registry/sabk/kbd/kbd.demo.tsx
@@ -7,7 +7,7 @@ import { Kbd, KbdDisplay, KbdGroup } from "@/registry/sabk/kbd/kbd"
 export default function KbdDemo() {
   return (
     <div className="grid w-full max-w-3xl gap-8">
-      {/* Single keycaps */}
+      {}
       <div className="grid gap-2">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           Pressable
@@ -23,7 +23,7 @@ export default function KbdDemo() {
         </div>
       </div>
 
-      {/* Chord groups */}
+      {}
       <div className="grid gap-2">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           Chords
@@ -48,7 +48,7 @@ export default function KbdDemo() {
         </div>
       </div>
 
-      {/* Inline display */}
+      {}
       <div className="grid gap-2">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           Inline display

--- a/registry/sabk/kbd/kbd.tsx
+++ b/registry/sabk/kbd/kbd.tsx
@@ -2,10 +2,6 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-/* ============================================================================
- * Kbd · pressable 3D keycap
- * ========================================================================== */
-
 type KbdProps = React.ComponentProps<"button">
 
 function Kbd({ className, type = "button", ...props }: KbdProps) {
@@ -38,10 +34,6 @@ function Kbd({ className, type = "button", ...props }: KbdProps) {
   )
 }
 
-/* ============================================================================
- * KbdDisplay · static inline keycap (e.g. inside tooltips, menus)
- * ========================================================================== */
-
 type KbdDisplayProps = React.ComponentProps<"kbd">
 
 function KbdDisplay({ className, ...props }: KbdDisplayProps) {
@@ -57,10 +49,6 @@ function KbdDisplay({ className, ...props }: KbdDisplayProps) {
     />
   )
 }
-
-/* ============================================================================
- * KbdGroup · row layout for chords like ⌘ + K
- * ========================================================================== */
 
 type KbdGroupProps = React.ComponentProps<"div">
 

--- a/registry/sabk/multi-select/multi-select.demo.tsx
+++ b/registry/sabk/multi-select/multi-select.demo.tsx
@@ -27,7 +27,7 @@ export default function MultiSelectDemo() {
 
   return (
     <div className="grid w-full max-w-md gap-8">
-      {/* Basic */}
+      {}
       <div className="grid gap-2">
         <Label htmlFor="ms-basic">Basic</Label>
         <MultiSelect
@@ -44,7 +44,7 @@ export default function MultiSelectDemo() {
         </p>
       </div>
 
-      {/* Composed */}
+      {}
       <div className="grid gap-2">
         <Label htmlFor="ms-composed">Composed</Label>
         <MultiSelect

--- a/registry/sabk/multi-select/multi-select.tsx
+++ b/registry/sabk/multi-select/multi-select.tsx
@@ -20,10 +20,6 @@ import {
   CommandSeparator,
 } from "@/registry/sabk/ui/command"
 
-/* ============================================================================
- * Types
- * ========================================================================== */
-
 export type MultiSelectOption = {
   value: string
   label: string
@@ -61,10 +57,6 @@ function useMultiSelect() {
   }
   return ctx
 }
-
-/* ============================================================================
- * Root
- * ========================================================================== */
 
 export type MultiSelectProps = {
   value?: string[]
@@ -185,10 +177,6 @@ function MultiSelect({
   )
 }
 
-/* ============================================================================
- * Trigger
- * ========================================================================== */
-
 type MultiSelectTriggerProps = Omit<
   React.ComponentProps<"button">,
   "children"
@@ -284,10 +272,6 @@ function MultiSelectTrigger({
     </PopoverTrigger>
   )
 }
-
-/* ============================================================================
- * Content (the dropdown)
- * ========================================================================== */
 
 type MultiSelectContentProps = React.ComponentProps<typeof PopoverContent> & {
   searchPlaceholder?: string
@@ -401,10 +385,6 @@ function MultiSelectContent({
   )
 }
 
-/* ============================================================================
- * Item (re-exported for custom rendering)
- * ========================================================================== */
-
 type MultiSelectItemProps = Omit<
   React.ComponentProps<typeof CommandItem>,
   "value" | "onSelect" | "children"
@@ -446,10 +426,6 @@ function MultiSelectItem({
     </CommandItem>
   )
 }
-
-/* ============================================================================
- * Async loader hook
- * ========================================================================== */
 
 export function useAsyncOptions<T>(
   loader: (query: string) => Promise<T[]>,

--- a/registry/sabk/number-range/number-range.demo.tsx
+++ b/registry/sabk/number-range/number-range.demo.tsx
@@ -19,7 +19,7 @@ export default function NumberRangeDemo() {
 
   return (
     <div className="grid w-full max-w-md gap-8">
-      {/* Basic */}
+      {}
       <div className="grid gap-3">
         <div className="flex items-baseline justify-between">
           <Label>Price (USD)</Label>
@@ -42,7 +42,7 @@ export default function NumberRangeDemo() {
         </NumberRange>
       </div>
 
-      {/* Composed */}
+      {}
       <div className="grid gap-3">
         <div className="flex items-baseline justify-between">
           <Label>Age</Label>

--- a/registry/sabk/number-range/number-range.tsx
+++ b/registry/sabk/number-range/number-range.tsx
@@ -6,10 +6,6 @@ import { cn } from "@/lib/utils"
 import { Input } from "@/registry/sabk/ui/input"
 import { Slider } from "@/registry/sabk/ui/slider"
 
-/* ============================================================================
- * Types
- * ========================================================================== */
-
 export type NumberRangeValue = [number, number]
 
 export type NumberFormatter = (n: number) => string
@@ -42,10 +38,6 @@ function useNumberRange() {
   return ctx
 }
 
-/* ============================================================================
- * Helpers
- * ========================================================================== */
-
 function clamp(n: number, lo: number, hi: number) {
   return Math.min(hi, Math.max(lo, n))
 }
@@ -66,10 +58,6 @@ const defaultParse: NumberParser = (s) => {
   const n = Number(cleaned)
   return Number.isFinite(n) ? n : 0
 }
-
-/* ============================================================================
- * Root
- * ========================================================================== */
 
 export type NumberRangeProps = {
   value?: NumberRangeValue
@@ -143,10 +131,6 @@ function NumberRange({
   )
 }
 
-/* ============================================================================
- * Slider
- * ========================================================================== */
-
 function NumberRangeSlider({
   className,
   ...props
@@ -169,10 +153,6 @@ function NumberRangeSlider({
     />
   )
 }
-
-/* ============================================================================
- * Inputs
- * ========================================================================== */
 
 type NumberRangeInputProps = Omit<
   React.ComponentProps<typeof Input>,
@@ -251,10 +231,6 @@ function NumberRangeInput({
     </div>
   )
 }
-
-/* ============================================================================
- * Inputs pair (convenience for the common two-input row)
- * ========================================================================== */
 
 function NumberRangeInputs({
   className,

--- a/registry/sabk/password-input/password-input.demo.tsx
+++ b/registry/sabk/password-input/password-input.demo.tsx
@@ -15,7 +15,7 @@ export default function PasswordInputDemo() {
 
   return (
     <div className="grid w-full max-w-md gap-8">
-      {/* Basic */}
+      {}
       <div className="grid gap-2">
         <Label htmlFor="pw-basic">Password · with strength meter</Label>
         <PasswordInput id="pw-basic" value={basic} onValueChange={setBasic}>
@@ -24,7 +24,7 @@ export default function PasswordInputDemo() {
         </PasswordInput>
       </div>
 
-      {/* Composed */}
+      {}
       <div className="grid gap-2">
         <Label htmlFor="pw-composed">Password · custom strength hint</Label>
         <PasswordInput

--- a/registry/sabk/password-input/password-input.tsx
+++ b/registry/sabk/password-input/password-input.tsx
@@ -6,22 +6,14 @@ import { Eye, EyeOff } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Input } from "@/registry/sabk/ui/input"
 
-/* ============================================================================
- * Types & default scorer
- * ========================================================================== */
-
 export type PasswordStrength = {
-  /** Integer 0-4. */
   score: number
-  /** Short label (e.g. "weak"). */
   label: string
-  /** Optional hint shown next to the meter. */
   hint?: string
 }
 
 export type PasswordScorer = (value: string) => PasswordStrength
 
-/** Default scorer: counts length and character classes; produces a 0-4 score. */
 export const defaultPasswordScorer: PasswordScorer = (value) => {
   if (!value) return { score: 0, label: "empty" }
   let score = 0
@@ -46,10 +38,6 @@ export const defaultPasswordScorer: PasswordScorer = (value) => {
   return { score, label: labels[score], hint: hints[score] }
 }
 
-/* ============================================================================
- * Context
- * ========================================================================== */
-
 type Ctx = {
   id: string
   value: string
@@ -72,10 +60,6 @@ function usePasswordContext() {
   }
   return ctx
 }
-
-/* ============================================================================
- * Root
- * ========================================================================== */
 
 export type PasswordInputProps = {
   id?: string
@@ -132,10 +116,6 @@ function PasswordInput({
   )
 }
 
-/* ============================================================================
- * Field (the input + toggle)
- * ========================================================================== */
-
 type PasswordInputFieldProps = Omit<
   React.ComponentProps<"input">,
   "type" | "value" | "defaultValue" | "onChange" | "id"
@@ -185,10 +165,6 @@ function PasswordInputField({
   )
 }
 
-/* ============================================================================
- * Strength meter
- * ========================================================================== */
-
 const STRENGTH_COLORS = [
   "bg-destructive",
   "bg-destructive",
@@ -199,7 +175,6 @@ const STRENGTH_COLORS = [
 
 type PasswordInputStrengthProps = React.ComponentProps<"div"> & {
   showLabel?: boolean
-  /** Render a custom label/hint pair given the strength. */
   renderMeta?: (strength: PasswordStrength) => React.ReactNode
 }
 

--- a/registry/sabk/phone-input/phone-input.demo.tsx
+++ b/registry/sabk/phone-input/phone-input.demo.tsx
@@ -15,7 +15,7 @@ export default function PhoneInputDemo() {
 
   return (
     <div className="grid w-full max-w-md gap-8">
-      {/* Basic */}
+      {}
       <div className="grid gap-2">
         <Label htmlFor="ph-basic">Phone · default US</Label>
         <PhoneInput
@@ -32,7 +32,7 @@ export default function PhoneInputDemo() {
         </p>
       </div>
 
-      {/* Composed */}
+      {}
       <div className="grid gap-2">
         <Label htmlFor="ph-composed">Phone · pre-filled UK number</Label>
         <PhoneInput

--- a/registry/sabk/phone-input/phone-input.tsx
+++ b/registry/sabk/phone-input/phone-input.tsx
@@ -18,10 +18,6 @@ import {
   CommandList,
 } from "@/registry/sabk/ui/command"
 
-/* ============================================================================
- * Country data
- * ========================================================================== */
-
 export type Country = {
   iso2: string
   name: string
@@ -64,7 +60,6 @@ function digitsOnly(input: string): string {
   return input.replace(/\D/g, "")
 }
 
-/** Parse an incoming E.164-ish string into country + national digits. */
 function parseE164(
   value: string | undefined,
   fallback: Country
@@ -74,7 +69,6 @@ function parseE164(
   if (!trimmed.startsWith("+")) {
     return { country: fallback, national: digitsOnly(trimmed) }
   }
-  // Try the longest dial-code prefix first.
   const sorted = [...COUNTRIES].sort(
     (a, b) => b.dialCode.length - a.dialCode.length
   )
@@ -85,10 +79,6 @@ function parseE164(
   }
   return { country: fallback, national: digitsOnly(trimmed) }
 }
-
-/* ============================================================================
- * Context
- * ========================================================================== */
 
 type Ctx = {
   id: string
@@ -113,13 +103,6 @@ function usePhoneInput() {
   }
   return ctx
 }
-
-/* ============================================================================
- * Root
- *
- * The root renders the pill-style container itself; compose `<PhoneInputCountrySelect />`
- * and `<PhoneInputField />` as children.
- * ========================================================================== */
 
 export type PhoneInputProps = Omit<
   React.ComponentProps<"div">,
@@ -155,8 +138,6 @@ function PhoneInput({
 
   const initial = React.useMemo(
     () => parseE164(valueProp ?? defaultValue, fallback),
-    // Run once for defaults; controlled sync happens in effect below.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
 
@@ -166,7 +147,6 @@ function PhoneInput({
 
   const isControlled = valueProp !== undefined
 
-  // Sync from controlled value when it changes externally.
   const lastSeen = React.useRef<string | undefined>(valueProp)
   React.useEffect(() => {
     if (!isControlled) return
@@ -237,10 +217,6 @@ function PhoneInput({
   )
 }
 
-/* ============================================================================
- * Country select
- * ========================================================================== */
-
 type PhoneInputCountrySelectProps = Omit<
   React.ComponentProps<"button">,
   "children" | "type"
@@ -290,7 +266,6 @@ function PhoneInputCountrySelect({
         sideOffset={6}
         className="w-64 p-0"
         onOpenAutoFocus={(e) => {
-          // Let cmdk autofocus its input.
           e.preventDefault()
         }}
       >
@@ -328,10 +303,6 @@ function PhoneInputCountrySelect({
   )
 }
 
-/* ============================================================================
- * Field
- * ========================================================================== */
-
 type PhoneInputFieldProps = Omit<
   React.ComponentProps<"input">,
   "type" | "value" | "defaultValue" | "onChange" | "id"
@@ -356,13 +327,11 @@ function PhoneInputField({
       disabled={ctx.disabled}
       data-slot="phone-input-field"
       onChange={(e) => {
-        // Allow digits and spaces while typing; strip everything else.
         const cleaned = e.target.value.replace(/[^\d\s]/g, "")
         ctx.setNational(cleaned)
       }}
       onBlur={(e) => {
         onBlur?.(e)
-        // Normalize on blur: collapse whitespace.
         const normalized = ctx.national.replace(/\s+/g, " ").trim()
         if (normalized !== ctx.national) ctx.setNational(normalized)
       }}

--- a/registry/sabk/rating/rating.demo.tsx
+++ b/registry/sabk/rating/rating.demo.tsx
@@ -9,7 +9,7 @@ export default function RatingDemo() {
 
   return (
     <div className="grid w-full max-w-2xl gap-8">
-      {/* Whole-star interactive */}
+      {}
       <div className="grid gap-2">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           Interactive · whole stars
@@ -17,7 +17,7 @@ export default function RatingDemo() {
         <Rating defaultValue={4} aria-label="Overall rating" />
       </div>
 
-      {/* Half-star controlled */}
+      {}
       <div className="grid gap-2">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           Controlled · half steps
@@ -35,7 +35,7 @@ export default function RatingDemo() {
         </div>
       </div>
 
-      {/* Read-only with half star */}
+      {}
       <div className="grid gap-2">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           Read-only display
@@ -48,7 +48,7 @@ export default function RatingDemo() {
         </div>
       </div>
 
-      {/* Sizes */}
+      {}
       <div className="grid gap-2">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           Sizes

--- a/registry/sabk/rating/rating.tsx
+++ b/registry/sabk/rating/rating.tsx
@@ -5,10 +5,6 @@ import { Star } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-/* ============================================================================
- * Rating · star rating with hover, half-step and readOnly modes
- * ========================================================================== */
-
 export type RatingProps = Omit<
   React.ComponentProps<"div">,
   "onChange" | "defaultValue"
@@ -17,13 +13,11 @@ export type RatingProps = Omit<
   defaultValue?: number
   onValueChange?: (value: number) => void
   max?: number
-  /** Use 0.5 for half-star precision, 1 (default) for whole stars. */
   step?: 0.5 | 1
   readOnly?: boolean
   disabled?: boolean
   size?: "sm" | "md" | "lg"
   name?: string
-  /** Accessible label, e.g. "Rating". */
   "aria-label"?: string
 }
 
@@ -91,7 +85,7 @@ function Rating({
               interactive && "cursor-pointer"
             )}
           >
-            {/* base (empty) */}
+            {}
             <Star
               className={cn(
                 iconSize,
@@ -99,7 +93,7 @@ function Rating({
               )}
               aria-hidden
             />
-            {/* fill overlay */}
+            {}
             {(filled || half) && (
               <Star
                 className={cn(
@@ -111,7 +105,7 @@ function Rating({
               />
             )}
 
-            {/* hit targets */}
+            {}
             {interactive && step === 0.5 && (
               <>
                 <button

--- a/registry/sabk/registry-meta.ts
+++ b/registry/sabk/registry-meta.ts
@@ -60,17 +60,12 @@ export type RegistryEntryMeta = {
   description: string
   category: ComponentCategory
   status: "stable" | "planned"
-  /** Demo component, when status === "stable". */
   Demo?: React.ComponentType
-  /** Repo-relative paths of source files to surface in the Code tab. */
   sourceFiles?: string[]
-  /** Public install URL slug (defaults to `${name}`). */
   installSlug?: string
   registryDependencies?: string[]
   dependencies?: string[]
-  /** Block-only: the kind of section this block is, used for /blocks grouping. */
   blockKind?: BlockKind
-  /** Block-only: short tagline shown on the /blocks index cards. */
   blockTagline?: string
 }
 
@@ -255,7 +250,6 @@ export const REGISTRY: RegistryEntryMeta[] = [
     registryDependencies: [],
     dependencies: [],
   },
-  // ===== Blocks =====
   {
     name: "hero-01",
     title: "Hero · stat strip + install card",
@@ -494,7 +488,6 @@ export const REGISTRY: RegistryEntryMeta[] = [
     registryDependencies: ["button"],
     dependencies: ["lucide-react"],
   },
-  // ===== Phase 1 stubs — declared in registry.json, implementation pending =====
   {
     name: "month-picker",
     title: "Month Picker",

--- a/registry/sabk/scroll-progress/scroll-progress.tsx
+++ b/registry/sabk/scroll-progress/scroll-progress.tsx
@@ -4,19 +4,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-/* ============================================================================
- * ScrollProgress · fixed reading progress bar
- *
- * Pixel pipeline: scroll events drive a single rAF per frame that writes
- * `transform: scaleX(...)` straight to the DOM via ref — no React render
- * on scroll, no CSS transition fighting the compositor. The bar is
- * promoted to its own layer via `will-change: transform`.
- * ========================================================================== */
-
 export type ScrollProgressProps = React.ComponentProps<"div"> & {
-  /** Element to track. Defaults to document scroll. */
   target?: React.RefObject<HTMLElement | null>
-  /** Position. Defaults to "top". */
   position?: "top" | "bottom"
 }
 
@@ -48,7 +37,6 @@ function ScrollProgress({
         const max = doc.scrollHeight - doc.clientHeight
         progress = max > 0 ? doc.scrollTop / max : 0
       }
-      // Skip the write when the bar wouldn't visibly move (~sub-pixel).
       if (Math.abs(progress - lastProgress) < 0.001) return
       lastProgress = progress
       bar.style.transform = `scaleX(${progress})`

--- a/registry/sabk/stat-card/stat-card.demo.tsx
+++ b/registry/sabk/stat-card/stat-card.demo.tsx
@@ -10,7 +10,7 @@ import {
 export default function StatCardDemo() {
   return (
     <div className="grid w-full max-w-3xl gap-8">
-      {/* Basic */}
+      {}
       <div className="grid gap-2">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           3-up grid
@@ -39,7 +39,7 @@ export default function StatCardDemo() {
         </div>
       </div>
 
-      {/* Composed */}
+      {}
       <div className="grid gap-2">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           Custom layout

--- a/registry/sabk/stat-card/stat-card.tsx
+++ b/registry/sabk/stat-card/stat-card.tsx
@@ -5,15 +5,7 @@ import { Minus, TrendingDown, TrendingUp } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-/* ============================================================================
- * Types
- * ========================================================================== */
-
 export type StatCardTrend = "up" | "down" | "flat"
-
-/* ============================================================================
- * Root
- * ========================================================================== */
 
 type StatCardProps = React.ComponentProps<"div">
 
@@ -30,10 +22,6 @@ function StatCard({ className, ...props }: StatCardProps) {
   )
 }
 
-/* ============================================================================
- * Label
- * ========================================================================== */
-
 type StatCardLabelProps = React.ComponentProps<"p">
 
 function StatCardLabel({ className, ...props }: StatCardLabelProps) {
@@ -49,10 +37,6 @@ function StatCardLabel({ className, ...props }: StatCardLabelProps) {
   )
 }
 
-/* ============================================================================
- * Value
- * ========================================================================== */
-
 type StatCardValueProps = React.ComponentProps<"p">
 
 function StatCardValue({ className, ...props }: StatCardValueProps) {
@@ -67,10 +51,6 @@ function StatCardValue({ className, ...props }: StatCardValueProps) {
     />
   )
 }
-
-/* ============================================================================
- * Delta
- * ========================================================================== */
 
 type StatCardDeltaProps = Omit<React.ComponentProps<"span">, "children"> & {
   trend: StatCardTrend

--- a/registry/sabk/tag-input/tag-input.demo.tsx
+++ b/registry/sabk/tag-input/tag-input.demo.tsx
@@ -15,7 +15,7 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 export default function TagInputDemo() {
   const [basic, setBasic] = React.useState<string[]>(["typescript", "react"])
-  const [emails, setEmails] = React.useState<string[]>(["jane@sabk.dev"])
+  const [emails, setEmails] = React.useState<string[]>(["jane@forgecn.dev"])
 
   return (
     <div className="grid w-full max-w-md gap-8">

--- a/registry/sabk/tag-input/tag-input.demo.tsx
+++ b/registry/sabk/tag-input/tag-input.demo.tsx
@@ -19,7 +19,7 @@ export default function TagInputDemo() {
 
   return (
     <div className="grid w-full max-w-md gap-8">
-      {/* Basic */}
+      {}
       <div className="grid gap-2">
         <Label>Tags · max 6</Label>
         <TagInput value={basic} onValueChange={setBasic} maxTags={6}>
@@ -36,7 +36,7 @@ export default function TagInputDemo() {
         </p>
       </div>
 
-      {/* Composed */}
+      {}
       <div className="grid gap-2">
         <Label>Email tags · validated</Label>
         <TagInput

--- a/registry/sabk/tag-input/tag-input.tsx
+++ b/registry/sabk/tag-input/tag-input.tsx
@@ -6,10 +6,6 @@ import { X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Badge } from "@/registry/sabk/ui/badge"
 
-/* ============================================================================
- * Types
- * ========================================================================== */
-
 export type TagValidator = (
   candidate: string,
   current: string[]
@@ -29,9 +25,7 @@ type Ctx = {
   maxTags?: number
   caseSensitive: boolean
   validate?: TagValidator
-  /** Keys that commit the draft. */
   commitKeys: string[]
-  /** Characters that split a paste into multiple tags. */
   splitOn: RegExp
   inputRef: React.RefObject<HTMLInputElement | null>
 }
@@ -48,10 +42,6 @@ function useTagInput() {
   return ctx
 }
 
-/* ============================================================================
- * Root
- * ========================================================================== */
-
 export type TagInputProps = {
   value?: string[]
   defaultValue?: string[]
@@ -59,13 +49,10 @@ export type TagInputProps = {
   disabled?: boolean
   readOnly?: boolean
   maxTags?: number
-  /** Trim whitespace and dedupe inputs. Default: true. */
   unique?: boolean
   caseSensitive?: boolean
-  /** Returns true (accept) or an error message (reject). */
   validate?: TagValidator
   commitKeys?: string[]
-  /** Regex used to split pasted text into multiple tags. */
   splitOn?: RegExp
   children?: React.ReactNode
 }
@@ -192,10 +179,6 @@ function TagInput({
   )
 }
 
-/* ============================================================================
- * Container (the bordered chip area)
- * ========================================================================== */
-
 type TagInputContainerProps = React.ComponentProps<"div">
 
 function TagInputContainer({
@@ -232,12 +215,7 @@ function TagInputContainer({
   )
 }
 
-/* ============================================================================
- * Tag (chip)
- * ========================================================================== */
-
 type TagInputTagProps = Omit<React.ComponentProps<"span">, "children"> & {
-  /** Index of the tag in the value array. */
   index: number
   children?: React.ReactNode
 }
@@ -269,10 +247,6 @@ function TagInputTag({ index, children, className, ...props }: TagInputTagProps)
   )
 }
 
-/* ============================================================================
- * Tags (renders all current tags from context)
- * ========================================================================== */
-
 function TagInputTags() {
   const ctx = useTagInput()
   return (
@@ -283,10 +257,6 @@ function TagInputTags() {
     </>
   )
 }
-
-/* ============================================================================
- * Field (the inline input)
- * ========================================================================== */
 
 type TagInputFieldProps = Omit<
   React.ComponentProps<"input">,
@@ -362,10 +332,6 @@ function TagInputField({
     />
   )
 }
-
-/* ============================================================================
- * Error message
- * ========================================================================== */
 
 function TagInputError({
   className,

--- a/registry/sabk/timeline/timeline.demo.tsx
+++ b/registry/sabk/timeline/timeline.demo.tsx
@@ -15,7 +15,7 @@ import {
 export default function TimelineDemo() {
   return (
     <div className="grid w-full max-w-2xl gap-8">
-      {/* Basic dots */}
+      {}
       <div className="grid gap-3">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           Activity feed
@@ -64,7 +64,7 @@ export default function TimelineDemo() {
         </Timeline>
       </div>
 
-      {/* Icon dots */}
+      {}
       <div className="grid gap-3">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           With icons

--- a/registry/sabk/timeline/timeline.tsx
+++ b/registry/sabk/timeline/timeline.tsx
@@ -2,21 +2,6 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-/* ============================================================================
- * Timeline · vertical event timeline (compound)
- *
- *   <Timeline>
- *     <TimelineItem>
- *       <TimelineDot />
- *       <TimelineContent>
- *         <TimelineTitle>Shipped v1.4</TimelineTitle>
- *         <TimelineTime>Today · 14:02</TimelineTime>
- *         <TimelineDescription>...</TimelineDescription>
- *       </TimelineContent>
- *     </TimelineItem>
- *   </Timeline>
- * ========================================================================== */
-
 type TimelineProps = React.ComponentProps<"ol">
 
 function Timeline({ className, ...props }: TimelineProps) {
@@ -29,10 +14,6 @@ function Timeline({ className, ...props }: TimelineProps) {
   )
 }
 
-/* ============================================================================
- * Item · draws the connecting line via a pseudo-element on the dot column.
- * ========================================================================== */
-
 type TimelineItemProps = React.ComponentProps<"li">
 
 function TimelineItem({ className, ...props }: TimelineItemProps) {
@@ -41,7 +22,6 @@ function TimelineItem({ className, ...props }: TimelineItemProps) {
       data-slot="timeline-item"
       className={cn(
         "group relative flex gap-4 pb-6 last:pb-0",
-        // vertical rule, anchored under the dot
         "before:absolute before:left-[7px] before:top-4 before:bottom-0 before:w-px before:bg-border",
         "last:before:hidden",
         className
@@ -50,10 +30,6 @@ function TimelineItem({ className, ...props }: TimelineItemProps) {
     />
   )
 }
-
-/* ============================================================================
- * Dot · default marker. Pass children to render a custom icon.
- * ========================================================================== */
 
 type TimelineDotProps = Omit<React.ComponentProps<"span">, "children"> & {
   tone?: "default" | "muted" | "success" | "warning" | "danger"
@@ -102,10 +78,6 @@ function TimelineDot({
     />
   )
 }
-
-/* ============================================================================
- * Content · text column to the right of the dot.
- * ========================================================================== */
 
 type TimelineContentProps = React.ComponentProps<"div">
 

--- a/registry/sabk/ui/sidebar.tsx
+++ b/registry/sabk/ui/sidebar.tsx
@@ -200,7 +200,7 @@ function Sidebar({
       data-side={side}
       data-slot="sidebar"
     >
-      {/* gap on the sidebar side of the layout */}
+      {}
       <div
         data-slot="sidebar-gap"
         className={cn(

--- a/registry/sabk/year-picker/year-picker.demo.tsx
+++ b/registry/sabk/year-picker/year-picker.demo.tsx
@@ -19,7 +19,7 @@ export default function YearPickerDemo() {
 
   return (
     <div className="grid w-full max-w-md grid-cols-1 gap-8 sm:grid-cols-2">
-      {/* Basic */}
+      {}
       <div className="grid gap-2">
         <Label>Founded</Label>
         <YearPicker
@@ -36,7 +36,7 @@ export default function YearPickerDemo() {
         </p>
       </div>
 
-      {/* Composed */}
+      {}
       <div className="grid gap-2">
         <Label>Range</Label>
         <YearPicker

--- a/registry/sabk/year-picker/year-picker.tsx
+++ b/registry/sabk/year-picker/year-picker.tsx
@@ -11,10 +11,6 @@ import {
   PopoverTrigger,
 } from "@/registry/sabk/ui/popover"
 
-/* ============================================================================
- * Types
- * ========================================================================== */
-
 export type YearRange = { from: number; to?: number }
 export type YearPickerMode = "single" | "range"
 
@@ -58,15 +54,9 @@ function useYearPicker() {
   return ctx
 }
 
-/* ============================================================================
- * Root
- * ========================================================================== */
-
-const DECADE = 12 // 4x3 grid: anchor decade + 1 before + 1 after
+const DECADE = 12
 
 function decadeStartFor(year: number) {
-  // Anchor a decade as the 12-year block beginning at year - (year % 10) - 1.
-  // This way the current year sits in the visible row, with one buffer year.
   const base = year - (year % 10)
   return base - 1
 }
@@ -242,10 +232,6 @@ function YearPicker(props: YearPickerProps) {
   )
 }
 
-/* ============================================================================
- * Trigger
- * ========================================================================== */
-
 function formatYearValue(ctx: YearPickerContextValue, placeholder: string) {
   if (ctx.mode === "single") return ctx.value ? String(ctx.value) : placeholder
   if (!ctx.value) return placeholder
@@ -286,10 +272,6 @@ function YearPickerTrigger({
     </PopoverTrigger>
   )
 }
-
-/* ============================================================================
- * Content (decade grid)
- * ========================================================================== */
 
 function isInRange(year: number, range: YearRange | undefined) {
   if (!range || range.to === undefined) return false

--- a/scripts/strip-comments.mjs
+++ b/scripts/strip-comments.mjs
@@ -1,0 +1,128 @@
+// Strip comments from registry .ts/.tsx files using the TypeScript parser.
+// We walk the AST and collect every leading/trailing comment range, then
+// excise just those byte ranges from the original source. The parser is
+// fully JSX-aware, so URLs in JSX text and `{/* … */}` comments are
+// classified correctly.
+
+import * as fs from "node:fs/promises"
+import * as path from "node:path"
+import ts from "typescript"
+
+function collectCommentRanges(src, fileName) {
+  const sf = ts.createSourceFile(
+    fileName,
+    src,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  )
+  const seen = new Set()
+  const ranges = []
+
+  function push(rs) {
+    if (!rs) return
+    for (const r of rs) {
+      const key = `${r.pos}:${r.end}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      ranges.push([r.pos, r.end])
+    }
+  }
+
+  function visit(node) {
+    push(ts.getLeadingCommentRanges(src, node.getFullStart()))
+    push(ts.getTrailingCommentRanges(src, node.getEnd()))
+    ts.forEachChild(node, visit)
+  }
+  visit(sf)
+
+  // The parser doesn't always attach comments inside JSX children — sweep
+  // them manually with the scanner, only inside JSX expression containers.
+  // (Top-level block + line comments are already covered above.)
+  const scanner = ts.createScanner(
+    ts.ScriptTarget.Latest,
+    false,
+    ts.LanguageVariant.JSX,
+    src
+  )
+  function sweepExpression(start, end) {
+    scanner.setTextPos(start)
+    while (scanner.getTokenPos() < end) {
+      const t = scanner.scan()
+      if (t === ts.SyntaxKind.EndOfFileToken) break
+      if (
+        t === ts.SyntaxKind.SingleLineCommentTrivia ||
+        t === ts.SyntaxKind.MultiLineCommentTrivia
+      ) {
+        const p = scanner.getTokenPos()
+        const e = scanner.getTokenEnd()
+        if (p >= start && e <= end) {
+          const key = `${p}:${e}`
+          if (!seen.has(key)) {
+            seen.add(key)
+            ranges.push([p, e])
+          }
+        }
+      }
+    }
+  }
+  function visitJsx(node) {
+    if (ts.isJsxExpression(node)) {
+      sweepExpression(node.getStart(sf), node.getEnd())
+    }
+    ts.forEachChild(node, visitJsx)
+  }
+  visitJsx(sf)
+
+  return ranges
+}
+
+function stripComments(src, fileName) {
+  const ranges = collectCommentRanges(src, fileName)
+  if (ranges.length === 0) return src
+
+  ranges.sort((a, b) => b[0] - a[0])
+  let out = src
+  for (const [start, end] of ranges) {
+    let from = start
+    let to = end
+    const lineStart = out.lastIndexOf("\n", from - 1) + 1
+    const before = out.slice(lineStart, from)
+    if (/^\s*$/.test(before)) {
+      from = lineStart
+      if (out[to] === "\n") to = to + 1
+    } else {
+      const trimmed = before.replace(/\s+$/, "")
+      from = lineStart + trimmed.length
+    }
+    out = out.slice(0, from) + out.slice(to)
+  }
+
+  out = out.replace(/\n{3,}/g, "\n\n")
+  if (!out.endsWith("\n")) out += "\n"
+  return out
+}
+
+async function walk(dir, acc = []) {
+  const ents = await fs.readdir(dir, { withFileTypes: true })
+  for (const e of ents) {
+    const p = path.join(dir, e.name)
+    if (e.isDirectory()) await walk(p, acc)
+    else if (e.isFile() && (e.name.endsWith(".ts") || e.name.endsWith(".tsx")))
+      acc.push(p)
+  }
+  return acc
+}
+
+const root = process.argv[2] ?? "registry/sabk"
+const files = await walk(root)
+let changed = 0
+for (const f of files) {
+  const src = await fs.readFile(f, "utf8")
+  const next = stripComments(src, f)
+  if (next !== src) {
+    await fs.writeFile(f, next, "utf8")
+    changed++
+  }
+}
+console.log(`stripped ${changed} / ${files.length} files`)


### PR DESCRIPTION
## Summary
Complete rebrand of the project from "Sabk" to "msh ui" with a new public-facing landing page, updated site configuration, and refreshed branding throughout the codebase.

## Key Changes

### New Landing Page
- Added `app/page.tsx` with a comprehensive marketing landing page featuring:
  - Hero section with version badge and installation instructions
  - Features showcase highlighting key differentiators (copy-paste distribution, accessibility, theming, etc.)
  - Statistics strip showing component and block counts
  - Component preview sections organized by category
  - Code composition example with syntax highlighting
  - Section blocks preview
  - Call-to-action sections

### Site Configuration & Branding
- Created `lib/site.ts` as single source of truth for:
  - Site name, description, and version
  - Author information and social links
  - GitHub repository details (owner: MohammadShehadeh, repo: forgecn)
  - Registry configuration with new domain (forgecn.dev)
  - Navigation links
- Updated `package.json` name from "sabk" to "msh-ui"
- Updated `registry.json` with new registry name and homepage URL

### New Showcase Components
- Added `components/showcase/site-header.tsx` - sticky header with navigation and theme toggle
- Added `components/showcase/site-footer.tsx` - footer with links and copyright
- Added `components/showcase/github-stars.tsx` - GitHub stars display with caching
- Added `components/showcase/logo.tsx` - Logo components (Logo, LogoMark, LogoLockup)
- Added `components/showcase/topbar.tsx` - Topbar for showcase pages
- Updated `components/showcase/theme-toggle.tsx` - Theme switcher component

### Layout & Navigation Updates
- Updated `app/(showcase)/layout.tsx` to use new topbar and footer components
- Updated `app/(showcase)/components/page.tsx` with new metadata
- Updated `components/showcase/sidebar.tsx` to use new LogoMark component
- Updated `app/layout.tsx` to use centralized SITE configuration

### Content & Copy Updates
- Updated all block components (hero, feature, pricing, testimonial, CTA, FAQ, login, footer) to reference "msh ui" instead of "Sabk"
- Updated README.md with new branding and domain
- Updated metadata titles and descriptions across showcase pages
- Updated storage keys and configuration references from "sabk" to "msh-ui"

### Domain & URL Changes
- Changed primary domain from sabk.dev to forgecn.dev
- Updated all installation command examples
- Updated GitHub URLs to point to MohammadShehadeh/forgecn repository

## Notable Implementation Details
- Landing page uses async code highlighting for the composition example
- GitHub stars component implements client-side caching with 30-minute TTL
- Site configuration is centralized and imported throughout the app for consistency
- New header/footer components are reusable across showcase pages
- Logo component includes fallback text rendering if external image fails to load

https://claude.ai/code/session_01PPWhmS6iJ7bfh3dbCti5Kx