### PR TITLE
docs: add CONTRIBUTING.md and expand README with project structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,300 @@
+# Contributing to forgecn
+
+Thanks for taking the time to contribute — forgecn is small, opinionated,
+and benefits from every well-scoped PR. This guide covers the dev
+workflow, the conventions we follow, and the checklist for shipping a
+new component or block.
+
+By participating you agree to abide by the project's Code of Conduct.
+
+> **TODO** — link to `CODE_OF_CONDUCT.md` once committed.
+
+## Table of contents
+
+- [Setting up the dev environment](#setting-up-the-dev-environment)
+- [Project layout](#project-layout)
+- [Branch and commit conventions](#branch-and-commit-conventions)
+- [Coding standards](#coding-standards)
+- [Component contribution checklist](#component-contribution-checklist)
+- [Testing requirements](#testing-requirements)
+- [Pull request process](#pull-request-process)
+- [Issue workflow](#issue-workflow)
+- [Reporting security issues](#reporting-security-issues)
+
+## Setting up the dev environment
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org) **20+**
+- [pnpm](https://pnpm.io) **8+** (the repo ships `pnpm-lock.yaml`; do
+  not switch package managers in a PR)
+
+### First-time setup
+
+```bash
+git clone https://github.com/MohammadShehadeh/forgecn.git
+cd forgecn
+pnpm install
+pnpm dev          # showcase site at http://localhost:3000
+```
+
+### Validating an install end-to-end
+
+To confirm a registry item installs cleanly into a consumer project:
+
+```bash
+pnpm registry:build                # emits /public/r/<name>.json
+pnpm dev                            # serve /r/<name>.json locally
+
+# in a separate consumer app that already has shadcn installed
+npx shadcn@latest add http://localhost:3000/r/<name>.json
+```
+
+Resolving `registryDependencies` reaches out to `ui.shadcn.com`, so the
+machine running the consumer install must have network access to that
+host.
+
+## Project layout
+
+```
+registry/sabk/
+  <component>/
+    <component>.tsx          # source (flat compound exports)
+    <component>.demo.tsx     # showcase demo
+    index.ts                 # re-export
+  ui/                        # shadcn primitives the registry imports from
+  blocks/<block>/            # marketing blocks
+  registry-meta.ts           # showcase metadata for sidebar / pages
+registry.json                # canonical declaration of every item
+```
+
+See the top-level **[README.md](./README.md)** for a full directory
+tour.
+
+## Branch and commit conventions
+
+### Branches
+
+Work on a topic branch off `main`:
+
+```
+<type>/<short-kebab-description>
+```
+
+Examples:
+
+- `feat/month-picker`
+- `fix/multi-select-keyboard-nav`
+- `docs/contributing-guide`
+- `refactor/registry-meta-types`
+
+Avoid long-lived branches — rebase on `main` frequently and keep PRs
+focused.
+
+### Commit messages — Conventional Commits
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/)
+so the history is scannable and ready for tooling. The format is:
+
+```
+<type>(<optional scope>): <imperative summary>
+
+<optional body>
+
+<optional footer(s)>
+```
+
+| Type       | When to use                                                   |
+| ---------- | ------------------------------------------------------------- |
+| `feat`     | New component, block, prop, public surface area               |
+| `fix`      | Bug fix in a component, block, or the showcase site           |
+| `docs`     | README, CONTRIBUTING, comments, JSDoc                         |
+| `style`    | Formatting only — no behavior change                          |
+| `refactor` | Internal rework with no externally visible change             |
+| `perf`     | Performance improvement                                       |
+| `test`     | Adding or correcting tests                                    |
+| `build`    | Build pipeline, Tailwind config, `tsconfig`, deps             |
+| `ci`       | GitHub Actions and other CI                                   |
+| `chore`    | Maintenance with no production impact                         |
+| `revert`   | Revert a prior commit                                         |
+
+Scope is optional but encouraged — use the component or area name:
+
+```
+feat(multi-select): add async loader prop
+fix(phone-input): correct E.164 normalization for short numbers
+docs(readme): document NEXT_PUBLIC_BASE_URL
+```
+
+Breaking changes — add `!` after the type and a `BREAKING CHANGE:`
+footer:
+
+```
+feat(multi-select)!: rename `onChange` to `onValueChange`
+
+BREAKING CHANGE: `MultiSelect` now exposes `onValueChange` to match the
+shadcn convention. Consumers using `onChange` must rename the prop.
+```
+
+Keep the subject line ≤ 72 characters and in the imperative mood
+("add", not "added"/"adds").
+
+## Coding standards
+
+### TypeScript
+
+- `tsconfig.json` runs in **strict** mode — no implicit `any`, no
+  ignored errors. Fix the type, don't widen it.
+- Prefer named exports. Default exports are reserved for Next.js route
+  files and page-level components.
+- Use the `@/` path alias instead of relative `../../` chains.
+
+### Linting and formatting
+
+```bash
+pnpm lint        # ESLint via next/core-web-vitals + next/typescript
+pnpm typecheck   # tsc --noEmit
+```
+
+The repo does not enforce a separate formatter. Match the surrounding
+code (2-space indent, double-quoted strings, no semicolons at the end
+of statements is the prevailing style in `registry/sabk/`). If your
+editor disagrees, reset its formatter on this repo rather than
+reformatting committed files.
+
+### Component conventions
+
+- **Flat compound exports.** Compose like shadcn — no namespacing,
+  no convenience wrappers. The bare component name is the root
+  primitive and holds the state.
+- **`data-slot`.** Every rendered slot carries `data-slot="<kebab>"`
+  so downstream styling and slot-targeting just works.
+- **Imports for shadcn primitives** go through `@/registry/sabk/ui/*`.
+  The alias is rewritten on install based on the consumer's
+  `components.json`.
+- **Tokens.** Use `--background / --foreground / --border / --primary /
+  --accent` and the rest of the design tokens — never hard-code a
+  color. Light is a faithful inverse of dark; both must work.
+- **`cn` helper.** Compose class names with `cn(...)` from
+  `@/lib/utils`. Don't ad-hoc-concatenate `className` strings.
+- **Comments.** Comments in registry source are stripped by
+  `scripts/strip-comments.mjs` before publishing. Keep helpful
+  reasoning in commit messages, PR descriptions, or design docs —
+  not in shipped source.
+
+## Component contribution checklist
+
+For each new component:
+
+- [ ] Source file at `registry/sabk/<name>/<name>.tsx` exporting the
+      compound parts as flat top-level named exports (`Name`,
+      `NameTrigger`, `NameContent`, …). No namespacing, no convenience
+      wrappers. The bare `Name` is the root primitive and holds state.
+- [ ] Every rendered slot carries `data-slot="<kebab>"`.
+- [ ] `<name>.demo.tsx` showing a basic compose **and** a customized
+      compose.
+- [ ] `index.ts` re-export.
+- [ ] Entry in `registry.json` with `type: "registry:ui"`,
+      `dependencies`, `registryDependencies`,
+      `files[].target = "components/ui/<name>.tsx"`.
+- [ ] Entry in `registry/sabk/registry-meta.ts` with category, demo,
+      and source file list.
+- [ ] All imports for shadcn primitives go through
+      `@/registry/sabk/ui/*` (alias is rewritten on install).
+- [ ] Tokens reuse `--background / --foreground / --border /
+      --primary / --accent` and friends — never hard-code colors.
+- [ ] `pnpm lint && pnpm typecheck && pnpm registry:build && pnpm build`
+      clean.
+
+Marketing blocks follow the same shape but live under
+`registry/sabk/blocks/<block>/` and have a `blockKind` plus
+`blockTagline` in `registry-meta.ts`.
+
+## Testing requirements
+
+forgecn does not ship a unit-test suite today — the gating signal is
+the build pipeline:
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm registry:build
+pnpm build
+```
+
+All four must pass before requesting review. For component PRs you are
+also expected to:
+
+1. Visit the showcase page at
+   `http://localhost:3000/components/<name>` and exercise the demo.
+2. Confirm `npx shadcn@latest add http://localhost:3000/r/<name>.json`
+   succeeds in a separate consumer app (see
+   [Validating an install end-to-end](#validating-an-install-end-to-end)).
+3. Verify the component renders correctly in **both** light and dark
+   themes — toggle from the showcase header.
+4. Spot-check keyboard navigation and screen-reader output for any
+   interactive component.
+
+> **TODO** — automated unit and visual-regression tests are not yet
+> set up. A future PR is expected to introduce a test runner; until
+> then, the build pipeline plus the manual checks above are the
+> contract.
+
+## Pull request process
+
+1. **Open an issue first** for non-trivial work so we can agree on the
+   shape before code lands (see
+   [Issue workflow](#issue-workflow)). Small fixes and doc edits can
+   skip this.
+2. **Branch off `main`** using the
+   [branch convention](#branches) above.
+3. **Keep the PR focused.** One component, one fix, one refactor — not
+   all three at once.
+4. **Complete the
+   [component contribution checklist](#component-contribution-checklist)**
+   when adding a component.
+5. **Run the full build pipeline locally** — `pnpm lint && pnpm
+   typecheck && pnpm registry:build && pnpm build`.
+6. **Open the PR** with:
+   - a clear title in Conventional Commit format,
+   - a short summary of the change and the motivation,
+   - screenshots or short clips for any UI work,
+   - a manual test plan describing what you exercised.
+7. **Address review feedback** with follow-up commits — do not
+   force-push during review unless asked. Squash on merge keeps the
+   history clean.
+8. Maintainers will merge once CI is green and the checklist is met.
+
+## Issue workflow
+
+> **TODO** — issue templates under `.github/ISSUE_TEMPLATE/` are not
+> yet committed. Until they land, please follow the conventions
+> below.
+
+- **Bug reports** should include: the component or block, the
+  reproduction steps, the expected vs actual behavior, your Node
+  version, browser, and a minimal repro repo or CodeSandbox where
+  possible.
+- **Feature requests** should explain the user problem first, then
+  propose the API. Reference existing shadcn or Radix conventions
+  where relevant.
+- **Component proposals** should reference the shadcn convention you
+  expect to follow, list the `registryDependencies` you anticipate,
+  and sketch the compound surface area.
+- **Triage labels** are applied by maintainers — please do not assign
+  labels yourself.
+
+## Reporting security issues
+
+Please do **not** open a public GitHub issue for security
+vulnerabilities. Follow the private disclosure process documented in
+**[SECURITY.md](./SECURITY.md)**.
+
+> **TODO** — `SECURITY.md` is not yet committed. Until it lands,
+> contact the maintainer privately via the email listed on
+> [mohammadshehadeh.com](https://mohammadshehadeh.com).
+
+---
+
+Thanks again for contributing — every well-scoped PR makes forgecn
+sharper.

--- a/README.md
+++ b/README.md
@@ -5,23 +5,185 @@
 Multi-select, number range, year picker, tag input, phone input,
 file dropzone, the lot.
 
+[![Next.js](https://img.shields.io/badge/Next.js-15-000?logo=nextdotjs&logoColor=white)](https://nextjs.org)
+[![React](https://img.shields.io/badge/React-19-149eca?logo=react&logoColor=white)](https://react.dev)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
+[![Tailwind CSS](https://img.shields.io/badge/Tailwind-4-38bdf8?logo=tailwindcss&logoColor=white)](https://tailwindcss.com)
+[![shadcn registry](https://img.shields.io/badge/shadcn-registry-000)](https://ui.shadcn.com/docs/registry)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](#license)
+
 ```bash
 npx shadcn@latest add https://forgecn.dev/r/multi-select.json
 ```
 
-## Positioning
+## Why forgecn
 
 - **Peer of shadcn.** You must have shadcn installed first. forgecn
   components import from `@/components/ui/*` (Button, Input, Popover,
   Command, …) just like shadcn's own composed blocks do.
 - **Distributed via the shadcn registry schema.** No runtime dependency
-  on an forgecn package — source is copied straight into your repo.
+  on a forgecn package — source is copied straight into your repo.
 - **Modern shadcn polish.** 1px soft borders, 0.65rem radius scale
   (sm/md/lg/xl derived from `--radius`), zinc neutrals, dark as primary
   canvas, no chromatic accent — primary draws the eye. Geist Sans for
   body, Geist Mono reserved for code and identifiers.
 
-## Composition (shadcn-style)
+## Features
+
+- **Form inputs** — MultiSelect, NumberRange, TagInput, Combobox,
+  PasswordInput, CurrencyInput, PhoneInput, Rating.
+- **Pickers** — YearPicker (MonthPicker, TimePicker, ColorPicker
+  planned).
+- **Files** — FileDropzone with previews and validation.
+- **Data display** — StatCard, Timeline.
+- **Display utilities** — Kbd, Callout, ScrollProgress.
+- **Marketing blocks** — Hero, Feature, Pricing, Testimonial, CTA,
+  FAQ, Login, Header, Footer, Not-Found variants.
+- **Flat compound APIs** — same composition style shadcn ships, with a
+  `data-slot="…"` attribute on every rendered slot for downstream
+  styling.
+- **Design-token driven** — tokens reuse `--background / --foreground /
+  --border / --primary / --accent` and friends, never hard-coded colors.
+
+## Tech stack
+
+- [Next.js 15](https://nextjs.org) (App Router, Turbopack)
+- [React 19](https://react.dev)
+- [TypeScript 5](https://www.typescriptlang.org) — strict mode
+- [Tailwind CSS 4](https://tailwindcss.com) via `@tailwindcss/postcss`
+- [shadcn CLI](https://ui.shadcn.com) — registry build + install
+- [Radix UI](https://www.radix-ui.com) primitives
+- [cmdk](https://cmdk.paco.me) for command palettes
+- [Shiki](https://shiki.style) for syntax highlighting
+- [Lucide](https://lucide.dev) icons
+- [Geist Sans / Geist Mono / Fraunces](https://vercel.com/font) via
+  `next/font`
+- [Zod](https://zod.dev) for schemas
+- pnpm (workspace lockfile committed)
+
+## Components
+
+| Component        | Category | Status   | Registry deps                          |
+| ---------------- | -------- | -------- | -------------------------------------- |
+| MultiSelect      | inputs   | stable   | `button`, `popover`, `command`, `badge`|
+| NumberRange      | inputs   | stable   | `slider`, `input`, `label`             |
+| TagInput         | inputs   | stable   | `badge`                                |
+| Combobox         | inputs   | stable   | `button`, `popover`, `command`         |
+| PasswordInput    | inputs   | stable   | `input`                                |
+| CurrencyInput    | inputs   | stable   | `input`                                |
+| PhoneInput       | inputs   | stable   | `input`, `popover`, `command`          |
+| Rating           | inputs   | stable   | —                                      |
+| YearPicker       | pickers  | stable   | `button`, `popover`                    |
+| MonthPicker      | pickers  | planned  | `button`, `popover`                    |
+| TimePicker       | pickers  | planned  | `button`, `popover`, `input`           |
+| ColorPicker      | pickers  | planned  | `button`, `popover`, `input`           |
+| FileDropzone     | files    | stable   | `button`                               |
+| StatCard         | data     | stable   | —                                      |
+| Timeline         | data     | stable   | —                                      |
+| Kbd              | display  | stable   | —                                      |
+| Callout          | display  | stable   | —                                      |
+| ScrollProgress   | display  | stable   | —                                      |
+
+Marketing blocks (Hero, Feature, Pricing, Testimonial, CTA, FAQ,
+Login, Header, Footer, NotFound) live under `registry/sabk/blocks/`
+and are listed in `registry.json`. Browse them at
+[forgecn.dev/blocks](https://forgecn.dev/blocks).
+
+## Project structure
+
+```
+forgecn/
+├── app/                          # Next.js App Router
+│   ├── (showcase)/               # sidebar + main column
+│   │   ├── components/page.tsx   # component index
+│   │   ├── blocks/[block]/       # per-block preview
+│   │   └── theme/playground.tsx  # theme playground
+│   ├── embed/blocks/             # framed block previews
+│   ├── layout.tsx
+│   ├── globals.css               # design tokens (zinc, 0.65rem radius)
+│   └── page.tsx                  # landing
+├── components/showcase/          # site chrome (not part of the registry)
+├── registry/
+│   └── sabk/                     # canonical source for every registry item
+│       ├── ui/                   # shadcn primitives the registry imports from
+│       ├── <component>/          # *.tsx, *.demo.tsx, index.ts
+│       ├── blocks/<block>/       # marketing blocks
+│       └── registry-meta.ts      # showcase metadata for sidebar / pages
+├── hooks/                        # shared client hooks
+├── lib/                          # site config, theme, package-manager helpers
+├── scripts/strip-comments.mjs    # strip comments from registry source
+├── public/r/                     # generated by `pnpm registry:build` (gitignored)
+├── registry.json                 # canonical declaration of every item
+└── components.json               # shadcn config; `ui` alias → registry/sabk/ui
+```
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org) **20+**
+- [pnpm](https://pnpm.io) **8+** (lockfile is `pnpm-lock.yaml`)
+
+## Installation
+
+```bash
+git clone https://github.com/MohammadShehadeh/forgecn.git
+cd forgecn
+pnpm install
+```
+
+## Local development
+
+```bash
+pnpm dev              # start the showcase site at http://localhost:3000
+pnpm registry:build   # emit /public/r/<name>.json from registry.json
+```
+
+To validate a registry item end-to-end against a real consumer
+project:
+
+```bash
+# in a separate consumer app (must have shadcn installed)
+npx shadcn@latest add http://localhost:3000/r/<name>.json
+```
+
+Resolving `registryDependencies` reaches out to `ui.shadcn.com`, so the
+machine must have network access to that host.
+
+### Consuming from a published deployment
+
+```bash
+npx shadcn@latest add https://forgecn.dev/r/multi-select.json
+```
+
+The shadcn CLI fetches each `registryDependency` from the upstream
+shadcn registry, installs the listed npm dependencies, and copies the
+source file into your project — rewriting alias-prefixed imports to
+match your `components.json`.
+
+## Available scripts
+
+| Script                 | What it does                                              |
+| ---------------------- | --------------------------------------------------------- |
+| `pnpm dev`             | Next.js dev server with Turbopack on port 3000            |
+| `pnpm build`           | `registry:build` then `next build`                        |
+| `pnpm start`           | Serve the production build                                |
+| `pnpm lint`            | ESLint via `next lint` (`next/core-web-vitals` + TS)      |
+| `pnpm typecheck`       | `tsc --noEmit`                                            |
+| `pnpm registry:build`  | `shadcn build` — generates `/public/r/<name>.json`        |
+
+## Configuration
+
+Environment variables are optional and read at runtime in the
+showcase site.
+
+| Variable               | Used in                            | Default                                | Notes                                                                                              |
+| ---------------------- | ---------------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_BASE_URL` | `components/showcase/install-block.tsx` | `window.location.origin` at runtime    | Override the public origin used when generating `npx shadcn add <origin>/r/<name>.json` snippets.  |
+
+`registry.json` (`homepage`) and `lib/site.ts` (`SITE.registry.origin`)
+hold the canonical published origin — update both if the project moves
+to a new domain.
+
+## Usage examples
 
 Every compound component ships as flat top-level exports — no
 namespacing, no convenience wrappers. Compose the way shadcn ships
@@ -44,105 +206,19 @@ The bare component name is the root primitive (it holds the state).
 Each part renders with a `data-slot="…"` attribute so downstream
 styling and slot-targeting works out of the box.
 
-## Phase 1 — Form inputs
-
-| Component        | Status   | Registry deps                          |
-| ---------------- | -------- | -------------------------------------- |
-| MultiSelect      | stable   | `button`, `popover`, `command`, `badge`|
-| NumberRange      | stable   | `slider`, `input`, `label`             |
-| YearPicker       | stable   | `button`, `popover`                    |
-| TagInput         | stable   | `badge`                                |
-| Combobox         | stable   | `button`, `popover`, `command`         |
-| PasswordInput    | stable   | `input`                                |
-| CurrencyInput    | stable   | `input`                                |
-| PhoneInput       | stable   | `input`, `popover`, `command`          |
-| FileDropzone     | stable   | `button`                               |
-| StatCard         | stable   | —                                      |
-| MonthPicker      | planned  | `button`, `popover`                    |
-| TimePicker       | planned  | `button`, `popover`, `input`           |
-| ColorPicker      | planned  | `button`, `popover`, `input`           |
-
-Phase 2 (Data display) — DataTable, TreeView, Timeline, Stepper,
-KanbanBoard, Calendar, RatingInput, AvatarStack, EmptyState, CopyButton,
-JsonViewer, DiffViewer, Breadcrumb, CommandPalette — not in this cut.
-
-## Repository layout
-
-```
-forgecn/
-  app/
-    page.tsx                   # landing
-    (showcase)/
-      components/page.tsx      # full component index
-      [component]/page.tsx     # per-component page: preview · code · install
-      layout.tsx               # sidebar + main column
-    layout.tsx
-    globals.css                # design tokens (zinc, 0.65rem radius)
-  components/
-    showcase/                  # shell-only chrome, not part of the registry
-  registry/
-    sabk/
-      ui/                      # shadcn primitives forgecn imports from
-      multi-select/
-        multi-select.tsx         # component, flat compound exports
-        multi-select.demo.tsx
-        index.ts
-      number-range/
-      year-picker/
-      registry-meta.ts         # showcase metadata for sidebar / pages
-  public/r/                    # generated; gitignored
-  registry.json                # canonical declaration of every item
-  components.json              # shadcn config; `ui` alias → registry/sabk/ui
-```
-
-## Scripts
-
-```bash
-pnpm dev               # showcase site, http://localhost:3000
-pnpm registry:build    # emit /public/r/<name>.json from registry.json
-pnpm build             # registry:build && next build
-pnpm typecheck
-```
-
-## How install works
+### How install works
 
 1. `registry.json` declares each item: name, dependencies (npm packages),
-   registryDependencies (shadcn primitives), and source file paths.
+   `registryDependencies` (shadcn primitives), and source file paths.
 2. `pnpm registry:build` (the `shadcn build` CLI) reads `registry.json`,
    inlines source file contents into `/public/r/<name>.json`, and writes
    `target: components/ui/<name>.tsx` so the consumer's shadcn CLI knows
    where to drop the file.
-3. A consumer runs `npx shadcn add https://forgecn.dev/r/<name>.json`. The
-   shadcn CLI fetches each registryDependency from the upstream shadcn
-   registry, installs the listed npm dependencies, and copies the source
-   file — rewriting alias-prefixed imports to match the consumer's
+3. A consumer runs `npx shadcn add https://forgecn.dev/r/<name>.json`.
+   The shadcn CLI fetches each `registryDependency` from the upstream
+   shadcn registry, installs the listed npm dependencies, and copies the
+   source file — rewriting alias-prefixed imports to match the consumer's
    `components.json`.
-
-Local install can be validated with `npx shadcn add http://localhost:3000/r/<name>.json`
-from a separate consumer project (requires reachable `ui.shadcn.com`
-to resolve registry dependencies).
-
-## Contribution checklist
-
-For each new component:
-
-- [ ] Source file at `registry/sabk/<name>/<name>.tsx` exporting the
-      compound parts as flat top-level named exports (`Name`, `NameTrigger`,
-      `NameContent`, …). No namespacing, no convenience wrappers. The
-      bare `Name` is the root primitive and holds state.
-- [ ] Every rendered slot carries `data-slot="<kebab>"` so downstream
-      styling and slot-targeting just works.
-- [ ] `Name.demo.tsx` showing a basic compose + a customized compose.
-- [ ] `index.ts` re-export.
-- [ ] Entry in `registry.json` with `type: "registry:ui"`, `dependencies`,
-      `registryDependencies`, `files[].target = "components/ui/<name>.tsx"`.
-- [ ] Entry in `registry/sabk/registry-meta.ts` with category, demo,
-      and source file list.
-- [ ] All imports for shadcn primitives go through `@/registry/sabk/ui/*`
-      (alias is rewritten on install).
-- [ ] Tokens reuse `--background / --foreground / --border / --primary / --accent`
-      and friends — never hard-code colors.
-- [ ] `pnpm registry:build && pnpm typecheck && pnpm build` clean.
 
 ## Design tokens
 
@@ -155,6 +231,38 @@ xl = radius + 4px). Geist Sans is the default body face; Geist Mono is
 reserved for code, install commands, and identifiers. Motion stays
 short (120–180ms, ease-out).
 
+## Deployment
+
+The showcase site is a standard Next.js 15 App Router app. `pnpm build`
+runs `registry:build` first so the generated `/public/r/*.json` files
+travel with the build, then runs `next build`. `pnpm start` serves the
+production output.
+
+The canonical deployment runs at [forgecn.dev](https://forgecn.dev).
+`.vercel` is gitignored, so Vercel-style deployment is supported out of
+the box; any host that runs a Next.js production server will work.
+
+> **TODO** — document hosting-specific build, env, and domain
+> configuration once the production deployment pipeline is finalized.
+
+## Contributing
+
+Contributions are welcome — please read
+**[CONTRIBUTING.md](./CONTRIBUTING.md)** before opening a PR. It covers
+the development workflow, commit conventions, the component
+contribution checklist, and the PR review process.
+
+## Security
+
+If you discover a security issue, please follow the disclosure process
+in **[SECURITY.md](./SECURITY.md)** rather than opening a public issue.
+
+> **TODO** — `SECURITY.md` is not yet committed; add it before the
+> first public release.
+
 ## License
 
 MIT — © Mohammad Shehadeh
+
+> **TODO** — add a top-level `LICENSE` file containing the full MIT
+> license text.


### PR DESCRIPTION
## Summary

This PR establishes comprehensive contributor documentation and significantly expands the README to serve as a complete project guide. It adds a new `CONTRIBUTING.md` file covering the development workflow, coding standards, and contribution process, while reorganizing and extending the README with detailed project structure, tech stack, component inventory, and deployment information.

## Key changes

- **New `CONTRIBUTING.md`** — Complete contributor guide including:
  - Dev environment setup (Node.js 20+, pnpm 8+)
  - Project layout and directory structure
  - Branch and commit conventions (Conventional Commits format)
  - Coding standards (TypeScript strict mode, component conventions, `data-slot` attributes)
  - Component contribution checklist with all required artifacts
  - Testing requirements and manual validation steps
  - Pull request process and issue workflow
  - Security disclosure guidelines

- **Expanded `README.md`** — Reorganized and extended with:
  - Technology badges (Next.js 15, React 19, TypeScript 5, Tailwind 4, shadcn registry, MIT license)
  - "Why forgecn" section clarifying positioning as a shadcn peer
  - Comprehensive features list organized by category (form inputs, pickers, files, data display, utilities, blocks)
  - Full tech stack documentation (dependencies and tools)
  - Component inventory table with status and registry dependencies
  - Detailed project structure diagram
  - Prerequisites and installation instructions
  - Local development workflow with registry validation
  - Available scripts reference table
  - Configuration section documenting environment variables
  - Deployment guidance
  - Contributing and security sections with links to new docs
  - Multiple TODO markers for future documentation (CODE_OF_CONDUCT.md, SECURITY.md, LICENSE file)

## Notable details

- Both documents follow the project's Conventional Commits convention and coding standards
- CONTRIBUTING.md includes specific guidance on the `data-slot` attribute pattern, token reuse, and the comment-stripping build step
- README now serves as a single source of truth for project overview, setup, and contribution entry point
- Documentation emphasizes the flat compound export pattern and design-token-driven approach that differentiates forgecn from other component libraries

https://claude.ai/code/session_01Nzw5wCFj7QMSG563pK2fEv