### PR TITLE
Add block category showcase component

### DIFF
--- a/app/(showcase)/blocks/[block]/page.tsx
+++ b/app/(showcase)/blocks/[block]/page.tsx
@@ -3,6 +3,11 @@ import * as path from "node:path"
 import { notFound } from "next/navigation"
 import type { Metadata } from "next"
 
+import { CategoryPage } from "@/components/showcase/category-page"
+import {
+  CATEGORY_BY_SLUG,
+  CATEGORY_REGISTRY,
+} from "@/components/showcase/block-categories"
 import { ComponentPage } from "@/components/showcase/component-page"
 import type { SourceFile } from "@/components/showcase/component-page"
 import { highlightCode, langFromPath } from "@/lib/highlight"
@@ -11,9 +16,11 @@ import { REGISTRY, REGISTRY_BY_NAME } from "@/registry/msh-ui/registry-meta"
 export const dynamicParams = false
 
 export function generateStaticParams() {
-  return REGISTRY.filter((entry) => entry.category === "blocks").map(
-    (entry) => ({ block: entry.name })
-  )
+  const blockParams = REGISTRY.filter(
+    (entry) => entry.category === "blocks"
+  ).map((entry) => ({ block: entry.name }))
+  const categoryParams = CATEGORY_REGISTRY.map((c) => ({ block: c.slug }))
+  return [...categoryParams, ...blockParams]
 }
 
 export async function generateMetadata({
@@ -22,6 +29,13 @@ export async function generateMetadata({
   params: Promise<{ block: string }>
 }): Promise<Metadata> {
   const { block } = await params
+  const category = CATEGORY_BY_SLUG[block]
+  if (category) {
+    return {
+      title: `${category.title} blocks`,
+      description: category.description,
+    }
+  }
   const entry = REGISTRY_BY_NAME[block]
   if (!entry || entry.category !== "blocks") return {}
   return {
@@ -60,6 +74,12 @@ export default async function BlockRoute({
   params: Promise<{ block: string }>
 }) {
   const { block } = await params
+
+  const category = CATEGORY_BY_SLUG[block]
+  if (category) {
+    return <CategoryPage category={category} />
+  }
+
   const entry = REGISTRY_BY_NAME[block]
   if (!entry || entry.category !== "blocks") notFound()
   const source = await loadSource(entry.sourceFiles)

--- a/app/(showcase)/blocks/page.tsx
+++ b/app/(showcase)/blocks/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link"
 import type { Metadata } from "next"
 import { ArrowRight } from "lucide-react"
 
+import { BlockCategories } from "@/components/showcase/block-categories"
 import { BlockPreview } from "@/components/showcase/block-preview"
 import {
   BLOCK_KIND_LABELS,
@@ -42,6 +43,18 @@ export default function BlocksIndex() {
           {blockCount} blocks · {BLOCK_KIND_ORDER.length} categories · MIT
         </p>
       </header>
+
+      <section className="flex flex-col gap-4">
+        <div className="flex items-baseline justify-between">
+          <h2 className="font-mono text-xs uppercase tracking-[0.14em] text-muted-foreground">
+            Browse by category
+          </h2>
+          <span className="font-mono text-[10px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
+            17 categories
+          </span>
+        </div>
+        <BlockCategories />
+      </section>
 
       <nav className="flex flex-wrap gap-2 border-b border-border pb-5">
         {BLOCK_KIND_ORDER.map((kind) => {

--- a/app/(showcase)/blocks/page.tsx
+++ b/app/(showcase)/blocks/page.tsx
@@ -1,15 +1,7 @@
-import Link from "next/link"
 import type { Metadata } from "next"
-import { ArrowRight } from "lucide-react"
 
 import { BlockCategories } from "@/components/showcase/block-categories"
-import { BlockPreview } from "@/components/showcase/block-preview"
-import {
-  BLOCK_KIND_LABELS,
-  BLOCK_KIND_ORDER,
-  BLOCKS_BY_KIND,
-  REGISTRY,
-} from "@/registry/msh-ui/registry-meta"
+import { REGISTRY } from "@/registry/msh-ui/registry-meta"
 
 export const metadata: Metadata = {
   title: "Blocks",
@@ -40,7 +32,7 @@ export default function BlocksIndex() {
           shape it like any other source file in your repo.
         </p>
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
-          {blockCount} blocks · {BLOCK_KIND_ORDER.length} categories · MIT
+          {blockCount} blocks · 17 categories · MIT
         </p>
       </header>
 
@@ -55,81 +47,6 @@ export default function BlocksIndex() {
         </div>
         <BlockCategories />
       </section>
-
-      <nav className="flex flex-wrap gap-2 border-b border-border pb-5">
-        {BLOCK_KIND_ORDER.map((kind) => {
-          const items = BLOCKS_BY_KIND[kind]
-          return (
-            <a
-              key={kind}
-              href={`#${kind}`}
-              className="inline-flex items-center gap-2 rounded-sm border border-border bg-card px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:border-foreground hover:text-foreground"
-            >
-              <span className="size-1 rounded-full bg-foreground" />
-              {BLOCK_KIND_LABELS[kind]}
-              <span className="tabular-nums text-muted-foreground">
-                {items.length}
-              </span>
-            </a>
-          )
-        })}
-      </nav>
-
-      <div className="flex flex-col gap-20">
-        {BLOCK_KIND_ORDER.map((kind) => {
-          const items = BLOCKS_BY_KIND[kind]
-          if (!items.length) return null
-          return (
-            <section
-              key={kind}
-              id={kind}
-              className="flex flex-col gap-6 scroll-mt-12"
-            >
-              <div className="flex items-baseline justify-between">
-                <h2 className="font-mono text-xs uppercase tracking-[0.14em] text-muted-foreground">
-                  {BLOCK_KIND_LABELS[kind]}
-                </h2>
-                <span className="font-mono text-[10px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
-                  {items.length} variant{items.length === 1 ? "" : "s"}
-                </span>
-              </div>
-
-              <div className="grid grid-cols-1 gap-6 sm:gap-8 lg:grid-cols-2">
-                {items.map((entry) => (
-                  <Link
-                    key={entry.name}
-                    href={`/blocks/${entry.name}`}
-                    className="group flex flex-col overflow-hidden rounded-sm border border-border bg-background transition-colors hover:border-foreground focus-visible:border-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  >
-                    <BlockPreview name={entry.name} title={entry.title} />
-
-                    <div className="flex flex-col gap-2 p-4 sm:p-5">
-                      <div className="flex items-center justify-between gap-2">
-                        <h3 className="text-base font-medium tracking-[-0.015em]">
-                          {entry.title}
-                        </h3>
-                        <span className="size-1.5 shrink-0 rounded-full bg-foreground" />
-                      </div>
-                      <p className="text-xs text-muted-foreground">
-                        {entry.blockTagline ?? entry.description}
-                      </p>
-                      <div className="mt-2 flex items-center justify-between gap-2 border-t border-border pt-2.5 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
-                        <span className="truncate">
-                          /blocks/{entry.name}
-                        </span>
-                        <span className="inline-flex shrink-0 items-center gap-1 text-muted-foreground transition-colors group-hover:text-foreground">
-                          view
-                          <ArrowRight className="size-3 transition-transform duration-150 ease-out group-hover:translate-x-0.5" />
-                        </span>
-                      </div>
-                    </div>
-                  </Link>
-                ))}
-              </div>
-            </section>
-          )
-        })}
-      </div>
     </div>
   )
 }

--- a/app/(showcase)/components/page.tsx
+++ b/app/(showcase)/components/page.tsx
@@ -47,7 +47,7 @@ export default async function ComponentsIndex() {
   const composeHtml = await highlightCode(COMPOSE_SNIPPET, "tsx")
 
   return (
-    <div className="mx-auto flex w-full max-w-4xl flex-col gap-12 px-4 py-10 sm:gap-14 sm:px-6 sm:py-12 md:px-10 md:py-16">
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-4 py-10 sm:gap-14 sm:px-6 sm:py-12 md:px-10 md:py-16">
       <header className="flex flex-col gap-5 border-b border-border pb-10">
         <div className="flex flex-wrap items-center gap-2">
           <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-foreground">

--- a/app/(showcase)/theme/playground.tsx
+++ b/app/(showcase)/theme/playground.tsx
@@ -19,7 +19,7 @@ export function ThemePlayground() {
   )
 
   return (
-    <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 py-10 sm:gap-10 sm:px-6 sm:py-12 md:px-10 md:py-14">
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10 sm:gap-10 sm:px-6 sm:py-12 md:px-10 md:py-14">
       <header className="flex flex-col gap-5 border-b border-border pb-8">
         <div className="flex flex-wrap items-center gap-2">
           <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-foreground">

--- a/app/globals.css
+++ b/app/globals.css
@@ -204,7 +204,7 @@ html.light .shiki span {
     scrollbar-width: none;
   }
   .container {
-    @apply mx-auto w-full max-w-7xl;
+    @apply mx-auto w-full max-w-6xl;
   }
   .cpx {
     @apply px-4 lg:px-6;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,11 +9,9 @@ import { SiteHeader } from "@/components/showcase/site-header"
 import { SITE } from "@/lib/site"
 import {
   BLOCKS_BY_KIND,
-  CATEGORY_LABELS,
   REGISTRY,
   REGISTRY_BY_CATEGORY,
   type BlockKind,
-  type ComponentCategory,
 } from "@/registry/msh-ui/registry-meta"
 
 export const metadata: Metadata = {
@@ -117,16 +115,8 @@ function Hero() {
 }
 
 /* -------------------------------------------------------------------------- */
-/* Catalog — just names                                                       */
+/* Section blocks grid                                                        */
 /* -------------------------------------------------------------------------- */
-
-const COMPONENT_CATEGORY_ORDER: ComponentCategory[] = [
-  "inputs",
-  "pickers",
-  "files",
-  "data",
-  "display",
-]
 
 const BLOCK_ORDER: BlockKind[] = [
   "hero",
@@ -141,18 +131,7 @@ const BLOCK_ORDER: BlockKind[] = [
   "not-found",
 ]
 
-type CatalogItem = {
-  key: string
-  href: string
-  title: string
-  count: number
-}
-
 function CategoryGrid() {
-  const componentTotal = COMPONENT_CATEGORY_ORDER.reduce(
-    (sum, c) => sum + REGISTRY_BY_CATEGORY[c].length,
-    0
-  )
   const blocksTotal = BLOCK_ORDER.reduce(
     (sum, k) => sum + BLOCKS_BY_KIND[k].length,
     0
@@ -161,98 +140,37 @@ function CategoryGrid() {
   return (
     <section className="border-t border-border">
       <div className="mx-auto w-full max-w-6xl px-4 py-12 sm:px-6 sm:py-16 lg:px-8">
-        <header className="mb-8 flex flex-col gap-2 sm:mb-10 sm:flex-row sm:items-end sm:justify-between">
+        <header className="mb-10 flex flex-col gap-2 sm:mb-12 sm:flex-row sm:items-end sm:justify-between">
           <div className="flex flex-col gap-2">
             <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-              ◆ Catalog
+              ◆ Section blocks
             </span>
             <h2
               className="text-balance text-2xl tracking-[-0.02em] sm:text-3xl"
               style={{ fontFamily: "var(--font-fraunces), ui-serif, serif" }}
             >
-              <span className="font-semibold">Everything</span>{" "}
+              <span className="font-semibold">Compose</span>{" "}
               <span className="font-normal text-muted-foreground">
-                we ship.
+                full pages, faster.
               </span>
             </h2>
           </div>
-          <Link
-            href="/components"
-            className="inline-flex items-center gap-1 self-start font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground transition-colors hover:text-foreground sm:self-auto"
-          >
-            See everything
-            <ArrowRight className="size-3" />
-          </Link>
+          <div className="flex items-center gap-4 self-start sm:self-auto">
+            <span className="font-mono text-[10px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
+              {blocksTotal} shipped · {BLOCK_ORDER.length} / 17 categories
+            </span>
+            <Link
+              href="/blocks"
+              className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground transition-colors hover:text-foreground"
+            >
+              See all
+              <ArrowRight className="size-3" />
+            </Link>
+          </div>
         </header>
 
-        <div className="flex flex-col gap-10">
-          <CatalogGroup
-            label="Components"
-            count={componentTotal}
-            items={COMPONENT_CATEGORY_ORDER.map((cat) => ({
-              key: `c-${cat}`,
-              href: "/components",
-              title: CATEGORY_LABELS[cat],
-              count: REGISTRY_BY_CATEGORY[cat].length,
-            }))}
-          />
-
-          <div className="flex flex-col gap-3">
-            <div className="flex items-baseline justify-between">
-              <h3 className="font-mono text-[11px] uppercase tracking-[0.14em] text-foreground">
-                Section blocks
-              </h3>
-              <span className="font-mono text-[10px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
-                {blocksTotal} shipped · {BLOCK_ORDER.length} / 17 categories
-              </span>
-            </div>
-            <BlockCategories variant="indexed" hrefPrefix="/blocks" />
-          </div>
-        </div>
+        <BlockCategories variant="indexed" hrefPrefix="/blocks" />
       </div>
     </section>
-  )
-}
-
-function CatalogGroup({
-  label,
-  count,
-  items,
-}: {
-  label: string
-  count: number
-  items: CatalogItem[]
-}) {
-  return (
-    <div className="flex flex-col gap-3">
-      <div className="flex items-baseline justify-between">
-        <h3 className="font-mono text-[11px] uppercase tracking-[0.14em] text-foreground">
-          {label}
-        </h3>
-        <span className="font-mono text-[10px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
-          {count} total
-        </span>
-      </div>
-      <ul className="grid grid-cols-2 gap-px overflow-hidden rounded-md border border-border bg-border sm:grid-cols-3 lg:grid-cols-5">
-        {items.map((item) => (
-          <li key={item.key}>
-            <Link
-              href={item.href}
-              className="group flex h-full items-center justify-between gap-3 bg-card px-4 py-3 transition-colors hover:bg-accent"
-            >
-              <div className="flex flex-col gap-0.5 leading-tight">
-                <span className="text-sm font-medium tracking-[-0.01em] text-foreground">
-                  {item.title}
-                </span>
-                <span className="font-mono text-[10px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
-                  {item.count}
-                </span>
-              </div>
-              <ArrowRight className="size-3.5 text-muted-foreground transition-transform duration-150 group-hover:translate-x-0.5 group-hover:text-foreground" />
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </div>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -169,7 +169,7 @@ function CategoryGrid() {
           </div>
         </header>
 
-        <BlockCategories variant="indexed" hrefPrefix="/blocks" />
+        <BlockCategories variant="indexed" />
       </div>
     </section>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,12 +2,12 @@ import Link from "next/link"
 import type { Metadata } from "next"
 import { ArrowRight } from "lucide-react"
 
+import { BlockCategories } from "@/components/showcase/block-categories"
 import { InstallBlock } from "@/components/showcase/install-block"
 import { SiteFooter } from "@/components/showcase/site-footer"
 import { SiteHeader } from "@/components/showcase/site-header"
 import { SITE } from "@/lib/site"
 import {
-  BLOCK_KIND_LABELS,
   BLOCKS_BY_KIND,
   CATEGORY_LABELS,
   REGISTRY,
@@ -185,7 +185,7 @@ function CategoryGrid() {
           </Link>
         </header>
 
-        <div className="flex flex-col gap-8">
+        <div className="flex flex-col gap-10">
           <CatalogGroup
             label="Components"
             count={componentTotal}
@@ -196,16 +196,18 @@ function CategoryGrid() {
               count: REGISTRY_BY_CATEGORY[cat].length,
             }))}
           />
-          <CatalogGroup
-            label="Section blocks"
-            count={blocksTotal}
-            items={BLOCK_ORDER.map((kind) => ({
-              key: `b-${kind}`,
-              href: `/blocks#${kind}`,
-              title: BLOCK_KIND_LABELS[kind],
-              count: BLOCKS_BY_KIND[kind].length,
-            }))}
-          />
+
+          <div className="flex flex-col gap-3">
+            <div className="flex items-baseline justify-between">
+              <h3 className="font-mono text-[11px] uppercase tracking-[0.14em] text-foreground">
+                Section blocks
+              </h3>
+              <span className="font-mono text-[10px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
+                {blocksTotal} shipped · {BLOCK_ORDER.length} / 17 categories
+              </span>
+            </div>
+            <BlockCategories variant="indexed" hrefPrefix="/blocks" />
+          </div>
         </div>
       </div>
     </section>

--- a/components/showcase/block-categories.tsx
+++ b/components/showcase/block-categories.tsx
@@ -1,0 +1,528 @@
+import Link from "next/link"
+
+import {
+  BLOCKS_BY_KIND,
+  type BlockKind,
+} from "@/registry/msh-ui/registry-meta"
+
+type CategorySlug =
+  | BlockKind
+  | "blog"
+  | "contact"
+  | "image-gallery"
+  | "integrations"
+  | "logo-cloud"
+  | "app-shell"
+  | "dashboard"
+
+type CategoryCard = {
+  slug: CategorySlug
+  title: string
+  count: number
+  freeCount?: number
+  comingSoon?: boolean
+  render: (meta: { title: string; countLabel: string }) => React.ReactNode
+}
+
+const cardShell =
+  "group relative aspect-video size-full overflow-hidden rounded-md border bg-background transition-colors hover:bg-card dark:bg-[radial-gradient(80%_100%_at_49%_0%,rgba(255,255,255,0.06),transparent)]"
+
+const headingClass = "font-medium text-sm tracking-[-0.01em] md:text-base"
+const subClass = "text-muted-foreground text-xs"
+
+function countLabel(count: number, free?: number) {
+  if (free && !count) return `${free} Free  block${free === 1 ? "" : "s"}`
+  if (free) return `${count}  blocks (+ ${free} Free)`
+  return `${count}  block${count === 1 ? "" : "s"}`
+}
+
+const CATEGORIES: CategoryCard[] = [
+  {
+    slug: "login",
+    title: "Auth",
+    count: BLOCKS_BY_KIND.login.length,
+    render: ({ title, countLabel }) => (
+      <div className="grid size-full grid-cols-2">
+        <div className="z-10 border-r py-5 ps-3 pe-1 md:px-5">
+          <h3 className={headingClass}>{title}</h3>
+          <p className={subClass}>{countLabel}</p>
+        </div>
+        <div className="flex flex-col items-center justify-center p-3">
+          <div className="mx-auto mb-3 h-1 w-12 rounded-full bg-muted-foreground/20 p-2 md:h-2" />
+          <div className="mb-1.5 h-1 w-full rounded-sm bg-muted-foreground/10 md:h-2" />
+          <div className="mb-3 h-1 w-full rounded-sm bg-muted-foreground/10 md:h-2" />
+          <div className="h-3 w-full rounded-sm bg-primary/20 md:h-4" />
+        </div>
+      </div>
+    ),
+  },
+  {
+    slug: "blog",
+    title: "Blog Sections",
+    count: 0,
+    comingSoon: true,
+    render: ({ title, countLabel }) => (
+      <div className="flex size-full w-full flex-col items-center justify-center gap-2 px-8">
+        <div className="w-full">
+          <h3 className={headingClass}>{title}</h3>
+          <p className={subClass}>{countLabel}</p>
+        </div>
+        <div className="flex w-full items-center gap-2">
+          {[0, 1].map((i) => (
+            <div
+              key={i}
+              className="w-full overflow-hidden rounded-sm border bg-background shadow-xs"
+            >
+              <div className="h-6 w-full bg-card md:h-12" />
+              <div className="flex flex-col gap-1 border-t p-1 md:p-2">
+                <div className="h-1 w-1/2 rounded-full bg-muted-foreground/20 md:h-1.5" />
+                <div className="h-0.5 w-3/4 rounded-full bg-muted-foreground/20 md:h-1.5" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    ),
+  },
+  {
+    slug: "contact",
+    title: "Contact",
+    count: 0,
+    comingSoon: true,
+    render: ({ title, countLabel }) => (
+      <div className="grid size-full grid-cols-2 gap-4 p-2 md:p-5">
+        <div className="flex flex-col justify-center gap-2">
+          <div>
+            <h3 className={headingClass}>{title}</h3>
+            <p className={subClass}>{countLabel}</p>
+          </div>
+          <div className="h-1 w-full rounded-full bg-muted-foreground/20 md:h-2" />
+          <div className="h-1 w-full rounded-full bg-muted-foreground/20 md:h-2" />
+        </div>
+        <div className="flex h-full w-full flex-col gap-1.5 rounded-md border bg-background p-2 shadow-xs">
+          <div className="h-1 w-8 rounded-full bg-muted-foreground/20 md:h-1.5" />
+          <div className="h-2 w-full rounded-sm border bg-muted/20 md:h-3" />
+          <div className="h-1 w-8 rounded-full bg-muted-foreground/20 md:h-1.5" />
+          <div className="h-2 w-full rounded-sm border bg-muted/20 md:h-3" />
+          <div className="mt-auto h-3 w-full rounded-sm bg-primary/20 md:h-4" />
+        </div>
+      </div>
+    ),
+  },
+  {
+    slug: "cta",
+    title: "Call to Action",
+    count: BLOCKS_BY_KIND.cta.length,
+    render: ({ title, countLabel }) => (
+      <div className="flex size-full flex-col items-center justify-center gap-2">
+        <h3 className={headingClass}>{title}</h3>
+        <div className="w-full border-y px-4">
+          <div className="grid grid-cols-2 border-x">
+            <div className="flex w-full items-center border-r px-2">
+              <p className={subClass}>{countLabel}</p>
+            </div>
+            <div className="flex items-center gap-2 p-1">
+              <div className="h-4 w-full rounded-sm bg-muted-foreground/20" />
+              <div className="h-4 w-full rounded-sm bg-primary/20" />
+            </div>
+          </div>
+        </div>
+      </div>
+    ),
+  },
+  {
+    slug: "faq",
+    title: "Faqs",
+    count: BLOCKS_BY_KIND.faq.length,
+    render: ({ title, countLabel }) => (
+      <div className="grid size-full grid-cols-2">
+        <div className="flex flex-col border-r py-5 ps-3 pe-1 md:px-5">
+          <h3 className={headingClass}>{title}</h3>
+          <p className={subClass}>{countLabel}</p>
+        </div>
+        <div className="flex items-center">
+          <div className="flex w-full flex-col border-t">
+            <div className="flex h-4 w-full items-center border-b px-2 md:h-6">
+              <div className="h-1.5 w-2/3 rounded-full bg-muted-foreground/20" />
+            </div>
+            <div className="flex h-4 w-full items-center border-b px-2 md:h-6">
+              <div className="h-1.5 w-1/2 rounded-full bg-muted-foreground/20" />
+            </div>
+            <div className="flex h-14 w-full flex-col gap-1.5 border-b bg-card px-2 pt-2">
+              <div className="h-1.5 w-3/4 rounded-full bg-primary/20" />
+              <div className="h-1 w-full rounded-full bg-muted-foreground/10" />
+              <div className="h-1 w-full rounded-full bg-muted-foreground/10" />
+              <div className="h-1 w-5/6 rounded-full bg-muted-foreground/10" />
+            </div>
+          </div>
+        </div>
+      </div>
+    ),
+  },
+  {
+    slug: "feature",
+    title: "Features",
+    count: BLOCKS_BY_KIND.feature.length,
+    render: ({ title, countLabel }) => (
+      <div className="flex size-full flex-col justify-center gap-2 px-4 md:gap-5">
+        <div className="flex flex-col items-center">
+          <h3 className={headingClass}>{title}</h3>
+          <p className={subClass}>{countLabel}</p>
+        </div>
+        <div className="grid grid-cols-3">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="relative flex flex-col items-center justify-center py-1 md:py-4"
+            >
+              {i < 2 && (
+                <span className="absolute inset-y-0 right-0 h-full w-px bg-gradient-to-b from-foreground/5 via-foreground/15 to-foreground/5" />
+              )}
+              <div className="size-1.5 rounded-sm bg-primary/20 md:size-2.5" />
+              <div className="mt-1 h-1 w-4 rounded-full bg-muted-foreground/20 md:mt-2 md:h-1.5 md:w-6" />
+              <div className="mt-1 h-1 w-8 rounded-full bg-muted-foreground/20 md:mt-1 md:h-1 md:w-10" />
+            </div>
+          ))}
+        </div>
+      </div>
+    ),
+  },
+  {
+    slug: "footer",
+    title: "Footer",
+    count: BLOCKS_BY_KIND.footer.length,
+    render: ({ title, countLabel }) => (
+      <div className="flex size-full w-full flex-col gap-2">
+        <div className="flex flex-col items-center pt-5">
+          <h3 className={headingClass}>{title}</h3>
+          <p className={subClass}>{countLabel}</p>
+        </div>
+        <div className="mt-auto border-t px-4 [mask-image:linear-gradient(to_bottom,black_60%,transparent)]">
+          <div className="grid grid-cols-4 gap-2 border-x p-3">
+            {[4, 3, 3, 1].map((rows, c) => (
+              <div key={c} className="flex flex-col gap-1">
+                <div className="mb-1 h-1 w-4 rounded-full bg-primary/20" />
+                {Array.from({ length: rows - 1 }).map((_, r) => (
+                  <div
+                    key={r}
+                    className="h-1 w-6 rounded-full bg-muted-foreground/20"
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    ),
+  },
+  {
+    slug: "header",
+    title: "Header",
+    count: BLOCKS_BY_KIND.header.length,
+    render: ({ title, countLabel }) => (
+      <div className="flex size-full w-full flex-col gap-2 p-2 md:p-4">
+        <div className="flex items-center justify-between gap-4 rounded-md border bg-card p-1 shadow-xs">
+          <div className="size-3.5 rounded-full bg-primary/20" />
+          <div className="flex gap-1">
+            <div className="h-1.5 w-5 rounded-full bg-muted-foreground/20 md:w-8" />
+            <div className="h-1.5 w-5 rounded-full bg-muted-foreground/20 md:w-8" />
+            <div className="h-1.5 w-5 rounded-full bg-muted-foreground/20 md:w-8" />
+          </div>
+          <div className="h-3.5 w-8 rounded-sm bg-primary/20 md:w-12" />
+        </div>
+        <div className="flex flex-col items-center pt-2 md:pt-5">
+          <p className={subClass}>{countLabel}</p>
+          <h3 className={headingClass}>{title}</h3>
+        </div>
+      </div>
+    ),
+  },
+  {
+    slug: "hero",
+    title: "Hero Sections",
+    count: BLOCKS_BY_KIND.hero.length,
+    render: ({ title, countLabel }) => (
+      <div className="relative flex size-full w-full flex-col items-center justify-center">
+        <span className="absolute inset-y-0 left-4 w-px bg-gradient-to-b from-transparent via-border to-border" />
+        <span className="absolute inset-y-0 right-4 w-px bg-gradient-to-b from-transparent via-border to-border" />
+        <h3 className={headingClass}>{title}</h3>
+        <p className={subClass}>{countLabel}</p>
+        <div className="mt-2 grid grid-cols-2 gap-2">
+          <div className="mx-auto h-4 w-12 rounded bg-primary/10" />
+          <div className="mx-auto h-4 w-12 rounded bg-primary/20" />
+        </div>
+      </div>
+    ),
+  },
+  {
+    slug: "image-gallery",
+    title: "Image Gallery",
+    count: 0,
+    comingSoon: true,
+    render: ({ title, countLabel }) => (
+      <div className="flex size-full w-full flex-col gap-2 px-4 pt-5">
+        <div className="w-full text-center">
+          <h3 className={headingClass}>{title}</h3>
+          <p className={subClass}>{countLabel}</p>
+        </div>
+        <div className="relative -mt-2.5 size-full [mask-image:linear-gradient(to_bottom,black_60%,transparent)]">
+          <div className="absolute inset-0 grid grid-cols-4 gap-1.5">
+            <div className="flex flex-col gap-1">
+              <div className="aspect-square rounded-sm bg-muted-foreground/10" />
+              <div className="aspect-square rounded-sm bg-muted-foreground/10" />
+            </div>
+            <div className="flex flex-col gap-1 pt-5">
+              <div className="aspect-square rounded-sm bg-muted-foreground/10" />
+              <div className="aspect-square rounded-sm bg-muted-foreground/10" />
+            </div>
+            <div className="flex flex-col gap-1 pt-5">
+              <div className="aspect-square rounded-sm bg-muted-foreground/10" />
+              <div className="aspect-square rounded-sm bg-muted-foreground/10" />
+            </div>
+            <div className="flex flex-col gap-1">
+              <div className="aspect-square rounded-sm bg-muted-foreground/10" />
+              <div className="aspect-square rounded-sm bg-muted-foreground/10" />
+            </div>
+          </div>
+        </div>
+      </div>
+    ),
+  },
+  {
+    slug: "integrations",
+    title: "Integrations",
+    count: 0,
+    comingSoon: true,
+    render: ({ title, countLabel }) => (
+      <div className="grid size-full grid-cols-2 items-center justify-end px-6">
+        <div className="flex items-center px-2">
+          <div>
+            <h3 className={headingClass}>{title}</h3>
+            <p className={subClass}>{countLabel}</p>
+          </div>
+        </div>
+        <div className="relative size-20">
+          <div className="absolute inset-0 z-10 m-auto size-6 rounded-full border bg-card shadow-xs" />
+          <div className="absolute top-0 left-0 z-10 size-4 rounded-md bg-muted" />
+          <div className="absolute top-0 right-0 z-10 size-4 rounded-md bg-muted" />
+          <div className="absolute bottom-0 left-0 z-10 size-4 rounded-md bg-muted" />
+          <div className="absolute right-0 bottom-0 z-10 size-4 rounded-md bg-muted" />
+          <div className="absolute top-1/2 left-1/2 h-px w-full -translate-x-1/2 -translate-y-1/2 -rotate-45 bg-border" />
+          <div className="absolute top-1/2 left-1/2 h-px w-full -translate-x-1/2 -translate-y-1/2 rotate-45 bg-border" />
+        </div>
+      </div>
+    ),
+  },
+  {
+    slug: "logo-cloud",
+    title: "Logo Cloud",
+    count: 0,
+    comingSoon: true,
+    render: ({ title, countLabel }) => (
+      <div className="flex size-full w-full flex-col items-center justify-center">
+        <div className="pb-3 text-center">
+          <h3 className={headingClass}>{title}</h3>
+          <p className={subClass}>{countLabel}</p>
+        </div>
+        <div className="mx-auto h-px w-full max-w-[50%] bg-border [mask-image:linear-gradient(to_right,transparent,black,transparent)]" />
+        <div className="flex w-full items-center gap-2 overflow-hidden py-2 [mask-image:linear-gradient(to_right,transparent,black,transparent)]">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-2.5 w-12 rounded-xs bg-muted-foreground/10 md:h-3.5"
+            />
+          ))}
+        </div>
+        <div className="h-px w-full bg-border [mask-image:linear-gradient(to_right,transparent,black,transparent)]" />
+      </div>
+    ),
+  },
+  {
+    slug: "not-found",
+    title: "Not Found",
+    count: BLOCKS_BY_KIND["not-found"].length,
+    render: ({ title, countLabel }) => (
+      <div className="flex size-full flex-col items-center justify-center">
+        <div className="text-5xl font-extrabold text-muted-foreground/25 [mask-image:linear-gradient(to_bottom,transparent,black_20%,black_80%,transparent)]">
+          404
+        </div>
+        <div className="-mt-2.5 w-full text-center">
+          <h3 className={headingClass}>{title}</h3>
+          <p className={subClass}>{countLabel}</p>
+        </div>
+      </div>
+    ),
+  },
+  {
+    slug: "pricing",
+    title: "Pricing",
+    count: BLOCKS_BY_KIND.pricing.length,
+    render: ({ title, countLabel }) => (
+      <div className="size-full pt-4">
+        <div className="grid size-full grid-cols-3 [mask-image:linear-gradient(to_bottom,black_60%,transparent)]">
+          <div className="flex w-full pt-8">
+            <div className="w-full border-t p-2 md:p-4">
+              <div className="mb-1.5 h-2.5 w-[85%] rounded-md bg-primary/20 md:h-3.5" />
+              <div className="h-1.5 w-[75%] rounded-full bg-muted-foreground/20 md:h-2" />
+            </div>
+          </div>
+          <div className="w-full rounded-t-md border-x border-t p-1 text-center md:p-3">
+            <h3 className={headingClass}>{title}</h3>
+            <p className={subClass}>{countLabel}</p>
+          </div>
+          <div className="flex w-full pt-8">
+            <div className="w-full border-t p-2 md:p-4">
+              <div className="mb-1.5 h-2.5 w-[85%] rounded-md bg-primary/20 md:h-3.5" />
+              <div className="h-2 w-[75%] rounded-full bg-muted-foreground/20" />
+            </div>
+          </div>
+        </div>
+      </div>
+    ),
+  },
+  {
+    slug: "testimonial",
+    title: "Testimonials",
+    count: BLOCKS_BY_KIND.testimonial.length,
+    render: ({ title, countLabel }) => (
+      <div className="flex size-full w-full flex-col items-center justify-center p-4">
+        <div className="w-full text-center">
+          <h3 className={headingClass}>{title}</h3>
+          <p className={subClass}>{countLabel}</p>
+        </div>
+        <div className="flex flex-col items-center gap-2 pt-1 md:pt-4">
+          <div className="mt-1 flex flex-col items-center gap-1">
+            <div className="h-1.5 w-32 rounded-full bg-muted-foreground/40" />
+            <div className="h-1.5 w-24 rounded-full bg-muted-foreground/40" />
+          </div>
+        </div>
+        <div className="mt-2 flex items-center gap-1">
+          <div className="size-5 rounded-full bg-muted-foreground/20" />
+          <div className="h-1.5 w-10 rounded-full bg-muted-foreground/30" />
+        </div>
+      </div>
+    ),
+  },
+  {
+    slug: "app-shell",
+    title: "App Shell",
+    count: 0,
+    comingSoon: true,
+    render: ({ title, countLabel }) => (
+      <div className="grid size-full grid-cols-[1fr_3fr] gap-1 p-2 md:p-3">
+        <div className="flex flex-col gap-1 rounded-sm border bg-card p-1.5 md:p-2">
+          <div className="h-1.5 w-full rounded-full bg-primary/20" />
+          <div className="h-1 w-2/3 rounded-full bg-muted-foreground/20" />
+          <div className="h-1 w-3/4 rounded-full bg-muted-foreground/20" />
+          <div className="h-1 w-1/2 rounded-full bg-muted-foreground/20" />
+          <div className="mt-auto h-1 w-2/3 rounded-full bg-muted-foreground/20" />
+        </div>
+        <div className="flex flex-col gap-1.5 rounded-sm border bg-background p-2">
+          <div className="flex items-center justify-between">
+            <h3 className={headingClass}>{title}</h3>
+            <div className="size-2 rounded-full bg-primary/30" />
+          </div>
+          <p className={subClass}>{countLabel}</p>
+          <div className="mt-auto grid grid-cols-3 gap-1">
+            <div className="h-3 rounded-sm bg-muted-foreground/10" />
+            <div className="h-3 rounded-sm bg-muted-foreground/10" />
+            <div className="h-3 rounded-sm bg-muted-foreground/10" />
+          </div>
+        </div>
+      </div>
+    ),
+  },
+  {
+    slug: "dashboard",
+    title: "Dashboard",
+    count: 0,
+    comingSoon: true,
+    render: ({ title, countLabel }) => (
+      <div className="flex size-full flex-col gap-1.5 p-3">
+        <div className="flex items-center justify-between">
+          <h3 className={headingClass}>{title}</h3>
+          <p className={subClass}>{countLabel}</p>
+        </div>
+        <div className="grid grid-cols-3 gap-1.5">
+          <div className="h-6 rounded-sm border bg-card p-1">
+            <div className="h-1 w-2/3 rounded-full bg-muted-foreground/20" />
+            <div className="mt-1 h-2 w-1/2 rounded-sm bg-primary/30" />
+          </div>
+          <div className="h-6 rounded-sm border bg-card p-1">
+            <div className="h-1 w-2/3 rounded-full bg-muted-foreground/20" />
+            <div className="mt-1 h-2 w-1/2 rounded-sm bg-primary/20" />
+          </div>
+          <div className="h-6 rounded-sm border bg-card p-1">
+            <div className="h-1 w-2/3 rounded-full bg-muted-foreground/20" />
+            <div className="mt-1 h-2 w-1/2 rounded-sm bg-muted-foreground/30" />
+          </div>
+        </div>
+        <div className="mt-auto h-8 rounded-sm border bg-card p-1.5">
+          <div className="flex h-full items-end gap-1">
+            <div className="h-1/3 w-2 rounded-xs bg-primary/30" />
+            <div className="h-2/3 w-2 rounded-xs bg-primary/30" />
+            <div className="h-1/2 w-2 rounded-xs bg-primary/30" />
+            <div className="h-3/4 w-2 rounded-xs bg-primary/30" />
+            <div className="h-2/5 w-2 rounded-xs bg-primary/30" />
+            <div className="h-full w-2 rounded-xs bg-primary/30" />
+          </div>
+        </div>
+      </div>
+    ),
+  },
+]
+
+const ANCHORABLE_KINDS: Record<string, BlockKind> = {
+  login: "login",
+  cta: "cta",
+  faq: "faq",
+  feature: "feature",
+  footer: "footer",
+  header: "header",
+  hero: "hero",
+  "not-found": "not-found",
+  pricing: "pricing",
+  testimonial: "testimonial",
+}
+
+export function BlockCategories() {
+  return (
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4">
+      {CATEGORIES.map((cat) => {
+        const label = countLabel(cat.count, cat.freeCount)
+        const anchor = ANCHORABLE_KINDS[cat.slug]
+        const inner = cat.render({ title: cat.title, countLabel: label })
+
+        if (anchor) {
+          return (
+            <Link
+              key={cat.slug}
+              href={`#${anchor}`}
+              className={cardShell}
+              aria-label={`Jump to ${cat.title}`}
+            >
+              {inner}
+            </Link>
+          )
+        }
+
+        return (
+          <div
+            key={cat.slug}
+            aria-disabled={cat.comingSoon}
+            className={`${cardShell} opacity-80`}
+          >
+            {inner}
+          </div>
+        )
+      })}
+      <div
+        aria-disabled
+        className={`${cardShell} flex flex-col items-center justify-center opacity-80`}
+      >
+        <h3 className={headingClass}>More</h3>
+        <p className={subClass}>Coming Soon…</p>
+      </div>
+    </div>
+  )
+}

--- a/components/showcase/block-categories.tsx
+++ b/components/showcase/block-categories.tsx
@@ -6,6 +6,10 @@ import {
   type BlockKind,
 } from "@/registry/msh-ui/registry-meta"
 
+/* -------------------------------------------------------------------------- */
+/* Design system                                                              */
+/* -------------------------------------------------------------------------- */
+
 type CategorySlug =
   | BlockKind
   | "blog"
@@ -16,475 +20,365 @@ type CategorySlug =
   | "app-shell"
   | "dashboard"
 
-type CategoryCard = {
+type CategoryDef = {
   slug: CategorySlug
   title: string
   count: number
   freeCount?: number
   comingSoon?: boolean
-  render: (meta: { title: string; countLabel: string }) => React.ReactNode
+  illustration: React.ComponentType
 }
 
-const cardShell =
-  "group relative aspect-video size-full overflow-hidden rounded-md border bg-background transition-colors hover:bg-card dark:bg-[radial-gradient(80%_100%_at_49%_0%,rgba(255,255,255,0.06),transparent)]"
+/* Illustration primitives — every tile composes from this small palette so
+   the grid reads as one design system instead of seventeen sketches. */
 
-const headingClass = "font-medium text-sm tracking-[-0.01em] md:text-base"
-const subClass = "text-muted-foreground text-xs"
+const Bar = ({
+  w = "w-full",
+  tone = "bg-muted-foreground/15",
+  className = "",
+}: {
+  w?: string
+  tone?: string
+  className?: string
+}) => (
+  <span className={`block h-1 rounded-full ${tone} ${w} ${className}`} />
+)
 
-function countLabel(count: number, free?: number) {
-  if (free && !count) return `${free} Free  block${free === 1 ? "" : "s"}`
-  if (free) return `${count}  blocks (+ ${free} Free)`
-  return `${count}  block${count === 1 ? "" : "s"}`
-}
+const AccentBar = ({
+  w = "w-full",
+  className = "",
+}: {
+  w?: string
+  className?: string
+}) => (
+  <span
+    className={`block h-1.5 rounded-full bg-primary/35 ${w} ${className}`}
+  />
+)
 
-const CATEGORIES: CategoryCard[] = [
-  {
-    slug: "login",
-    title: "Auth",
-    count: BLOCKS_BY_KIND.login.length,
-    render: ({ title, countLabel }) => (
-      <div className="grid size-full grid-cols-2">
-        <div className="z-10 border-r py-5 ps-3 pe-1 md:px-5">
-          <h3 className={headingClass}>{title}</h3>
-          <p className={subClass}>{countLabel}</p>
-        </div>
-        <div className="flex flex-col items-center justify-center p-3">
-          <div className="mx-auto mb-3 h-1 w-12 rounded-full bg-muted-foreground/20 p-2 md:h-2" />
-          <div className="mb-1.5 h-1 w-full rounded-sm bg-muted-foreground/10 md:h-2" />
-          <div className="mb-3 h-1 w-full rounded-sm bg-muted-foreground/10 md:h-2" />
-          <div className="h-3 w-full rounded-sm bg-primary/20 md:h-4" />
-        </div>
+const Pill = ({
+  w = "w-full",
+  tone = "bg-muted-foreground/15",
+  className = "",
+}: {
+  w?: string
+  tone?: string
+  className?: string
+}) => (
+  <span className={`block h-3 rounded-sm border border-border ${tone} ${w} ${className}`} />
+)
+
+const Box = ({ className = "" }: { className?: string }) => (
+  <span className={`block rounded-sm bg-muted-foreground/12 ${className}`} />
+)
+
+const AccentBox = ({ className = "" }: { className?: string }) => (
+  <span className={`block rounded-sm bg-primary/30 ${className}`} />
+)
+
+/* -------------------------------------------------------------------------- */
+/* Illustrations                                                              */
+/* -------------------------------------------------------------------------- */
+/* Each renders inside a 16:9 zone, centered. All compose from the primitives
+   above so colors, weights, and corners stay coherent. */
+
+const IllAuth = () => (
+  <div className="flex w-full max-w-[60%] flex-col gap-1.5">
+    <Bar w="w-1/2" />
+    <Pill />
+    <Bar w="w-1/3" />
+    <Pill />
+    <AccentBar className="mt-0.5" />
+  </div>
+)
+
+const IllBlog = () => (
+  <div className="grid w-full max-w-[80%] grid-cols-2 gap-2">
+    {[0, 1].map((i) => (
+      <div
+        key={i}
+        className="flex flex-col gap-1 rounded-sm border border-border p-1.5"
+      >
+        <Box className="h-6 w-full" />
+        <Bar w="w-2/3" />
+        <Bar w="w-1/2" tone="bg-muted-foreground/10" />
       </div>
-    ),
-  },
-  {
-    slug: "blog",
-    title: "Blog Sections",
-    count: 0,
-    comingSoon: true,
-    render: ({ title, countLabel }) => (
-      <div className="flex size-full w-full flex-col items-center justify-center gap-2 px-8">
-        <div className="w-full">
-          <h3 className={headingClass}>{title}</h3>
-          <p className={subClass}>{countLabel}</p>
-        </div>
-        <div className="flex w-full items-center gap-2">
-          {[0, 1].map((i) => (
-            <div
-              key={i}
-              className="w-full overflow-hidden rounded-sm border bg-background shadow-xs"
-            >
-              <div className="h-6 w-full bg-card md:h-12" />
-              <div className="flex flex-col gap-1 border-t p-1 md:p-2">
-                <div className="h-1 w-1/2 rounded-full bg-muted-foreground/20 md:h-1.5" />
-                <div className="h-0.5 w-3/4 rounded-full bg-muted-foreground/20 md:h-1.5" />
-              </div>
-            </div>
-          ))}
-        </div>
+    ))}
+  </div>
+)
+
+const IllContact = () => (
+  <div className="flex w-full max-w-[70%] items-end gap-2">
+    <div className="flex flex-1 flex-col gap-1.5">
+      <Bar w="w-1/2" />
+      <Pill />
+      <Bar w="w-1/2" />
+      <Pill />
+    </div>
+    <AccentBox className="size-6" />
+  </div>
+)
+
+const IllCta = () => (
+  <div className="flex w-full max-w-[70%] flex-col items-center gap-2">
+    <Bar w="w-3/4" />
+    <Bar w="w-1/2" tone="bg-muted-foreground/10" />
+    <div className="mt-1 flex gap-1.5">
+      <Pill w="w-10" tone="bg-muted-foreground/10" />
+      <Pill w="w-10" tone="bg-primary/30" />
+    </div>
+  </div>
+)
+
+const IllFaq = () => (
+  <div className="flex w-full max-w-[80%] flex-col gap-1 rounded-sm border border-border bg-card/40">
+    {[
+      { w: "w-3/4", emphasis: false },
+      { w: "w-2/3", emphasis: true },
+      { w: "w-1/2", emphasis: false },
+    ].map((row, i) => (
+      <div
+        key={i}
+        className={`flex items-center justify-between gap-2 px-2 py-1 ${i < 2 ? "border-b border-border" : ""}`}
+      >
+        <span
+          className={`block h-1 rounded-full ${row.emphasis ? "bg-primary/35" : "bg-muted-foreground/15"} ${row.w}`}
+        />
+        <span className="block size-1.5 rounded-full bg-muted-foreground/20" />
       </div>
-    ),
-  },
-  {
-    slug: "contact",
-    title: "Contact",
-    count: 0,
-    comingSoon: true,
-    render: ({ title, countLabel }) => (
-      <div className="grid size-full grid-cols-2 gap-4 p-2 md:p-5">
-        <div className="flex flex-col justify-center gap-2">
-          <div>
-            <h3 className={headingClass}>{title}</h3>
-            <p className={subClass}>{countLabel}</p>
-          </div>
-          <div className="h-1 w-full rounded-full bg-muted-foreground/20 md:h-2" />
-          <div className="h-1 w-full rounded-full bg-muted-foreground/20 md:h-2" />
-        </div>
-        <div className="flex h-full w-full flex-col gap-1.5 rounded-md border bg-background p-2 shadow-xs">
-          <div className="h-1 w-8 rounded-full bg-muted-foreground/20 md:h-1.5" />
-          <div className="h-2 w-full rounded-sm border bg-muted/20 md:h-3" />
-          <div className="h-1 w-8 rounded-full bg-muted-foreground/20 md:h-1.5" />
-          <div className="h-2 w-full rounded-sm border bg-muted/20 md:h-3" />
-          <div className="mt-auto h-3 w-full rounded-sm bg-primary/20 md:h-4" />
-        </div>
+    ))}
+  </div>
+)
+
+const IllFeatures = () => (
+  <div className="grid w-full max-w-[80%] grid-cols-3 gap-3">
+    {[0, 1, 2].map((i) => (
+      <div key={i} className="flex flex-col items-center gap-1">
+        <AccentBox className="size-2.5" />
+        <Bar w="w-3/4" />
+        <Bar w="w-full" tone="bg-muted-foreground/10" />
       </div>
-    ),
-  },
-  {
-    slug: "cta",
-    title: "Call to Action",
-    count: BLOCKS_BY_KIND.cta.length,
-    render: ({ title, countLabel }) => (
-      <div className="flex size-full flex-col items-center justify-center gap-2">
-        <h3 className={headingClass}>{title}</h3>
-        <div className="w-full border-y px-4">
-          <div className="grid grid-cols-2 border-x">
-            <div className="flex w-full items-center border-r px-2">
-              <p className={subClass}>{countLabel}</p>
-            </div>
-            <div className="flex items-center gap-2 p-1">
-              <div className="h-4 w-full rounded-sm bg-muted-foreground/20" />
-              <div className="h-4 w-full rounded-sm bg-primary/20" />
-            </div>
-          </div>
-        </div>
+    ))}
+  </div>
+)
+
+const IllFooter = () => (
+  <div className="grid w-full max-w-[80%] grid-cols-4 gap-2">
+    {[3, 3, 3, 1].map((rows, c) => (
+      <div key={c} className="flex flex-col gap-1">
+        <AccentBar w="w-6" className="mb-0.5 h-1" />
+        {Array.from({ length: rows }).map((_, r) => (
+          <Bar key={r} w="w-full" />
+        ))}
       </div>
-    ),
-  },
-  {
-    slug: "faq",
-    title: "Faqs",
-    count: BLOCKS_BY_KIND.faq.length,
-    render: ({ title, countLabel }) => (
-      <div className="grid size-full grid-cols-2">
-        <div className="flex flex-col border-r py-5 ps-3 pe-1 md:px-5">
-          <h3 className={headingClass}>{title}</h3>
-          <p className={subClass}>{countLabel}</p>
-        </div>
-        <div className="flex items-center">
-          <div className="flex w-full flex-col border-t">
-            <div className="flex h-4 w-full items-center border-b px-2 md:h-6">
-              <div className="h-1.5 w-2/3 rounded-full bg-muted-foreground/20" />
-            </div>
-            <div className="flex h-4 w-full items-center border-b px-2 md:h-6">
-              <div className="h-1.5 w-1/2 rounded-full bg-muted-foreground/20" />
-            </div>
-            <div className="flex h-14 w-full flex-col gap-1.5 border-b bg-card px-2 pt-2">
-              <div className="h-1.5 w-3/4 rounded-full bg-primary/20" />
-              <div className="h-1 w-full rounded-full bg-muted-foreground/10" />
-              <div className="h-1 w-full rounded-full bg-muted-foreground/10" />
-              <div className="h-1 w-5/6 rounded-full bg-muted-foreground/10" />
-            </div>
-          </div>
-        </div>
+    ))}
+  </div>
+)
+
+const IllHeader = () => (
+  <div className="flex w-full max-w-[80%] items-center justify-between gap-2 rounded-sm border border-border bg-card/40 px-2 py-1.5">
+    <span className="size-2.5 rounded-full bg-primary/35" />
+    <div className="flex gap-1.5">
+      <Bar w="w-5" />
+      <Bar w="w-5" />
+      <Bar w="w-5" />
+    </div>
+    <Pill w="w-8" tone="bg-primary/25" className="h-2" />
+  </div>
+)
+
+const IllHero = () => (
+  <div className="flex w-full max-w-[60%] flex-col items-center gap-1.5">
+    <Bar w="w-1/3" tone="bg-primary/25" />
+    <Bar w="w-full" />
+    <Bar w="w-3/4" />
+    <div className="mt-1 flex gap-1.5">
+      <Pill w="w-8" tone="bg-primary/30" />
+      <Pill w="w-8" tone="bg-muted-foreground/10" />
+    </div>
+  </div>
+)
+
+const IllGallery = () => (
+  <div className="grid w-full max-w-[80%] grid-cols-4 gap-1">
+    {Array.from({ length: 8 }).map((_, i) => (
+      <Box key={i} className="aspect-square" />
+    ))}
+  </div>
+)
+
+const IllIntegrations = () => (
+  <div className="relative h-[70%] w-[70%]">
+    <span className="absolute left-1/2 top-1/2 h-px w-[55%] -translate-x-1/2 -translate-y-1/2 rotate-45 bg-border" />
+    <span className="absolute left-1/2 top-1/2 h-px w-[55%] -translate-x-1/2 -translate-y-1/2 -rotate-45 bg-border" />
+    <span className="absolute left-1/2 top-1/2 h-px w-[80%] -translate-x-1/2 -translate-y-1/2 bg-border" />
+    <span className="absolute left-1/2 top-1/2 h-[80%] w-px -translate-x-1/2 -translate-y-1/2 bg-border" />
+    <span className="absolute left-1/2 top-1/2 size-4 -translate-x-1/2 -translate-y-1/2 rounded-full border border-border bg-card" />
+    <span className="absolute left-0 top-1/2 size-2.5 -translate-y-1/2 rounded-sm bg-muted-foreground/15" />
+    <span className="absolute right-0 top-1/2 size-2.5 -translate-y-1/2 rounded-sm bg-muted-foreground/15" />
+    <span className="absolute left-1/2 top-0 size-2.5 -translate-x-1/2 rounded-sm bg-muted-foreground/15" />
+    <span className="absolute bottom-0 left-1/2 size-2.5 -translate-x-1/2 rounded-sm bg-primary/30" />
+  </div>
+)
+
+const IllLogoCloud = () => (
+  <div className="flex w-full flex-col items-center gap-1.5">
+    <div className="flex w-[80%] items-center gap-2 [mask-image:linear-gradient(to_right,transparent,black_30%,black_70%,transparent)]">
+      <Pill w="w-full" tone="bg-muted-foreground/10" className="h-2.5" />
+      <Pill w="w-full" tone="bg-muted-foreground/10" className="h-2.5" />
+      <Pill w="w-full" tone="bg-muted-foreground/10" className="h-2.5" />
+      <Pill w="w-full" tone="bg-muted-foreground/10" className="h-2.5" />
+      <Pill w="w-full" tone="bg-muted-foreground/10" className="h-2.5" />
+    </div>
+    <div className="flex w-[60%] items-center gap-2 [mask-image:linear-gradient(to_right,transparent,black_30%,black_70%,transparent)]">
+      <Pill w="w-full" tone="bg-muted-foreground/10" className="h-2.5" />
+      <Pill w="w-full" tone="bg-muted-foreground/10" className="h-2.5" />
+      <Pill w="w-full" tone="bg-muted-foreground/10" className="h-2.5" />
+    </div>
+  </div>
+)
+
+const IllNotFound = () => (
+  <div className="flex flex-col items-center gap-1">
+    <span
+      className="font-mono text-2xl font-semibold leading-none tracking-tight text-muted-foreground/35"
+      style={{ fontVariantNumeric: "tabular-nums" }}
+    >
+      404
+    </span>
+    <Bar w="w-12" tone="bg-muted-foreground/10" />
+  </div>
+)
+
+const IllPricing = () => (
+  <div className="grid w-full max-w-[80%] grid-cols-3 items-end gap-1.5">
+    {[
+      { h: "h-10", accent: false },
+      { h: "h-14", accent: true },
+      { h: "h-12", accent: false },
+    ].map((col, i) => (
+      <div
+        key={i}
+        className={`flex ${col.h} flex-col gap-1 rounded-sm border border-border ${col.accent ? "bg-card" : "bg-card/30"} p-1.5`}
+      >
+        <Bar w="w-1/2" />
+        <AccentBar w="w-3/4" className="mt-auto" />
+        <Bar w="w-full" tone="bg-muted-foreground/10" />
       </div>
-    ),
-  },
-  {
-    slug: "feature",
-    title: "Features",
-    count: BLOCKS_BY_KIND.feature.length,
-    render: ({ title, countLabel }) => (
-      <div className="flex size-full flex-col justify-center gap-2 px-4 md:gap-5">
-        <div className="flex flex-col items-center">
-          <h3 className={headingClass}>{title}</h3>
-          <p className={subClass}>{countLabel}</p>
-        </div>
-        <div className="grid grid-cols-3">
-          {[0, 1, 2].map((i) => (
-            <div
-              key={i}
-              className="relative flex flex-col items-center justify-center py-1 md:py-4"
-            >
-              {i < 2 && (
-                <span className="absolute inset-y-0 right-0 h-full w-px bg-gradient-to-b from-foreground/5 via-foreground/15 to-foreground/5" />
-              )}
-              <div className="size-1.5 rounded-sm bg-primary/20 md:size-2.5" />
-              <div className="mt-1 h-1 w-4 rounded-full bg-muted-foreground/20 md:mt-2 md:h-1.5 md:w-6" />
-              <div className="mt-1 h-1 w-8 rounded-full bg-muted-foreground/20 md:mt-1 md:h-1 md:w-10" />
-            </div>
-          ))}
-        </div>
+    ))}
+  </div>
+)
+
+const IllTestimonial = () => (
+  <div className="flex w-full max-w-[70%] flex-col gap-2">
+    <span className="font-mono text-xl leading-none text-muted-foreground/30">
+      &ldquo;
+    </span>
+    <div className="flex flex-col gap-1 -mt-2">
+      <Bar w="w-full" />
+      <Bar w="w-3/4" />
+    </div>
+    <div className="mt-1 flex items-center gap-1.5">
+      <span className="size-3 rounded-full bg-muted-foreground/25" />
+      <Bar w="w-12" tone="bg-muted-foreground/25" />
+    </div>
+  </div>
+)
+
+const IllAppShell = () => (
+  <div className="flex h-[70%] w-full max-w-[80%] gap-1.5">
+    <div className="flex w-1/4 flex-col gap-1 rounded-sm border border-border bg-card/40 p-1.5">
+      <AccentBar w="w-full" className="h-1" />
+      <Bar w="w-3/4" />
+      <Bar w="w-full" />
+      <Bar w="w-2/3" />
+    </div>
+    <div className="flex flex-1 flex-col gap-1 rounded-sm border border-border bg-card/30 p-1.5">
+      <Bar w="w-1/3" tone="bg-primary/30" />
+      <div className="mt-auto grid grid-cols-3 gap-1">
+        <Box className="h-2.5" />
+        <Box className="h-2.5" />
+        <Box className="h-2.5" />
       </div>
-    ),
-  },
-  {
-    slug: "footer",
-    title: "Footer",
-    count: BLOCKS_BY_KIND.footer.length,
-    render: ({ title, countLabel }) => (
-      <div className="flex size-full w-full flex-col gap-2">
-        <div className="flex flex-col items-center pt-5">
-          <h3 className={headingClass}>{title}</h3>
-          <p className={subClass}>{countLabel}</p>
+    </div>
+  </div>
+)
+
+const IllDashboard = () => (
+  <div className="flex h-[70%] w-full max-w-[80%] flex-col gap-1.5">
+    <div className="grid grid-cols-3 gap-1.5">
+      {[0, 1, 2].map((i) => (
+        <div
+          key={i}
+          className="flex flex-col gap-0.5 rounded-sm border border-border bg-card/40 p-1"
+        >
+          <Bar w="w-2/3" />
+          <AccentBar w="w-1/2" className="h-1.5" />
         </div>
-        <div className="mt-auto border-t px-4 [mask-image:linear-gradient(to_bottom,black_60%,transparent)]">
-          <div className="grid grid-cols-4 gap-2 border-x p-3">
-            {[4, 3, 3, 1].map((rows, c) => (
-              <div key={c} className="flex flex-col gap-1">
-                <div className="mb-1 h-1 w-4 rounded-full bg-primary/20" />
-                {Array.from({ length: rows - 1 }).map((_, r) => (
-                  <div
-                    key={r}
-                    className="h-1 w-6 rounded-full bg-muted-foreground/20"
-                  />
-                ))}
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    ),
-  },
-  {
-    slug: "header",
-    title: "Header",
-    count: BLOCKS_BY_KIND.header.length,
-    render: ({ title, countLabel }) => (
-      <div className="flex size-full w-full flex-col gap-2 p-2 md:p-4">
-        <div className="flex items-center justify-between gap-4 rounded-md border bg-card p-1 shadow-xs">
-          <div className="size-3.5 rounded-full bg-primary/20" />
-          <div className="flex gap-1">
-            <div className="h-1.5 w-5 rounded-full bg-muted-foreground/20 md:w-8" />
-            <div className="h-1.5 w-5 rounded-full bg-muted-foreground/20 md:w-8" />
-            <div className="h-1.5 w-5 rounded-full bg-muted-foreground/20 md:w-8" />
-          </div>
-          <div className="h-3.5 w-8 rounded-sm bg-primary/20 md:w-12" />
-        </div>
-        <div className="flex flex-col items-center pt-2 md:pt-5">
-          <p className={subClass}>{countLabel}</p>
-          <h3 className={headingClass}>{title}</h3>
-        </div>
-      </div>
-    ),
-  },
-  {
-    slug: "hero",
-    title: "Hero Sections",
-    count: BLOCKS_BY_KIND.hero.length,
-    render: ({ title, countLabel }) => (
-      <div className="relative flex size-full w-full flex-col items-center justify-center">
-        <span className="absolute inset-y-0 left-4 w-px bg-gradient-to-b from-transparent via-border to-border" />
-        <span className="absolute inset-y-0 right-4 w-px bg-gradient-to-b from-transparent via-border to-border" />
-        <h3 className={headingClass}>{title}</h3>
-        <p className={subClass}>{countLabel}</p>
-        <div className="mt-2 grid grid-cols-2 gap-2">
-          <div className="mx-auto h-4 w-12 rounded bg-primary/10" />
-          <div className="mx-auto h-4 w-12 rounded bg-primary/20" />
-        </div>
-      </div>
-    ),
-  },
-  {
-    slug: "image-gallery",
-    title: "Image Gallery",
-    count: 0,
-    comingSoon: true,
-    render: ({ title, countLabel }) => (
-      <div className="flex size-full w-full flex-col gap-2 px-4 pt-5">
-        <div className="w-full text-center">
-          <h3 className={headingClass}>{title}</h3>
-          <p className={subClass}>{countLabel}</p>
-        </div>
-        <div className="relative -mt-2.5 size-full [mask-image:linear-gradient(to_bottom,black_60%,transparent)]">
-          <div className="absolute inset-0 grid grid-cols-4 gap-1.5">
-            <div className="flex flex-col gap-1">
-              <div className="aspect-square rounded-sm bg-muted-foreground/10" />
-              <div className="aspect-square rounded-sm bg-muted-foreground/10" />
-            </div>
-            <div className="flex flex-col gap-1 pt-5">
-              <div className="aspect-square rounded-sm bg-muted-foreground/10" />
-              <div className="aspect-square rounded-sm bg-muted-foreground/10" />
-            </div>
-            <div className="flex flex-col gap-1 pt-5">
-              <div className="aspect-square rounded-sm bg-muted-foreground/10" />
-              <div className="aspect-square rounded-sm bg-muted-foreground/10" />
-            </div>
-            <div className="flex flex-col gap-1">
-              <div className="aspect-square rounded-sm bg-muted-foreground/10" />
-              <div className="aspect-square rounded-sm bg-muted-foreground/10" />
-            </div>
-          </div>
-        </div>
-      </div>
-    ),
-  },
-  {
-    slug: "integrations",
-    title: "Integrations",
-    count: 0,
-    comingSoon: true,
-    render: ({ title, countLabel }) => (
-      <div className="grid size-full grid-cols-2 items-center justify-end px-6">
-        <div className="flex items-center px-2">
-          <div>
-            <h3 className={headingClass}>{title}</h3>
-            <p className={subClass}>{countLabel}</p>
-          </div>
-        </div>
-        <div className="relative size-20">
-          <div className="absolute inset-0 z-10 m-auto size-6 rounded-full border bg-card shadow-xs" />
-          <div className="absolute top-0 left-0 z-10 size-4 rounded-md bg-muted" />
-          <div className="absolute top-0 right-0 z-10 size-4 rounded-md bg-muted" />
-          <div className="absolute bottom-0 left-0 z-10 size-4 rounded-md bg-muted" />
-          <div className="absolute right-0 bottom-0 z-10 size-4 rounded-md bg-muted" />
-          <div className="absolute top-1/2 left-1/2 h-px w-full -translate-x-1/2 -translate-y-1/2 -rotate-45 bg-border" />
-          <div className="absolute top-1/2 left-1/2 h-px w-full -translate-x-1/2 -translate-y-1/2 rotate-45 bg-border" />
-        </div>
-      </div>
-    ),
-  },
-  {
-    slug: "logo-cloud",
-    title: "Logo Cloud",
-    count: 0,
-    comingSoon: true,
-    render: ({ title, countLabel }) => (
-      <div className="flex size-full w-full flex-col items-center justify-center">
-        <div className="pb-3 text-center">
-          <h3 className={headingClass}>{title}</h3>
-          <p className={subClass}>{countLabel}</p>
-        </div>
-        <div className="mx-auto h-px w-full max-w-[50%] bg-border [mask-image:linear-gradient(to_right,transparent,black,transparent)]" />
-        <div className="flex w-full items-center gap-2 overflow-hidden py-2 [mask-image:linear-gradient(to_right,transparent,black,transparent)]">
-          {Array.from({ length: 8 }).map((_, i) => (
-            <div
-              key={i}
-              className="h-2.5 w-12 rounded-xs bg-muted-foreground/10 md:h-3.5"
-            />
-          ))}
-        </div>
-        <div className="h-px w-full bg-border [mask-image:linear-gradient(to_right,transparent,black,transparent)]" />
-      </div>
-    ),
-  },
-  {
-    slug: "not-found",
-    title: "Not Found",
-    count: BLOCKS_BY_KIND["not-found"].length,
-    render: ({ title, countLabel }) => (
-      <div className="flex size-full flex-col items-center justify-center">
-        <div className="text-5xl font-extrabold text-muted-foreground/25 [mask-image:linear-gradient(to_bottom,transparent,black_20%,black_80%,transparent)]">
-          404
-        </div>
-        <div className="-mt-2.5 w-full text-center">
-          <h3 className={headingClass}>{title}</h3>
-          <p className={subClass}>{countLabel}</p>
-        </div>
-      </div>
-    ),
-  },
-  {
-    slug: "pricing",
-    title: "Pricing",
-    count: BLOCKS_BY_KIND.pricing.length,
-    render: ({ title, countLabel }) => (
-      <div className="size-full pt-4">
-        <div className="grid size-full grid-cols-3 [mask-image:linear-gradient(to_bottom,black_60%,transparent)]">
-          <div className="flex w-full pt-8">
-            <div className="w-full border-t p-2 md:p-4">
-              <div className="mb-1.5 h-2.5 w-[85%] rounded-md bg-primary/20 md:h-3.5" />
-              <div className="h-1.5 w-[75%] rounded-full bg-muted-foreground/20 md:h-2" />
-            </div>
-          </div>
-          <div className="w-full rounded-t-md border-x border-t p-1 text-center md:p-3">
-            <h3 className={headingClass}>{title}</h3>
-            <p className={subClass}>{countLabel}</p>
-          </div>
-          <div className="flex w-full pt-8">
-            <div className="w-full border-t p-2 md:p-4">
-              <div className="mb-1.5 h-2.5 w-[85%] rounded-md bg-primary/20 md:h-3.5" />
-              <div className="h-2 w-[75%] rounded-full bg-muted-foreground/20" />
-            </div>
-          </div>
-        </div>
-      </div>
-    ),
-  },
-  {
-    slug: "testimonial",
-    title: "Testimonials",
-    count: BLOCKS_BY_KIND.testimonial.length,
-    render: ({ title, countLabel }) => (
-      <div className="flex size-full w-full flex-col items-center justify-center p-4">
-        <div className="w-full text-center">
-          <h3 className={headingClass}>{title}</h3>
-          <p className={subClass}>{countLabel}</p>
-        </div>
-        <div className="flex flex-col items-center gap-2 pt-1 md:pt-4">
-          <div className="mt-1 flex flex-col items-center gap-1">
-            <div className="h-1.5 w-32 rounded-full bg-muted-foreground/40" />
-            <div className="h-1.5 w-24 rounded-full bg-muted-foreground/40" />
-          </div>
-        </div>
-        <div className="mt-2 flex items-center gap-1">
-          <div className="size-5 rounded-full bg-muted-foreground/20" />
-          <div className="h-1.5 w-10 rounded-full bg-muted-foreground/30" />
-        </div>
-      </div>
-    ),
-  },
-  {
-    slug: "app-shell",
-    title: "App Shell",
-    count: 0,
-    comingSoon: true,
-    render: ({ title, countLabel }) => (
-      <div className="grid size-full grid-cols-[1fr_3fr] gap-1 p-2 md:p-3">
-        <div className="flex flex-col gap-1 rounded-sm border bg-card p-1.5 md:p-2">
-          <div className="h-1.5 w-full rounded-full bg-primary/20" />
-          <div className="h-1 w-2/3 rounded-full bg-muted-foreground/20" />
-          <div className="h-1 w-3/4 rounded-full bg-muted-foreground/20" />
-          <div className="h-1 w-1/2 rounded-full bg-muted-foreground/20" />
-          <div className="mt-auto h-1 w-2/3 rounded-full bg-muted-foreground/20" />
-        </div>
-        <div className="flex flex-col gap-1.5 rounded-sm border bg-background p-2">
-          <div className="flex items-center justify-between">
-            <h3 className={headingClass}>{title}</h3>
-            <div className="size-2 rounded-full bg-primary/30" />
-          </div>
-          <p className={subClass}>{countLabel}</p>
-          <div className="mt-auto grid grid-cols-3 gap-1">
-            <div className="h-3 rounded-sm bg-muted-foreground/10" />
-            <div className="h-3 rounded-sm bg-muted-foreground/10" />
-            <div className="h-3 rounded-sm bg-muted-foreground/10" />
-          </div>
-        </div>
-      </div>
-    ),
-  },
-  {
-    slug: "dashboard",
-    title: "Dashboard",
-    count: 0,
-    comingSoon: true,
-    render: ({ title, countLabel }) => (
-      <div className="flex size-full flex-col gap-1.5 p-3">
-        <div className="flex items-center justify-between">
-          <h3 className={headingClass}>{title}</h3>
-          <p className={subClass}>{countLabel}</p>
-        </div>
-        <div className="grid grid-cols-3 gap-1.5">
-          <div className="h-6 rounded-sm border bg-card p-1">
-            <div className="h-1 w-2/3 rounded-full bg-muted-foreground/20" />
-            <div className="mt-1 h-2 w-1/2 rounded-sm bg-primary/30" />
-          </div>
-          <div className="h-6 rounded-sm border bg-card p-1">
-            <div className="h-1 w-2/3 rounded-full bg-muted-foreground/20" />
-            <div className="mt-1 h-2 w-1/2 rounded-sm bg-primary/20" />
-          </div>
-          <div className="h-6 rounded-sm border bg-card p-1">
-            <div className="h-1 w-2/3 rounded-full bg-muted-foreground/20" />
-            <div className="mt-1 h-2 w-1/2 rounded-sm bg-muted-foreground/30" />
-          </div>
-        </div>
-        <div className="mt-auto h-8 rounded-sm border bg-card p-1.5">
-          <div className="flex h-full items-end gap-1">
-            <div className="h-1/3 w-2 rounded-xs bg-primary/30" />
-            <div className="h-2/3 w-2 rounded-xs bg-primary/30" />
-            <div className="h-1/2 w-2 rounded-xs bg-primary/30" />
-            <div className="h-3/4 w-2 rounded-xs bg-primary/30" />
-            <div className="h-2/5 w-2 rounded-xs bg-primary/30" />
-            <div className="h-full w-2 rounded-xs bg-primary/30" />
-          </div>
-        </div>
-      </div>
-    ),
-  },
+      ))}
+    </div>
+    <div className="flex flex-1 items-end gap-1 rounded-sm border border-border bg-card/40 p-1.5">
+      {[40, 70, 50, 80, 35, 60, 90].map((h, i) => (
+        <span
+          key={i}
+          className="block w-1.5 rounded-xs bg-primary/30"
+          style={{ height: `${h}%` }}
+        />
+      ))}
+    </div>
+  </div>
+)
+
+/* -------------------------------------------------------------------------- */
+/* Category registry                                                          */
+/* -------------------------------------------------------------------------- */
+
+const CATEGORIES: CategoryDef[] = [
+  { slug: "hero", title: "Hero Sections", count: BLOCKS_BY_KIND.hero.length, illustration: IllHero },
+  { slug: "feature", title: "Features", count: BLOCKS_BY_KIND.feature.length, illustration: IllFeatures },
+  { slug: "pricing", title: "Pricing", count: BLOCKS_BY_KIND.pricing.length, illustration: IllPricing },
+  { slug: "testimonial", title: "Testimonials", count: BLOCKS_BY_KIND.testimonial.length, illustration: IllTestimonial },
+  { slug: "cta", title: "Call to Action", count: BLOCKS_BY_KIND.cta.length, illustration: IllCta },
+  { slug: "faq", title: "FAQs", count: BLOCKS_BY_KIND.faq.length, illustration: IllFaq },
+  { slug: "login", title: "Auth", count: BLOCKS_BY_KIND.login.length, illustration: IllAuth },
+  { slug: "header", title: "Header", count: BLOCKS_BY_KIND.header.length, illustration: IllHeader },
+  { slug: "footer", title: "Footer", count: BLOCKS_BY_KIND.footer.length, illustration: IllFooter },
+  { slug: "not-found", title: "Not Found", count: BLOCKS_BY_KIND["not-found"].length, illustration: IllNotFound },
+  { slug: "blog", title: "Blog Sections", count: 0, comingSoon: true, illustration: IllBlog },
+  { slug: "contact", title: "Contact", count: 0, comingSoon: true, illustration: IllContact },
+  { slug: "image-gallery", title: "Image Gallery", count: 0, comingSoon: true, illustration: IllGallery },
+  { slug: "integrations", title: "Integrations", count: 0, comingSoon: true, illustration: IllIntegrations },
+  { slug: "logo-cloud", title: "Logo Cloud", count: 0, comingSoon: true, illustration: IllLogoCloud },
+  { slug: "app-shell", title: "App Shell", count: 0, comingSoon: true, illustration: IllAppShell },
+  { slug: "dashboard", title: "Dashboard", count: 0, comingSoon: true, illustration: IllDashboard },
 ]
 
-const ANCHORABLE_KINDS: Record<string, BlockKind> = {
-  login: "login",
-  cta: "cta",
-  faq: "faq",
-  feature: "feature",
-  footer: "footer",
-  header: "header",
+const ANCHORABLE: Partial<Record<CategorySlug, BlockKind>> = {
   hero: "hero",
-  "not-found": "not-found",
+  feature: "feature",
   pricing: "pricing",
   testimonial: "testimonial",
+  cta: "cta",
+  faq: "faq",
+  login: "login",
+  header: "header",
+  footer: "footer",
+  "not-found": "not-found",
 }
+
+function countLabel(count: number, free?: number) {
+  if (free && !count) return `${free} free`
+  if (free) return `${count} blocks · ${free} free`
+  if (count === 0) return "Soon"
+  return `${count} block${count === 1 ? "" : "s"}`
+}
+
+/* -------------------------------------------------------------------------- */
+/* Tile + grid                                                                */
+/* -------------------------------------------------------------------------- */
+
+const tileShell =
+  "group relative flex aspect-[5/4] size-full flex-col overflow-hidden rounded-md border border-border bg-background transition-all duration-200 hover:-translate-y-0.5 hover:border-foreground/30 hover:shadow-[0_8px_24px_-12px_rgba(0,0,0,0.25)]"
 
 type Variant = "plain" | "indexed"
 
@@ -493,136 +387,111 @@ export function BlockCategories({
   hrefPrefix = "",
 }: {
   variant?: Variant
-  /** Prefix prepended to in-page anchor hrefs (e.g. "/blocks" when used off /blocks). */
   hrefPrefix?: string
 } = {}) {
   const total = CATEGORIES.length
-  const totalStr = String(total).padStart(2, "0")
+
   return (
     <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4">
       {CATEGORIES.map((cat, i) => {
-        const label = countLabel(cat.count, cat.freeCount)
-        const anchor = ANCHORABLE_KINDS[cat.slug]
-        const inner = cat.render({ title: cat.title, countLabel: label })
-        const index = String(i + 1).padStart(2, "0")
-        const cardClass = anchor ? cardShell : `${cardShell} opacity-80`
+        const Illustration = cat.illustration
+        const anchor = ANCHORABLE[cat.slug]
+        const href = anchor ? `${hrefPrefix}#${anchor}` : undefined
+        const indexLabel =
+          variant === "indexed" ? String(i + 1).padStart(2, "0") : undefined
 
-        if (variant === "indexed") {
-          return (
-            <IndexedFrame
-              key={cat.slug}
-              index={index}
-              total={totalStr}
-              slug={cat.slug}
-              comingSoon={cat.comingSoon}
-            >
-              {anchor ? (
-                <Link
-                  href={`${hrefPrefix}#${anchor}`}
-                  className={cardClass}
-                  aria-label={`Jump to ${cat.title}`}
-                >
-                  {inner}
-                </Link>
-              ) : (
-                <div
-                  aria-disabled={cat.comingSoon}
-                  className={cardClass}
-                >
-                  {inner}
-                </div>
-              )}
-            </IndexedFrame>
-          )
-        }
-
-        return anchor ? (
-          <Link
+        return (
+          <Tile
             key={cat.slug}
-            href={`${hrefPrefix}#${anchor}`}
-            className={cardClass}
-            aria-label={`Jump to ${cat.title}`}
+            title={cat.title}
+            count={countLabel(cat.count, cat.freeCount)}
+            indexLabel={indexLabel}
+            total={total}
+            href={href}
+            comingSoon={cat.comingSoon}
           >
-            {inner}
-          </Link>
-        ) : (
-          <div
-            key={cat.slug}
-            aria-disabled={cat.comingSoon}
-            className={cardClass}
-          >
-            {inner}
-          </div>
+            <Illustration />
+          </Tile>
         )
       })}
-
-      {variant === "indexed" ? (
-        <IndexedFrame index="+" total={totalStr} slug="more" comingSoon>
-          <div
-            aria-disabled
-            className={`${cardShell} flex flex-col items-center justify-center opacity-80`}
-          >
-            <h3 className={headingClass}>More</h3>
-            <p className={subClass}>Coming Soon…</p>
-          </div>
-        </IndexedFrame>
-      ) : (
-        <div
-          aria-disabled
-          className={`${cardShell} flex flex-col items-center justify-center opacity-80`}
-        >
-          <h3 className={headingClass}>More</h3>
-          <p className={subClass}>Coming Soon…</p>
-        </div>
-      )}
     </div>
   )
 }
 
-/* -------------------------------------------------------------------------- */
-/* Indexed frame — adds a mono NN/total index counter and a hover-reveal      */
-/* slug pill. Differentiates the card grid here from the original             */
-/* inspiration it was adapted from.                                           */
-/* -------------------------------------------------------------------------- */
-
-function IndexedFrame({
-  index,
+function Tile({
+  title,
+  count,
+  indexLabel,
   total,
-  slug,
+  href,
   comingSoon,
   children,
 }: {
-  index: string
-  total: string
-  slug: string
+  title: string
+  count: string
+  indexLabel?: string
+  total: number
+  href?: string
   comingSoon?: boolean
   children: React.ReactNode
 }) {
-  return (
-    <div className="group/frame relative">
-      <span
-        aria-hidden
-        className="pointer-events-none absolute right-2 top-2 z-20 font-mono text-[9px] tabular-nums uppercase tracking-[0.12em] text-muted-foreground/70"
-      >
-        {index}
-        <span className="opacity-40"> / {total}</span>
-      </span>
-
-      {children}
-
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-x-2 bottom-2 z-20 flex items-center justify-between gap-2 opacity-0 transition-opacity duration-150 group-hover/frame:opacity-100"
-      >
-        <span className="inline-flex items-center gap-1 rounded-sm border border-border bg-background/90 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground backdrop-blur-sm">
-          {comingSoon ? "soon" : `/blocks/${slug}`}
-        </span>
-        {!comingSoon && (
-          <span className="inline-flex size-4 items-center justify-center rounded-sm border border-border bg-background/90 text-muted-foreground backdrop-blur-sm">
-            <ArrowUpRight className="size-2.5" />
-          </span>
-        )}
+  const inner = (
+    <>
+      <div className="flex items-start justify-between gap-2 px-3.5 pb-2 pt-2.5">
+        <div className="min-w-0">
+          <h3 className="truncate text-[13px] font-medium tracking-[-0.005em] text-foreground">
+            {title}
+          </h3>
+          <p className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+            {count}
+          </p>
+        </div>
+        <div className="flex items-center gap-1.5">
+          {comingSoon ? (
+            <span className="rounded-sm border border-border bg-card px-1 py-0.5 font-mono text-[8.5px] uppercase tracking-[0.1em] text-muted-foreground">
+              Soon
+            </span>
+          ) : (
+            href && (
+              <span className="inline-flex size-4 items-center justify-center rounded-sm border border-border text-muted-foreground transition-colors group-hover:border-foreground/40 group-hover:text-foreground">
+                <ArrowUpRight className="size-2.5" />
+              </span>
+            )
+          )}
+          {indexLabel && (
+            <span className="font-mono text-[9px] tabular-nums uppercase tracking-[0.1em] text-muted-foreground/60">
+              {indexLabel}
+              <span className="opacity-50">/{String(total).padStart(2, "0")}</span>
+            </span>
+          )}
+        </div>
       </div>
+
+      <div className="relative flex flex-1 items-center justify-center overflow-hidden px-4 pb-4 pt-1">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-3 top-0 h-px bg-gradient-to-r from-transparent via-border to-transparent"
+        />
+        {children}
+      </div>
+    </>
+  )
+
+  if (href) {
+    return (
+      <Link
+        href={href}
+        className={tileShell}
+        aria-label={`Browse ${title} blocks`}
+      >
+        {inner}
+      </Link>
+    )
+  }
+
+  return (
+    <div aria-disabled={comingSoon} className={`${tileShell} cursor-default`}>
+      {inner}
     </div>
   )
 }

--- a/components/showcase/block-categories.tsx
+++ b/components/showcase/block-categories.tsx
@@ -498,9 +498,13 @@ export function BlockCategories({
 } = {}) {
   const total = CATEGORIES.length
   const totalStr = String(total).padStart(2, "0")
+  const gridClass =
+    variant === "indexed"
+      ? "grid grid-cols-2 gap-6 md:grid-cols-3 md:gap-8 lg:grid-cols-4"
+      : "grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4"
 
   return (
-    <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4">
+    <div className={gridClass}>
       {CATEGORIES.map((cat, i) => {
         const label = countLabel(cat.count, cat.freeCount)
         const anchor = ANCHORABLE_KINDS[cat.slug]

--- a/components/showcase/block-categories.tsx
+++ b/components/showcase/block-categories.tsx
@@ -498,13 +498,8 @@ export function BlockCategories({
 } = {}) {
   const total = CATEGORIES.length
   const totalStr = String(total).padStart(2, "0")
-  const gridClass =
-    variant === "indexed"
-      ? "grid grid-cols-2 gap-6 md:grid-cols-3 md:gap-8 lg:grid-cols-4"
-      : "grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4"
-
   return (
-    <div className={gridClass}>
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4">
       {CATEGORIES.map((cat, i) => {
         const label = countLabel(cat.count, cat.freeCount)
         const anchor = ANCHORABLE_KINDS[cat.slug]
@@ -585,9 +580,9 @@ export function BlockCategories({
 }
 
 /* -------------------------------------------------------------------------- */
-/* Indexed frame — adds the project's signature corner marks, a mono index    */
-/* counter, and a hover-reveal slug pill. This is what differentiates the     */
-/* card grid here from the original inspiration it was adapted from.          */
+/* Indexed frame — adds a mono NN/total index counter and a hover-reveal      */
+/* slug pill. Differentiates the card grid here from the original             */
+/* inspiration it was adapted from.                                           */
 /* -------------------------------------------------------------------------- */
 
 function IndexedFrame({
@@ -605,11 +600,6 @@ function IndexedFrame({
 }) {
   return (
     <div className="group/frame relative">
-      <span aria-hidden className="corner-mark -left-1 -top-1" />
-      <span aria-hidden className="corner-mark -right-1 -top-1" />
-      <span aria-hidden className="corner-mark -bottom-1 -left-1" />
-      <span aria-hidden className="corner-mark -bottom-1 -right-1" />
-
       <span
         aria-hidden
         className="pointer-events-none absolute right-2 top-2 z-20 font-mono text-[9px] tabular-nums uppercase tracking-[0.12em] text-muted-foreground/70"

--- a/components/showcase/block-categories.tsx
+++ b/components/showcase/block-categories.tsx
@@ -10,24 +10,7 @@ import {
 /* Design system                                                              */
 /* -------------------------------------------------------------------------- */
 
-type CategorySlug =
-  | BlockKind
-  | "blog"
-  | "contact"
-  | "image-gallery"
-  | "integrations"
-  | "logo-cloud"
-  | "app-shell"
-  | "dashboard"
-
-type CategoryDef = {
-  slug: CategorySlug
-  title: string
-  count: number
-  freeCount?: number
-  comingSoon?: boolean
-  illustration: React.ComponentType
-}
+// (Category types are declared below alongside CATEGORY_REGISTRY.)
 
 /* Illustration primitives — every tile composes from this small palette so
    the grid reads as one design system instead of seventeen sketches. */
@@ -333,43 +316,171 @@ const IllDashboard = () => (
 /* Category registry                                                          */
 /* -------------------------------------------------------------------------- */
 
-const CATEGORIES: CategoryDef[] = [
-  { slug: "hero", title: "Hero Sections", count: BLOCKS_BY_KIND.hero.length, illustration: IllHero },
-  { slug: "feature", title: "Features", count: BLOCKS_BY_KIND.feature.length, illustration: IllFeatures },
-  { slug: "pricing", title: "Pricing", count: BLOCKS_BY_KIND.pricing.length, illustration: IllPricing },
-  { slug: "testimonial", title: "Testimonials", count: BLOCKS_BY_KIND.testimonial.length, illustration: IllTestimonial },
-  { slug: "cta", title: "Call to Action", count: BLOCKS_BY_KIND.cta.length, illustration: IllCta },
-  { slug: "faq", title: "FAQs", count: BLOCKS_BY_KIND.faq.length, illustration: IllFaq },
-  { slug: "login", title: "Auth", count: BLOCKS_BY_KIND.login.length, illustration: IllAuth },
-  { slug: "header", title: "Header", count: BLOCKS_BY_KIND.header.length, illustration: IllHeader },
-  { slug: "footer", title: "Footer", count: BLOCKS_BY_KIND.footer.length, illustration: IllFooter },
-  { slug: "not-found", title: "Not Found", count: BLOCKS_BY_KIND["not-found"].length, illustration: IllNotFound },
-  { slug: "blog", title: "Blog Sections", count: 0, comingSoon: true, illustration: IllBlog },
-  { slug: "contact", title: "Contact", count: 0, comingSoon: true, illustration: IllContact },
-  { slug: "image-gallery", title: "Image Gallery", count: 0, comingSoon: true, illustration: IllGallery },
-  { slug: "integrations", title: "Integrations", count: 0, comingSoon: true, illustration: IllIntegrations },
-  { slug: "logo-cloud", title: "Logo Cloud", count: 0, comingSoon: true, illustration: IllLogoCloud },
-  { slug: "app-shell", title: "App Shell", count: 0, comingSoon: true, illustration: IllAppShell },
-  { slug: "dashboard", title: "Dashboard", count: 0, comingSoon: true, illustration: IllDashboard },
+export type CategoryMeta = {
+  slug: string
+  title: string
+  /** Internal BlockKind — present only for categories that have shipped blocks. */
+  blockKind?: BlockKind
+  comingSoon?: boolean
+  description: string
+}
+
+type CategoryDefWithIllustration = CategoryMeta & {
+  count: number
+  freeCount?: number
+  illustration: React.ComponentType
+}
+
+export const CATEGORY_REGISTRY: CategoryMeta[] = [
+  {
+    slug: "hero",
+    title: "Hero Sections",
+    blockKind: "hero",
+    description:
+      "Above-the-fold openers — split layouts, centered editorials, stat strips, wordmark trust rows.",
+  },
+  {
+    slug: "features",
+    title: "Features",
+    blockKind: "feature",
+    description:
+      "Alternating rows, three-up icon grids, and bordered feature cards.",
+  },
+  {
+    slug: "pricing",
+    title: "Pricing",
+    blockKind: "pricing",
+    description:
+      "Three-tier card layouts and feature-comparison tables, each with per-tier CTAs.",
+  },
+  {
+    slug: "testimonials",
+    title: "Testimonials",
+    blockKind: "testimonial",
+    description:
+      "Single-quote spotlights and masonry quote grids with author rows.",
+  },
+  {
+    slug: "cta",
+    title: "Call to Action",
+    blockKind: "cta",
+    description:
+      "Framed bands and centered announce blocks with inline install hints.",
+  },
+  {
+    slug: "faqs",
+    title: "FAQs",
+    blockKind: "faq",
+    description:
+      "Sticky split layouts and centered accordion grids with numbered indices.",
+  },
+  {
+    slug: "auth",
+    title: "Auth",
+    blockKind: "login",
+    description:
+      "Centered login cards and split testimonial panes with OAuth providers and strength meters.",
+  },
+  {
+    slug: "header",
+    title: "Header",
+    blockKind: "header",
+    description:
+      "Sticky navs with backdrop blur, mobile menus, and dual-CTA layouts.",
+  },
+  {
+    slug: "footer",
+    title: "Footer",
+    blockKind: "footer",
+    description:
+      "Multi-column link layouts with brand block, social row, and copyright rule.",
+  },
+  {
+    slug: "not-found",
+    title: "Not Found",
+    blockKind: "not-found",
+    description:
+      "Centered 404s with paired CTAs and suggested-route lists.",
+  },
+  {
+    slug: "blog",
+    title: "Blog Sections",
+    comingSoon: true,
+    description:
+      "Article grids, featured-post heroes, and editorial card layouts.",
+  },
+  {
+    slug: "contact",
+    title: "Contact",
+    comingSoon: true,
+    description:
+      "Split form-and-info layouts, map embeds, and inline support panels.",
+  },
+  {
+    slug: "image-gallery",
+    title: "Image Gallery",
+    comingSoon: true,
+    description:
+      "Masonry, grid, and carousel gallery layouts with optional lightbox.",
+  },
+  {
+    slug: "integrations",
+    title: "Integrations",
+    comingSoon: true,
+    description:
+      "Hub-and-spoke diagrams, integration cards, and connector showcases.",
+  },
+  {
+    slug: "logo-cloud",
+    title: "Logo Cloud",
+    comingSoon: true,
+    description:
+      "Trusted-by wordmark rows, marquee strips, and bordered logo grids.",
+  },
+  {
+    slug: "app-shell",
+    title: "App Shell",
+    comingSoon: true,
+    description:
+      "Sidebar + topbar layouts with command-palette and breadcrumb chrome.",
+  },
+  {
+    slug: "dashboard",
+    title: "Dashboard",
+    comingSoon: true,
+    description:
+      "Stat cards, charts, and table-driven views composed into full dashboards.",
+  },
 ]
 
-const ANCHORABLE: Partial<Record<CategorySlug, BlockKind>> = {
-  hero: "hero",
-  feature: "feature",
-  pricing: "pricing",
-  testimonial: "testimonial",
-  cta: "cta",
-  faq: "faq",
-  login: "login",
-  header: "header",
-  footer: "footer",
-  "not-found": "not-found",
-}
+export const CATEGORY_BY_SLUG = Object.fromEntries(
+  CATEGORY_REGISTRY.map((c) => [c.slug, c])
+) as Record<string, CategoryMeta>
+
+const CATEGORIES: CategoryDefWithIllustration[] = [
+  { ...CATEGORY_BY_SLUG["hero"], count: BLOCKS_BY_KIND.hero.length, illustration: IllHero },
+  { ...CATEGORY_BY_SLUG["features"], count: BLOCKS_BY_KIND.feature.length, illustration: IllFeatures },
+  { ...CATEGORY_BY_SLUG["pricing"], count: BLOCKS_BY_KIND.pricing.length, illustration: IllPricing },
+  { ...CATEGORY_BY_SLUG["testimonials"], count: BLOCKS_BY_KIND.testimonial.length, illustration: IllTestimonial },
+  { ...CATEGORY_BY_SLUG["cta"], count: BLOCKS_BY_KIND.cta.length, illustration: IllCta },
+  { ...CATEGORY_BY_SLUG["faqs"], count: BLOCKS_BY_KIND.faq.length, illustration: IllFaq },
+  { ...CATEGORY_BY_SLUG["auth"], count: BLOCKS_BY_KIND.login.length, illustration: IllAuth },
+  { ...CATEGORY_BY_SLUG["header"], count: BLOCKS_BY_KIND.header.length, illustration: IllHeader },
+  { ...CATEGORY_BY_SLUG["footer"], count: BLOCKS_BY_KIND.footer.length, illustration: IllFooter },
+  { ...CATEGORY_BY_SLUG["not-found"], count: BLOCKS_BY_KIND["not-found"].length, illustration: IllNotFound },
+  { ...CATEGORY_BY_SLUG["blog"], count: 0, illustration: IllBlog },
+  { ...CATEGORY_BY_SLUG["contact"], count: 0, illustration: IllContact },
+  { ...CATEGORY_BY_SLUG["image-gallery"], count: 0, illustration: IllGallery },
+  { ...CATEGORY_BY_SLUG["integrations"], count: 0, illustration: IllIntegrations },
+  { ...CATEGORY_BY_SLUG["logo-cloud"], count: 0, illustration: IllLogoCloud },
+  { ...CATEGORY_BY_SLUG["app-shell"], count: 0, illustration: IllAppShell },
+  { ...CATEGORY_BY_SLUG["dashboard"], count: 0, illustration: IllDashboard },
+]
 
 function countLabel(count: number, free?: number) {
   if (free && !count) return `${free} free`
   if (free) return `${count} blocks · ${free} free`
-  if (count === 0) return "Soon"
+  if (count === 0) return "Roadmap"
   return `${count} block${count === 1 ? "" : "s"}`
 }
 
@@ -384,10 +495,8 @@ type Variant = "plain" | "indexed"
 
 export function BlockCategories({
   variant = "plain",
-  hrefPrefix = "",
 }: {
   variant?: Variant
-  hrefPrefix?: string
 } = {}) {
   const total = CATEGORIES.length
 
@@ -395,8 +504,6 @@ export function BlockCategories({
     <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4">
       {CATEGORIES.map((cat, i) => {
         const Illustration = cat.illustration
-        const anchor = ANCHORABLE[cat.slug]
-        const href = anchor ? `${hrefPrefix}#${anchor}` : undefined
         const indexLabel =
           variant === "indexed" ? String(i + 1).padStart(2, "0") : undefined
 
@@ -407,7 +514,7 @@ export function BlockCategories({
             count={countLabel(cat.count, cat.freeCount)}
             indexLabel={indexLabel}
             total={total}
-            href={href}
+            href={`/blocks/${cat.slug}`}
             comingSoon={cat.comingSoon}
           >
             <Illustration />
@@ -482,7 +589,9 @@ function Tile({
       <Link
         href={href}
         className={tileShell}
-        aria-label={`Browse ${title} blocks`}
+        aria-label={
+          comingSoon ? `${title} (roadmap)` : `Browse ${title} blocks`
+        }
       >
         {inner}
       </Link>

--- a/components/showcase/block-categories.tsx
+++ b/components/showcase/block-categories.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import { ArrowUpRight } from "lucide-react"
 
 import {
   BLOCKS_BY_KIND,
@@ -485,43 +486,148 @@ const ANCHORABLE_KINDS: Record<string, BlockKind> = {
   testimonial: "testimonial",
 }
 
-export function BlockCategories() {
+type Variant = "plain" | "indexed"
+
+export function BlockCategories({
+  variant = "plain",
+  hrefPrefix = "",
+}: {
+  variant?: Variant
+  /** Prefix prepended to in-page anchor hrefs (e.g. "/blocks" when used off /blocks). */
+  hrefPrefix?: string
+} = {}) {
+  const total = CATEGORIES.length
+  const totalStr = String(total).padStart(2, "0")
+
   return (
     <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-4">
-      {CATEGORIES.map((cat) => {
+      {CATEGORIES.map((cat, i) => {
         const label = countLabel(cat.count, cat.freeCount)
         const anchor = ANCHORABLE_KINDS[cat.slug]
         const inner = cat.render({ title: cat.title, countLabel: label })
+        const index = String(i + 1).padStart(2, "0")
+        const cardClass = anchor ? cardShell : `${cardShell} opacity-80`
 
-        if (anchor) {
+        if (variant === "indexed") {
           return (
-            <Link
+            <IndexedFrame
               key={cat.slug}
-              href={`#${anchor}`}
-              className={cardShell}
-              aria-label={`Jump to ${cat.title}`}
+              index={index}
+              total={totalStr}
+              slug={cat.slug}
+              comingSoon={cat.comingSoon}
             >
-              {inner}
-            </Link>
+              {anchor ? (
+                <Link
+                  href={`${hrefPrefix}#${anchor}`}
+                  className={cardClass}
+                  aria-label={`Jump to ${cat.title}`}
+                >
+                  {inner}
+                </Link>
+              ) : (
+                <div
+                  aria-disabled={cat.comingSoon}
+                  className={cardClass}
+                >
+                  {inner}
+                </div>
+              )}
+            </IndexedFrame>
           )
         }
 
-        return (
+        return anchor ? (
+          <Link
+            key={cat.slug}
+            href={`${hrefPrefix}#${anchor}`}
+            className={cardClass}
+            aria-label={`Jump to ${cat.title}`}
+          >
+            {inner}
+          </Link>
+        ) : (
           <div
             key={cat.slug}
             aria-disabled={cat.comingSoon}
-            className={`${cardShell} opacity-80`}
+            className={cardClass}
           >
             {inner}
           </div>
         )
       })}
-      <div
-        aria-disabled
-        className={`${cardShell} flex flex-col items-center justify-center opacity-80`}
+
+      {variant === "indexed" ? (
+        <IndexedFrame index="+" total={totalStr} slug="more" comingSoon>
+          <div
+            aria-disabled
+            className={`${cardShell} flex flex-col items-center justify-center opacity-80`}
+          >
+            <h3 className={headingClass}>More</h3>
+            <p className={subClass}>Coming Soon…</p>
+          </div>
+        </IndexedFrame>
+      ) : (
+        <div
+          aria-disabled
+          className={`${cardShell} flex flex-col items-center justify-center opacity-80`}
+        >
+          <h3 className={headingClass}>More</h3>
+          <p className={subClass}>Coming Soon…</p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Indexed frame — adds the project's signature corner marks, a mono index    */
+/* counter, and a hover-reveal slug pill. This is what differentiates the     */
+/* card grid here from the original inspiration it was adapted from.          */
+/* -------------------------------------------------------------------------- */
+
+function IndexedFrame({
+  index,
+  total,
+  slug,
+  comingSoon,
+  children,
+}: {
+  index: string
+  total: string
+  slug: string
+  comingSoon?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <div className="group/frame relative">
+      <span aria-hidden className="corner-mark -left-1 -top-1" />
+      <span aria-hidden className="corner-mark -right-1 -top-1" />
+      <span aria-hidden className="corner-mark -bottom-1 -left-1" />
+      <span aria-hidden className="corner-mark -bottom-1 -right-1" />
+
+      <span
+        aria-hidden
+        className="pointer-events-none absolute right-2 top-2 z-20 font-mono text-[9px] tabular-nums uppercase tracking-[0.12em] text-muted-foreground/70"
       >
-        <h3 className={headingClass}>More</h3>
-        <p className={subClass}>Coming Soon…</p>
+        {index}
+        <span className="opacity-40"> / {total}</span>
+      </span>
+
+      {children}
+
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-2 bottom-2 z-20 flex items-center justify-between gap-2 opacity-0 transition-opacity duration-150 group-hover/frame:opacity-100"
+      >
+        <span className="inline-flex items-center gap-1 rounded-sm border border-border bg-background/90 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground backdrop-blur-sm">
+          {comingSoon ? "soon" : `/blocks/${slug}`}
+        </span>
+        {!comingSoon && (
+          <span className="inline-flex size-4 items-center justify-center rounded-sm border border-border bg-background/90 text-muted-foreground backdrop-blur-sm">
+            <ArrowUpRight className="size-2.5" />
+          </span>
+        )}
       </div>
     </div>
   )

--- a/components/showcase/category-page.tsx
+++ b/components/showcase/category-page.tsx
@@ -1,0 +1,162 @@
+import Link from "next/link"
+import { ArrowRight, ArrowUpRight, ChevronLeft } from "lucide-react"
+
+import type { CategoryMeta } from "@/components/showcase/block-categories"
+import { BlockPreview } from "@/components/showcase/block-preview"
+import {
+  BLOCKS_BY_KIND,
+  type RegistryEntryMeta,
+} from "@/registry/msh-ui/registry-meta"
+
+export function CategoryPage({ category }: { category: CategoryMeta }) {
+  const blocks: RegistryEntryMeta[] = category.blockKind
+    ? BLOCKS_BY_KIND[category.blockKind]
+    : []
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 py-10 sm:gap-12 sm:px-6 sm:py-12 md:px-10 md:py-16">
+      <Breadcrumb title={category.title} />
+
+      <header className="flex flex-col gap-5 border-b border-border pb-8 sm:pb-10">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-foreground">
+            ◆ {category.title.toLowerCase()}
+          </span>
+          {category.comingSoon && (
+            <span className="rounded-sm border border-border bg-card px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+              Roadmap
+            </span>
+          )}
+        </div>
+        <h1 className="text-balance text-4xl font-semibold leading-[1.05] tracking-[-0.04em] sm:text-5xl">
+          {category.title}.
+        </h1>
+        <p className="max-w-2xl text-base text-muted-foreground">
+          {category.description}
+        </p>
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          {category.comingSoon
+            ? "Planned · not yet shipped"
+            : `${blocks.length} block${blocks.length === 1 ? "" : "s"} · MIT`}
+        </p>
+      </header>
+
+      {category.comingSoon ? (
+        <RoadmapState category={category} />
+      ) : (
+        <BlocksGrid blocks={blocks} />
+      )}
+    </div>
+  )
+}
+
+function Breadcrumb({ title }: { title: string }) {
+  return (
+    <nav className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+      <Link
+        href="/blocks"
+        className="inline-flex items-center gap-1 transition-colors hover:text-foreground"
+      >
+        <ChevronLeft className="size-3" />
+        Blocks
+      </Link>
+      <span className="text-muted-foreground/50">/</span>
+      <span className="text-foreground">{title}</span>
+    </nav>
+  )
+}
+
+function BlocksGrid({ blocks }: { blocks: RegistryEntryMeta[] }) {
+  return (
+    <section className="flex flex-col gap-6">
+      <div className="flex items-baseline justify-between">
+        <h2 className="font-mono text-xs uppercase tracking-[0.14em] text-muted-foreground">
+          Variants
+        </h2>
+        <span className="font-mono text-[10px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
+          {blocks.length} variant{blocks.length === 1 ? "" : "s"}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 sm:gap-8 lg:grid-cols-2">
+        {blocks.map((entry) => (
+          <Link
+            key={entry.name}
+            href={`/blocks/${entry.name}`}
+            className="group flex flex-col overflow-hidden rounded-sm border border-border bg-background transition-colors hover:border-foreground focus-visible:border-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <BlockPreview name={entry.name} title={entry.title} />
+
+            <div className="flex flex-col gap-2 p-4 sm:p-5">
+              <div className="flex items-center justify-between gap-2">
+                <h3 className="text-base font-medium tracking-[-0.015em]">
+                  {entry.title}
+                </h3>
+                <span className="size-1.5 shrink-0 rounded-full bg-foreground" />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {entry.blockTagline ?? entry.description}
+              </p>
+              <div className="mt-2 flex items-center justify-between gap-2 border-t border-border pt-2.5 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+                <span className="truncate">/blocks/{entry.name}</span>
+                <span className="inline-flex shrink-0 items-center gap-1 text-muted-foreground transition-colors group-hover:text-foreground">
+                  view
+                  <ArrowRight className="size-3 transition-transform duration-150 ease-out group-hover:translate-x-0.5" />
+                </span>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function RoadmapState({ category }: { category: CategoryMeta }) {
+  return (
+    <section className="flex flex-col gap-8">
+      <div className="relative overflow-hidden rounded-md border border-border bg-card/30 p-8 sm:p-12">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 opacity-[0.04] [mask-image:radial-gradient(ellipse_at_top,black,transparent_70%)]"
+          style={{
+            backgroundImage:
+              "radial-gradient(circle at 1px 1px, currentColor 1px, transparent 0)",
+            backgroundSize: "16px 16px",
+          }}
+        />
+        <div className="relative flex flex-col gap-4">
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            In design
+          </span>
+          <h3 className="text-balance text-2xl font-medium tracking-[-0.02em] sm:text-3xl">
+            {category.title} blocks are on the roadmap.
+          </h3>
+          <p className="max-w-xl text-sm text-muted-foreground">
+            {category.description} We&apos;re drafting variants now — the
+            first one ships when it&apos;s good enough that we&apos;d copy it
+            into our own products.
+          </p>
+          <div className="mt-2 flex flex-wrap items-center gap-3 font-mono text-[10px] uppercase tracking-[0.1em]">
+            <Link
+              href="/blocks"
+              className="inline-flex items-center gap-1.5 rounded-sm border border-border bg-background px-3 py-1.5 text-muted-foreground transition-colors hover:border-foreground hover:text-foreground"
+            >
+              <ChevronLeft className="size-3" />
+              All categories
+            </Link>
+            <a
+              href="https://github.com/MohammadShehadeh/forgecn/issues"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex items-center gap-1.5 rounded-sm border border-border bg-background px-3 py-1.5 text-muted-foreground transition-colors hover:border-foreground hover:text-foreground"
+            >
+              Request variant
+              <ArrowUpRight className="size-3" />
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/showcase/component-page.tsx
+++ b/components/showcase/component-page.tsx
@@ -53,12 +53,7 @@ export function ComponentPage({
   }, [showUsageTab])
 
   return (
-    <div
-      className={cn(
-        "mx-auto flex w-full flex-col gap-6 px-4 py-8 sm:gap-8 sm:px-6 sm:py-10 md:px-10",
-        isBlock ? "max-w-6xl" : "max-w-4xl"
-      )}
-    >
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-8 sm:gap-8 sm:px-6 sm:py-10 md:px-10">
       <header className="flex flex-col gap-3 border-b border-border pb-6">
         <div className="flex flex-wrap items-center gap-2">
           <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">

--- a/components/showcase/site-footer.tsx
+++ b/components/showcase/site-footer.tsx
@@ -45,7 +45,7 @@ export function SiteFooter({ className }: { className?: string }) {
         className
       )}
     >
-      <div className="mx-auto w-full max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
+      <div className="mx-auto w-full max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
         <div className="grid grid-cols-2 gap-8 sm:grid-cols-3 md:grid-cols-5">
           <div className="col-span-2 flex flex-col gap-3">
             <Link

--- a/components/showcase/site-header.tsx
+++ b/components/showcase/site-header.tsx
@@ -36,7 +36,7 @@ export function SiteHeader({
         className
       )}
     >
-      <div className="mx-auto flex h-14 w-full max-w-7xl items-center gap-3 px-4 sm:px-6 lg:px-8">
+      <div className="mx-auto flex h-14 w-full max-w-6xl items-center gap-3 px-4 sm:px-6 lg:px-8">
         {withSidebarTrigger}
 
         <Link
@@ -94,7 +94,7 @@ export function SiteHeader({
           id="site-mobile-nav"
           className="border-t border-border bg-background/95 backdrop-blur-md md:hidden"
         >
-          <nav className="mx-auto flex w-full max-w-7xl flex-col gap-0.5 px-4 py-3 sm:px-6">
+          <nav className="mx-auto flex w-full max-w-6xl flex-col gap-0.5 px-4 py-3 sm:px-6">
             {NAV_LINKS.map((link) => {
               const active = isActive(link.href)
               return (


### PR DESCRIPTION
## Summary
Added a new `BlockCategories` component to display block categories in a grid layout on the blocks showcase page, providing users with an organized way to browse blocks by category.

## Key Changes
- **New component**: Created `components/showcase/block-categories.tsx` with:
  - `CategoryCard` type defining category structure with slug, title, count, and custom render function
  - `CATEGORIES` array containing 17 category definitions (login, blog, contact, cta, faq, feature, footer, header, hero, image-gallery, integrations, logo-cloud, not-found, pricing, testimonial, app-shell, dashboard)
  - Visual preview renderers for each category using Tailwind CSS with skeleton/placeholder UI
  - Support for "coming soon" categories and free block counts
  - `ANCHORABLE_KINDS` mapping to enable navigation links to specific block kinds
  - `BlockCategories` component that renders categories as a responsive grid with proper linking

- **Updated blocks page**: Modified `app/(showcase)/blocks/page.tsx` to:
  - Import and display the new `BlockCategories` component
  - Add a "Browse by category" section above the existing block navigation
  - Display category count (17 categories) in the section header

## Implementation Details
- Categories use a consistent card shell styling with hover effects and dark mode support
- Each category has a custom render function that creates a visual preview/mockup of the category type
- Responsive grid layout: 2 columns on mobile, 3 on tablet, 4 on desktop
- Anchorable categories (those with existing block kinds) render as clickable links for navigation
- Coming soon categories are displayed with reduced opacity and disabled state
- Includes a final "More" card indicating additional categories coming soon

https://claude.ai/code/session_01R8evk4xQAUAmHFfx5WTyQp