### PR TITLE
Add tree layout view for code blocks and install targets

### DIFF
--- a/components/showcase/code-block.tsx
+++ b/components/showcase/code-block.tsx
@@ -1,12 +1,13 @@
 "use client"
 
 import * as React from "react"
+import { ChevronRight, File, Folder } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { CopyButton } from "@/components/showcase/copy-button"
 
 export type CodeBlockTab = {
-  /** Tab label (e.g. filename). */
+  /** Tab label (e.g. filename or install-target path). */
   label: string
   /** Raw source — used for copy + clipboard. */
   code: string
@@ -14,17 +15,22 @@ export type CodeBlockTab = {
   html: string
 }
 
+export type CodeBlockLayout = "tabs" | "tree"
+
 export function CodeBlock({
   tabs,
   defaultTab,
   className,
   maxHeight = "max-h-[640px]",
+  layout = "tabs",
 }: {
   tabs: CodeBlockTab[]
   defaultTab?: string
   className?: string
   /** Tailwind max-h class for the scroll area. */
   maxHeight?: string
+  /** "tabs" (horizontal) or "tree" (left sidebar file hierarchy). */
+  layout?: CodeBlockLayout
 }) {
   const [active, setActive] = React.useState(
     () => defaultTab ?? tabs[0]?.label
@@ -32,6 +38,44 @@ export function CodeBlock({
   const current = tabs.find((t) => t.label === active) ?? tabs[0]
 
   if (!current) return null
+
+  if (layout === "tree") {
+    return (
+      <div
+        className={cn(
+          "overflow-hidden rounded-md border border-border bg-card",
+          className
+        )}
+      >
+        <div className="flex min-h-0">
+          <FileTree
+            paths={tabs.map((t) => t.label)}
+            active={current.label}
+            onSelect={setActive}
+            maxHeight={maxHeight}
+          />
+          <div className="flex min-w-0 flex-1 flex-col">
+            <div className="flex items-center justify-between gap-2 border-b border-l border-border px-2.5 py-1.5">
+              <span
+                title={current.label}
+                className="truncate font-mono text-[11px] text-muted-foreground"
+              >
+                {current.label}
+              </span>
+              <CopyButton text={current.code} label="Copy code" />
+            </div>
+            <div
+              className={cn(
+                "shiki-scroll overflow-auto border-l border-border",
+                maxHeight
+              )}
+              dangerouslySetInnerHTML={{ __html: current.html }}
+            />
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div
@@ -77,6 +121,156 @@ export function CodeBlock({
         dangerouslySetInnerHTML={{ __html: current.html }}
       />
     </div>
+  )
+}
+
+type TreeNode = {
+  name: string
+  /** Full path when this node is a file; undefined for folders. */
+  filePath?: string
+  children: TreeNode[]
+}
+
+function buildTree(paths: string[]): TreeNode[] {
+  const roots: TreeNode[] = []
+  for (const path of paths) {
+    const parts = path.split("/").filter(Boolean)
+    let level = roots
+    parts.forEach((segment, i) => {
+      const isLeaf = i === parts.length - 1
+      let node = level.find((n) => n.name === segment)
+      if (!node) {
+        node = { name: segment, children: [] }
+        if (isLeaf) node.filePath = path
+        level.push(node)
+      } else if (isLeaf && !node.filePath) {
+        node.filePath = path
+      }
+      level = node.children
+    })
+  }
+  const sort = (nodes: TreeNode[]) => {
+    nodes.sort((a, b) => {
+      const aFolder = a.children.length > 0
+      const bFolder = b.children.length > 0
+      if (aFolder !== bFolder) return aFolder ? -1 : 1
+      return a.name.localeCompare(b.name)
+    })
+    nodes.forEach((n) => sort(n.children))
+  }
+  sort(roots)
+  return roots
+}
+
+function FileTree({
+  paths,
+  active,
+  onSelect,
+  maxHeight,
+}: {
+  paths: string[]
+  active: string
+  onSelect: (path: string) => void
+  maxHeight: string
+}) {
+  const tree = React.useMemo(() => buildTree(paths), [paths])
+  return (
+    <div
+      role="tree"
+      aria-label="Files"
+      className={cn(
+        "w-56 shrink-0 overflow-auto py-2 pl-1 pr-1 text-[12px]",
+        maxHeight
+      )}
+    >
+      {tree.map((node) => (
+        <TreeRow
+          key={node.name}
+          node={node}
+          depth={0}
+          active={active}
+          onSelect={onSelect}
+        />
+      ))}
+    </div>
+  )
+}
+
+function TreeRow({
+  node,
+  depth,
+  active,
+  onSelect,
+}: {
+  node: TreeNode
+  depth: number
+  active: string
+  onSelect: (path: string) => void
+}) {
+  const isFolder = node.children.length > 0
+  const [open, setOpen] = React.useState(true)
+  const indent = { paddingLeft: 8 + depth * 12 }
+
+  if (isFolder) {
+    return (
+      <div role="treeitem" aria-expanded={open} aria-selected={false}>
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          style={indent}
+          className={cn(
+            "flex w-full items-center gap-1.5 rounded-sm py-1 pr-2 text-left font-mono text-muted-foreground transition-colors hover:text-foreground",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          )}
+        >
+          <ChevronRight
+            className={cn(
+              "size-3 shrink-0 transition-transform",
+              open && "rotate-90"
+            )}
+            aria-hidden
+          />
+          <Folder className="size-3 shrink-0" aria-hidden />
+          <span className="truncate">{node.name}</span>
+        </button>
+        {open && (
+          <div role="group">
+            {node.children.map((child) => (
+              <TreeRow
+                key={child.name}
+                node={child}
+                depth={depth + 1}
+                active={active}
+                onSelect={onSelect}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  const isActive = active === node.filePath
+  return (
+    <button
+      type="button"
+      role="treeitem"
+      aria-selected={isActive}
+      onClick={() => node.filePath && onSelect(node.filePath)}
+      style={indent}
+      title={node.filePath}
+      className={cn(
+        "flex w-full items-center gap-1.5 rounded-sm py-1 pr-2 text-left font-mono transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        isActive
+          ? "bg-accent text-foreground"
+          : "text-muted-foreground hover:text-foreground"
+      )}
+    >
+      <span className="size-3 shrink-0" aria-hidden />
+      <File className="size-3 shrink-0" aria-hidden />
+      <span className="truncate">{node.name}</span>
+    </button>
   )
 }
 

--- a/components/showcase/component-page.tsx
+++ b/components/showcase/component-page.tsx
@@ -29,20 +29,22 @@ export function ComponentPage({
 }) {
   const [tab, setTab] = React.useState<Tab>("preview")
 
+  const isBlock = entry.category === "blocks"
+
   const codeTabs: CodeBlockTab[] = React.useMemo(
     () =>
       (entry.sourceFiles ?? [])
-        .map((f) => {
+        .map((f, i) => {
           const file = source[f]
           if (!file) return null
-          return { label: f, code: file.code, html: file.html }
+          const label = isBlock ? entry.installTargets?.[i] ?? f : f
+          return { label, code: file.code, html: file.html }
         })
         .filter((t): t is CodeBlockTab => t !== null),
-    [entry.sourceFiles, source]
+    [entry.sourceFiles, entry.installTargets, source, isBlock]
   )
 
   const Demo = entry.Demo
-  const isBlock = entry.category === "blocks"
   const showUsageTab = !isBlock && !!demoSource
 
   const tabs = React.useMemo<Array<[Tab, string]>>(() => {
@@ -147,7 +149,10 @@ export function ComponentPage({
           )}
 
           {tab === "code" && codeTabs.length > 0 && (
-            <CodeBlock tabs={codeTabs} />
+            <CodeBlock
+              tabs={codeTabs}
+              layout={isBlock ? "tree" : "tabs"}
+            />
           )}
 
           {tab === "install" && (

--- a/registry/msh-ui/registry-meta.ts
+++ b/registry/msh-ui/registry-meta.ts
@@ -65,6 +65,11 @@ export type RegistryEntryMeta = {
   status: "stable" | "planned"
   Demo?: React.ComponentType
   sourceFiles?: string[]
+  /**
+   * Install-target paths, parallel to `sourceFiles`. Shown in the code view
+   * as a file hierarchy so users see where each file lands in their project.
+   */
+  installTargets?: string[]
   installSlug?: string
   registryDependencies?: string[]
   dependencies?: string[]
@@ -264,6 +269,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
     status: "stable",
     Demo: Hero01,
     sourceFiles: ["registry/msh-ui/blocks/hero-01/hero-01.tsx"],
+    installTargets: ["components/blocks/hero-01.tsx"],
     registryDependencies: ["button"],
     dependencies: ["lucide-react"],
   },
@@ -278,6 +284,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
     status: "stable",
     Demo: Hero02,
     sourceFiles: ["registry/msh-ui/blocks/hero-02/hero-02.tsx"],
+    installTargets: ["components/blocks/hero-02.tsx"],
     registryDependencies: ["button"],
     dependencies: ["lucide-react"],
   },
@@ -292,6 +299,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
     status: "stable",
     Demo: Feature01,
     sourceFiles: ["registry/msh-ui/blocks/feature-01/feature-01.tsx"],
+    installTargets: ["components/blocks/feature-01.tsx"],
     registryDependencies: ["button"],
     dependencies: ["lucide-react"],
   },
@@ -306,6 +314,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
     status: "stable",
     Demo: Feature02,
     sourceFiles: ["registry/msh-ui/blocks/feature-02/feature-02.tsx"],
+    installTargets: ["components/blocks/feature-02.tsx"],
     registryDependencies: [],
     dependencies: ["lucide-react"],
   },
@@ -320,6 +329,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
     status: "stable",
     Demo: Pricing01,
     sourceFiles: ["registry/msh-ui/blocks/pricing-01/pricing-01.tsx"],
+    installTargets: ["components/blocks/pricing-01.tsx"],
     registryDependencies: ["button"],
     dependencies: ["lucide-react"],
   },
@@ -334,6 +344,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
     status: "stable",
     Demo: Pricing02,
     sourceFiles: ["registry/msh-ui/blocks/pricing-02/pricing-02.tsx"],
+    installTargets: ["components/blocks/pricing-02.tsx"],
     registryDependencies: ["button"],
     dependencies: ["lucide-react"],
   },
@@ -348,6 +359,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
     status: "stable",
     Demo: Testimonial01,
     sourceFiles: ["registry/msh-ui/blocks/testimonial-01/testimonial-01.tsx"],
+    installTargets: ["components/blocks/testimonial-01.tsx"],
     registryDependencies: [],
     dependencies: [],
   },
@@ -362,6 +374,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
     status: "stable",
     Demo: Testimonial02,
     sourceFiles: ["registry/msh-ui/blocks/testimonial-02/testimonial-02.tsx"],
+    installTargets: ["components/blocks/testimonial-02.tsx"],
     registryDependencies: [],
     dependencies: [],
   },
@@ -376,6 +389,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
     status: "stable",
     Demo: Cta01,
     sourceFiles: ["registry/msh-ui/blocks/cta-01/cta-01.tsx"],
+    installTargets: ["components/blocks/cta-01.tsx"],
     registryDependencies: ["button"],
     dependencies: ["lucide-react"],
   },
@@ -390,6 +404,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
     status: "stable",
     Demo: Cta02,
     sourceFiles: ["registry/msh-ui/blocks/cta-02/cta-02.tsx"],
+    installTargets: ["components/blocks/cta-02.tsx"],
     registryDependencies: ["button"],
     dependencies: ["lucide-react"],
   },
@@ -404,6 +419,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
     status: "stable",
     Demo: Faq01,
     sourceFiles: ["registry/msh-ui/blocks/faq-01/faq-01.tsx"],
+    installTargets: ["components/blocks/faq-01.tsx"],
     registryDependencies: ["button", "accordion"],
     dependencies: ["@radix-ui/react-accordion", "lucide-react"],
   },
@@ -418,6 +434,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
     status: "stable",
     Demo: Faq02,
     sourceFiles: ["registry/msh-ui/blocks/faq-02/faq-02.tsx"],
+    installTargets: ["components/blocks/faq-02.tsx"],
     registryDependencies: ["accordion"],
     dependencies: ["@radix-ui/react-accordion"],
   },
@@ -432,6 +449,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
     status: "stable",
     Demo: Login01,
     sourceFiles: ["registry/msh-ui/blocks/login-01/login-01.tsx"],
+    installTargets: ["components/blocks/login-01.tsx"],
     registryDependencies: ["button", "input", "label", "password-input"],
     dependencies: ["lucide-react"],
   },
@@ -446,6 +464,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
     status: "stable",
     Demo: Login02,
     sourceFiles: ["registry/msh-ui/blocks/login-02/login-02.tsx"],
+    installTargets: ["components/blocks/login-02.tsx"],
     registryDependencies: ["button", "input", "label", "password-input"],
     dependencies: ["lucide-react"],
   },
@@ -460,6 +479,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
     status: "stable",
     Demo: Header01,
     sourceFiles: ["registry/msh-ui/blocks/header-01/header-01.tsx"],
+    installTargets: ["components/blocks/header-01.tsx"],
     registryDependencies: ["button"],
     dependencies: ["lucide-react"],
   },
@@ -474,6 +494,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
     status: "stable",
     Demo: Footer01,
     sourceFiles: ["registry/msh-ui/blocks/footer-01/footer-01.tsx"],
+    installTargets: ["components/blocks/footer-01.tsx"],
     registryDependencies: [],
     dependencies: ["lucide-react"],
   },
@@ -488,6 +509,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
     status: "stable",
     Demo: NotFound01,
     sourceFiles: ["registry/msh-ui/blocks/not-found-01/not-found-01.tsx"],
+    installTargets: ["components/blocks/not-found-01.tsx"],
     registryDependencies: ["button"],
     dependencies: ["lucide-react"],
   },


### PR DESCRIPTION
## Summary
This PR enhances the code block component to support a file tree layout view and adds install target paths to registry entries. This allows users to see where files will be installed in their project structure, particularly useful for block components.

## Key Changes

- **CodeBlock component enhancements:**
  - Added `layout` prop supporting "tabs" (default) and "tree" modes
  - Implemented tree layout that displays files in a hierarchical sidebar with expandable folders
  - Added file/folder icons from lucide-react for visual clarity
  - Tree view shows the active file with highlighting and includes copy button

- **File tree implementation:**
  - Created `buildTree()` utility to convert flat file paths into a hierarchical structure
  - Implemented `FileTree` and `TreeRow` components for rendering the file hierarchy
  - Folders are collapsible with chevron indicators
  - Files are selectable with keyboard navigation support (role="treeitem")
  - Proper sorting: folders first, then alphabetically within each level

- **Registry metadata updates:**
  - Added `installTargets` field to `RegistryEntryMeta` type for specifying where files should be installed
  - Updated all block entries (hero, feature, pricing, testimonial, cta, faq, login, etc.) with corresponding install target paths
  - Install targets follow pattern: `components/blocks/{component-name}.tsx`

- **ComponentPage integration:**
  - Modified code tab generation to use `installTargets` for block components
  - Automatically switches to tree layout for blocks, tabs layout for other components
  - Maintains backward compatibility with existing components

## Implementation Details

- Tree layout uses a two-column design: file tree sidebar (w-56) + code viewer
- Active file is highlighted with accent background color
- Both layouts respect the `maxHeight` prop for scrollable content
- File paths are preserved in tree nodes for proper selection handling
- Accessibility features included: ARIA roles, keyboard focus indicators, and semantic HTML

https://claude.ai/code/session_01NAwctKEggJ6cRxcmPbsoQM