### PR TITLE
Add Blocks navigation link to Hero section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -101,7 +101,13 @@ function Hero() {
               href="/components"
               className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-border bg-card px-4 text-sm font-medium text-foreground transition-colors hover:border-foreground/40 hover:bg-accent"
             >
-              Explore
+              Components
+            </Link>
+            <Link
+              href="/blocks"
+              className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-border bg-card px-4 text-sm font-medium text-foreground transition-colors hover:border-foreground/40 hover:bg-accent"
+            >
+              Blocks
             </Link>
           </div>
 


### PR DESCRIPTION
## Summary
Updated the Hero section navigation to include a new "Blocks" link alongside the existing "Components" link, and renamed the Components button text from "Explore" to "Components" for clarity.

## Key Changes
- Changed the "Explore" button text to "Components" for better clarity about the destination
- Added a new "Blocks" navigation link with identical styling to the Components button
- Both buttons now clearly indicate their respective destinations in the navigation

## Implementation Details
- The new Blocks link uses the same button styling and hover states as the Components link
- Both links maintain consistent visual design with the existing UI patterns
- The Blocks link routes to `/blocks` endpoint

https://claude.ai/code/session_01Sz1T6EwjFrVYkwBmAW2f8Z