### PR TITLE
Add "Usage" tab to component pages showing demo source code

### DIFF
--- a/app/(showcase)/[component]/page.tsx
+++ b/app/(showcase)/[component]/page.tsx
@@ -57,6 +57,29 @@ async function loadSource(
   return out
 }
 
+/**
+ * Convention: each component ships `<name>.tsx` alongside `<name>.demo.tsx`
+ * in the same directory. The demo source powers the "Usage" tab.
+ * Returns null when the demo file isn't present so the tab can be hidden.
+ */
+async function loadDemoSource(
+  entry: { sourceFiles?: string[] }
+): Promise<SourceFile | null> {
+  const primary = entry.sourceFiles?.[0]
+  if (!primary) return null
+  const relPath = primary.replace(/\.tsx$/, ".demo.tsx")
+  const abs = path.join(process.cwd(), relPath)
+  let code: string
+  try {
+    code = await fs.readFile(abs, "utf8")
+  } catch {
+    return null
+  }
+  const lang = langFromPath(relPath)
+  const html = await highlightCode(code, lang)
+  return { code, html, lang }
+}
+
 export default async function ComponentRoute({
   params,
 }: {
@@ -65,6 +88,11 @@ export default async function ComponentRoute({
   const { component } = await params
   const entry = REGISTRY_BY_NAME[component]
   if (!entry || entry.category === "blocks") notFound()
-  const source = await loadSource(entry.sourceFiles)
-  return <ComponentPage entry={entry} source={source} />
+  const [source, demoSource] = await Promise.all([
+    loadSource(entry.sourceFiles),
+    loadDemoSource(entry),
+  ])
+  return (
+    <ComponentPage entry={entry} source={source} demoSource={demoSource} />
+  )
 }

--- a/components/showcase/component-page.tsx
+++ b/components/showcase/component-page.tsx
@@ -8,7 +8,7 @@ import { CodeBlock, type CodeBlockTab } from "@/components/showcase/code-block"
 import { InstallBlock } from "@/components/showcase/install-block"
 import type { RegistryEntryMeta } from "@/registry/sabk/registry-meta"
 
-type Tab = "preview" | "code" | "install"
+type Tab = "preview" | "usage" | "code" | "install"
 
 export type SourceFile = {
   code: string
@@ -19,10 +19,13 @@ export type SourceFile = {
 export function ComponentPage({
   entry,
   source,
+  demoSource,
 }: {
   entry: RegistryEntryMeta
   /** Pre-highlighted source files keyed by repo-relative path. */
   source: Record<string, SourceFile>
+  /** Pre-highlighted demo source — shows how to use the component. */
+  demoSource?: SourceFile | null
 }) {
   const [tab, setTab] = React.useState<Tab>("preview")
 
@@ -40,6 +43,14 @@ export function ComponentPage({
 
   const Demo = entry.Demo
   const isBlock = entry.category === "blocks"
+  const showUsageTab = !isBlock && !!demoSource
+
+  const tabs = React.useMemo<Array<[Tab, string]>>(() => {
+    const list: Array<[Tab, string]> = [["preview", "Preview"]]
+    if (showUsageTab) list.push(["usage", "Usage"])
+    list.push(["code", "Code"], ["install", "Install"])
+    return list
+  }, [showUsageTab])
 
   return (
     <div
@@ -96,13 +107,7 @@ export function ComponentPage({
             aria-label="View"
             className="-mx-4 flex items-center gap-0 overflow-x-auto border-b border-border px-4 sm:mx-0 sm:px-0"
           >
-            {(
-              [
-                ["preview", "Preview"],
-                ["code", "Code"],
-                ["install", "Install"],
-              ] as const
-            ).map(([k, label]) => (
+            {tabs.map(([k, label]) => (
               <button
                 key={k}
                 type="button"
@@ -133,6 +138,18 @@ export function ComponentPage({
                 <Demo />
               </div>
             ))}
+
+          {tab === "usage" && demoSource && (
+            <CodeBlock
+              tabs={[
+                {
+                  label: `${entry.name}.demo.tsx`,
+                  code: demoSource.code,
+                  html: demoSource.html,
+                },
+              ]}
+            />
+          )}
 
           {tab === "code" && codeTabs.length > 0 && (
             <CodeBlock tabs={codeTabs} />

--- a/registry/sabk/combobox/combobox.demo.tsx
+++ b/registry/sabk/combobox/combobox.demo.tsx
@@ -56,7 +56,6 @@ export default function ComboboxDemo() {
 
   return (
     <div className="grid w-full max-w-md gap-8">
-      {}
       <div className="grid gap-2">
         <Label>Static options</Label>
         <Combobox
@@ -69,7 +68,6 @@ export default function ComboboxDemo() {
         </Combobox>
       </div>
 
-      {}
       <div className="grid gap-2">
         <Label>Async loader (250ms simulated)</Label>
         <Combobox

--- a/registry/sabk/currency-input/currency-input.demo.tsx
+++ b/registry/sabk/currency-input/currency-input.demo.tsx
@@ -15,7 +15,6 @@ export default function CurrencyInputDemo() {
 
   return (
     <div className="grid w-full max-w-md gap-8">
-      {}
       <div className="grid gap-2">
         <Label htmlFor="cur-basic">USD</Label>
         <CurrencyInput
@@ -34,7 +33,6 @@ export default function CurrencyInputDemo() {
         </p>
       </div>
 
-      {}
       <div className="grid gap-2">
         <Label htmlFor="cur-composed">EUR (de-DE)</Label>
         <CurrencyInput

--- a/registry/sabk/file-dropzone/file-dropzone.demo.tsx
+++ b/registry/sabk/file-dropzone/file-dropzone.demo.tsx
@@ -16,7 +16,6 @@ export default function FileDropzoneDemo() {
 
   return (
     <div className="grid w-full max-w-md gap-8">
-      {}
       <div className="grid gap-2">
         <Label>Images & PDFs · up to 5 MB</Label>
         <FileDropzone
@@ -32,7 +31,6 @@ export default function FileDropzoneDemo() {
         </FileDropzone>
       </div>
 
-      {}
       <div className="grid gap-2">
         <Label>Data files · custom layout</Label>
         <FileDropzone

--- a/registry/sabk/kbd/kbd.demo.tsx
+++ b/registry/sabk/kbd/kbd.demo.tsx
@@ -7,7 +7,6 @@ import { Kbd, KbdDisplay, KbdGroup } from "@/registry/sabk/kbd/kbd"
 export default function KbdDemo() {
   return (
     <div className="grid w-full max-w-3xl gap-8">
-      {}
       <div className="grid gap-2">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           Pressable
@@ -23,7 +22,6 @@ export default function KbdDemo() {
         </div>
       </div>
 
-      {}
       <div className="grid gap-2">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           Chords
@@ -48,7 +46,6 @@ export default function KbdDemo() {
         </div>
       </div>
 
-      {}
       <div className="grid gap-2">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           Inline display

--- a/registry/sabk/multi-select/multi-select.demo.tsx
+++ b/registry/sabk/multi-select/multi-select.demo.tsx
@@ -27,7 +27,6 @@ export default function MultiSelectDemo() {
 
   return (
     <div className="grid w-full max-w-md gap-8">
-      {}
       <div className="grid gap-2">
         <Label htmlFor="ms-basic">Basic</Label>
         <MultiSelect
@@ -44,7 +43,6 @@ export default function MultiSelectDemo() {
         </p>
       </div>
 
-      {}
       <div className="grid gap-2">
         <Label htmlFor="ms-composed">Composed</Label>
         <MultiSelect

--- a/registry/sabk/number-range/number-range.demo.tsx
+++ b/registry/sabk/number-range/number-range.demo.tsx
@@ -19,7 +19,6 @@ export default function NumberRangeDemo() {
 
   return (
     <div className="grid w-full max-w-md gap-8">
-      {}
       <div className="grid gap-3">
         <div className="flex items-baseline justify-between">
           <Label>Price (USD)</Label>
@@ -42,7 +41,6 @@ export default function NumberRangeDemo() {
         </NumberRange>
       </div>
 
-      {}
       <div className="grid gap-3">
         <div className="flex items-baseline justify-between">
           <Label>Age</Label>

--- a/registry/sabk/password-input/password-input.demo.tsx
+++ b/registry/sabk/password-input/password-input.demo.tsx
@@ -15,7 +15,6 @@ export default function PasswordInputDemo() {
 
   return (
     <div className="grid w-full max-w-md gap-8">
-      {}
       <div className="grid gap-2">
         <Label htmlFor="pw-basic">Password · with strength meter</Label>
         <PasswordInput id="pw-basic" value={basic} onValueChange={setBasic}>
@@ -24,7 +23,6 @@ export default function PasswordInputDemo() {
         </PasswordInput>
       </div>
 
-      {}
       <div className="grid gap-2">
         <Label htmlFor="pw-composed">Password · custom strength hint</Label>
         <PasswordInput

--- a/registry/sabk/phone-input/phone-input.demo.tsx
+++ b/registry/sabk/phone-input/phone-input.demo.tsx
@@ -15,7 +15,6 @@ export default function PhoneInputDemo() {
 
   return (
     <div className="grid w-full max-w-md gap-8">
-      {}
       <div className="grid gap-2">
         <Label htmlFor="ph-basic">Phone · default US</Label>
         <PhoneInput
@@ -32,7 +31,6 @@ export default function PhoneInputDemo() {
         </p>
       </div>
 
-      {}
       <div className="grid gap-2">
         <Label htmlFor="ph-composed">Phone · pre-filled UK number</Label>
         <PhoneInput

--- a/registry/sabk/rating/rating.demo.tsx
+++ b/registry/sabk/rating/rating.demo.tsx
@@ -9,7 +9,6 @@ export default function RatingDemo() {
 
   return (
     <div className="grid w-full max-w-2xl gap-8">
-      {}
       <div className="grid gap-2">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           Interactive · whole stars
@@ -17,7 +16,6 @@ export default function RatingDemo() {
         <Rating defaultValue={4} aria-label="Overall rating" />
       </div>
 
-      {}
       <div className="grid gap-2">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           Controlled · half steps
@@ -35,7 +33,6 @@ export default function RatingDemo() {
         </div>
       </div>
 
-      {}
       <div className="grid gap-2">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           Read-only display
@@ -48,7 +45,6 @@ export default function RatingDemo() {
         </div>
       </div>
 
-      {}
       <div className="grid gap-2">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           Sizes

--- a/registry/sabk/rating/rating.tsx
+++ b/registry/sabk/rating/rating.tsx
@@ -85,7 +85,6 @@ function Rating({
               interactive && "cursor-pointer"
             )}
           >
-            {}
             <Star
               className={cn(
                 iconSize,
@@ -93,7 +92,6 @@ function Rating({
               )}
               aria-hidden
             />
-            {}
             {(filled || half) && (
               <Star
                 className={cn(
@@ -105,7 +103,6 @@ function Rating({
               />
             )}
 
-            {}
             {interactive && step === 0.5 && (
               <>
                 <button

--- a/registry/sabk/stat-card/stat-card.demo.tsx
+++ b/registry/sabk/stat-card/stat-card.demo.tsx
@@ -10,7 +10,6 @@ import {
 export default function StatCardDemo() {
   return (
     <div className="grid w-full max-w-3xl gap-8">
-      {}
       <div className="grid gap-2">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           3-up grid
@@ -39,7 +38,6 @@ export default function StatCardDemo() {
         </div>
       </div>
 
-      {}
       <div className="grid gap-2">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           Custom layout

--- a/registry/sabk/tag-input/tag-input.demo.tsx
+++ b/registry/sabk/tag-input/tag-input.demo.tsx
@@ -19,7 +19,6 @@ export default function TagInputDemo() {
 
   return (
     <div className="grid w-full max-w-md gap-8">
-      {}
       <div className="grid gap-2">
         <Label>Tags · max 6</Label>
         <TagInput value={basic} onValueChange={setBasic} maxTags={6}>
@@ -36,7 +35,6 @@ export default function TagInputDemo() {
         </p>
       </div>
 
-      {}
       <div className="grid gap-2">
         <Label>Email tags · validated</Label>
         <TagInput

--- a/registry/sabk/timeline/timeline.demo.tsx
+++ b/registry/sabk/timeline/timeline.demo.tsx
@@ -15,7 +15,6 @@ import {
 export default function TimelineDemo() {
   return (
     <div className="grid w-full max-w-2xl gap-8">
-      {}
       <div className="grid gap-3">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           Activity feed
@@ -64,7 +63,6 @@ export default function TimelineDemo() {
         </Timeline>
       </div>
 
-      {}
       <div className="grid gap-3">
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           With icons

--- a/registry/sabk/ui/sidebar.tsx
+++ b/registry/sabk/ui/sidebar.tsx
@@ -200,7 +200,6 @@ function Sidebar({
       data-side={side}
       data-slot="sidebar"
     >
-      {}
       <div
         data-slot="sidebar-gap"
         className={cn(

--- a/registry/sabk/year-picker/year-picker.demo.tsx
+++ b/registry/sabk/year-picker/year-picker.demo.tsx
@@ -19,7 +19,6 @@ export default function YearPickerDemo() {
 
   return (
     <div className="grid w-full max-w-md grid-cols-1 gap-8 sm:grid-cols-2">
-      {}
       <div className="grid gap-2">
         <Label>Founded</Label>
         <YearPicker
@@ -36,7 +35,6 @@ export default function YearPickerDemo() {
         </p>
       </div>
 
-      {}
       <div className="grid gap-2">
         <Label>Range</Label>
         <YearPicker


### PR DESCRIPTION
## Summary
This PR adds a new "Usage" tab to component showcase pages that displays example code demonstrating how to use each component. The tab is conditionally shown only for non-block components that have an accompanying demo file.

## Key Changes
- **ComponentPage component**: 
  - Added `demoSource` prop to accept pre-highlighted demo source code
  - Added "usage" as a new tab type alongside existing "preview", "code", and "install" tabs
  - Dynamically build the tab list based on whether demo source is available
  - Render CodeBlock with demo source when "usage" tab is active

- **Component route handler**:
  - Added `loadDemoSource()` function that follows the convention of loading `<name>.demo.tsx` files alongside component source files
  - Returns `null` when demo file doesn't exist, allowing the tab to be hidden gracefully
  - Loads and highlights demo source in parallel with component source using `Promise.all()`
  - Passes loaded demo source to ComponentPage component

## Implementation Details
- The "Usage" tab only appears for non-block components that have a corresponding `.demo.tsx` file
- Demo files are expected to be in the same directory as the component source, following the naming convention `<name>.demo.tsx`
- The demo source is pre-highlighted server-side for consistency with other code blocks
- Tab ordering: Preview → Usage (if available) → Code → Install

https://claude.ai/code/session_01UwnicjZCgLbMjNsdY5Qtb8