### PR TITLE
Enhance SEO and add Open Graph metadata support

### DIFF
--- a/app/(showcase)/[component]/page.tsx
+++ b/app/(showcase)/[component]/page.tsx
@@ -6,6 +6,7 @@ import type { Metadata } from "next"
 import { ComponentPage } from "@/components/showcase/component-page"
 import type { SourceFile } from "@/components/showcase/component-page"
 import { highlightCode, langFromPath } from "@/lib/highlight"
+import { SITE } from "@/lib/site"
 import { REGISTRY, REGISTRY_BY_NAME } from "@/registry/msh-ui/registry-meta"
 
 export const dynamicParams = false
@@ -24,9 +25,37 @@ export async function generateMetadata({
   const { component } = await params
   const entry = REGISTRY_BY_NAME[component]
   if (!entry || entry.category === "blocks") return {}
+  const url = `${SITE.url}/${entry.name}`
+  const title = `${entry.title} — ${SITE.name}`
   return {
     title: entry.title,
     description: entry.description,
+    alternates: {
+      canonical: `/${entry.name}`,
+    },
+    openGraph: {
+      type: "article",
+      url,
+      siteName: SITE.name,
+      title,
+      description: entry.description,
+      images: [
+        {
+          url: "/opengraph-image",
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: entry.description,
+      creator: SITE.twitterHandle,
+      site: SITE.twitterHandle,
+      images: ["/opengraph-image"],
+    },
   }
 }
 

--- a/app/(showcase)/blocks/[block]/page.tsx
+++ b/app/(showcase)/blocks/[block]/page.tsx
@@ -11,6 +11,7 @@ import {
 import { ComponentPage } from "@/components/showcase/component-page"
 import type { SourceFile } from "@/components/showcase/component-page"
 import { highlightCode, langFromPath } from "@/lib/highlight"
+import { SITE } from "@/lib/site"
 import { REGISTRY, REGISTRY_BY_NAME } from "@/registry/msh-ui/registry-meta"
 
 export const dynamicParams = false
@@ -31,16 +32,72 @@ export async function generateMetadata({
   const { block } = await params
   const category = CATEGORY_BY_SLUG[block]
   if (category) {
+    const title = `${category.title} blocks — ${SITE.name}`
+    const url = `${SITE.url}/blocks/${category.slug}`
     return {
       title: `${category.title} blocks`,
       description: category.description,
+      alternates: {
+        canonical: `/blocks/${category.slug}`,
+      },
+      openGraph: {
+        type: "website",
+        url,
+        siteName: SITE.name,
+        title,
+        description: category.description,
+        images: [
+          {
+            url: "/opengraph-image",
+            width: 1200,
+            height: 630,
+            alt: title,
+          },
+        ],
+      },
+      twitter: {
+        card: "summary_large_image",
+        title,
+        description: category.description,
+        creator: SITE.twitterHandle,
+        site: SITE.twitterHandle,
+        images: ["/opengraph-image"],
+      },
     }
   }
   const entry = REGISTRY_BY_NAME[block]
   if (!entry || entry.category !== "blocks") return {}
+  const url = `${SITE.url}/blocks/${entry.name}`
+  const title = `${entry.title} block — ${SITE.name}`
   return {
     title: `${entry.title} block`,
     description: entry.description,
+    alternates: {
+      canonical: `/blocks/${entry.name}`,
+    },
+    openGraph: {
+      type: "article",
+      url,
+      siteName: SITE.name,
+      title,
+      description: entry.description,
+      images: [
+        {
+          url: "/opengraph-image",
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: entry.description,
+      creator: SITE.twitterHandle,
+      site: SITE.twitterHandle,
+      images: ["/opengraph-image"],
+    },
   }
 }
 

--- a/app/(showcase)/blocks/page.tsx
+++ b/app/(showcase)/blocks/page.tsx
@@ -1,12 +1,41 @@
 import type { Metadata } from "next"
 
 import { BlockCategories } from "@/components/showcase/block-categories"
+import { SITE } from "@/lib/site"
 import { REGISTRY } from "@/registry/msh-ui/registry-meta"
+
+const BLOCKS_DESCRIPTION =
+  "Top-tier, copy-into-your-repo section blocks — heroes, FAQs, CTAs and login screens that share the MSH UI aesthetic."
 
 export const metadata: Metadata = {
   title: "Blocks",
-  description:
-    "Top-tier, copy-into-your-repo section blocks — heroes, FAQs, CTAs and login screens that share the MSH UI aesthetic.",
+  description: BLOCKS_DESCRIPTION,
+  alternates: {
+    canonical: "/blocks",
+  },
+  openGraph: {
+    type: "website",
+    url: `${SITE.url}/blocks`,
+    siteName: SITE.name,
+    title: `Blocks — ${SITE.name}`,
+    description: BLOCKS_DESCRIPTION,
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: `Blocks — ${SITE.name}`,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `Blocks — ${SITE.name}`,
+    description: BLOCKS_DESCRIPTION,
+    creator: SITE.twitterHandle,
+    site: SITE.twitterHandle,
+    images: ["/opengraph-image"],
+  },
 }
 
 export default function BlocksIndex() {

--- a/app/(showcase)/components/page.tsx
+++ b/app/(showcase)/components/page.tsx
@@ -5,6 +5,7 @@ import { ArrowRight, Layers, Palette } from "lucide-react"
 import { InlineCodeBlock } from "@/components/showcase/code-block"
 import { InstallBlock } from "@/components/showcase/install-block"
 import { highlightCode } from "@/lib/highlight"
+import { SITE } from "@/lib/site"
 import {
   BLOCK_KIND_LABELS,
   BLOCK_KIND_ORDER,
@@ -34,10 +35,38 @@ const COMPOSE_SNIPPET = `import {
   <MultiSelectContent searchPlaceholder="Filter…" />
 </MultiSelect>`
 
+const COMPONENTS_DESCRIPTION =
+  "Browse the full MSH UI component registry — multi-select, combobox, tag input, currency input, file dropzone, and the rest of the components shadcn doesn't ship."
+
 export const metadata: Metadata = {
-  title: "Components — MSH UI",
-  description:
-    "Browse the full MSH UI component registry — multi-select, combobox, tag input, currency input, file dropzone, and the rest of the components shadcn doesn't ship.",
+  title: "Components",
+  description: COMPONENTS_DESCRIPTION,
+  alternates: {
+    canonical: "/components",
+  },
+  openGraph: {
+    type: "website",
+    url: `${SITE.url}/components`,
+    siteName: SITE.name,
+    title: `Components — ${SITE.name}`,
+    description: COMPONENTS_DESCRIPTION,
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: `Components — ${SITE.name}`,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `Components — ${SITE.name}`,
+    description: COMPONENTS_DESCRIPTION,
+    creator: SITE.twitterHandle,
+    site: SITE.twitterHandle,
+    images: ["/opengraph-image"],
+  },
 }
 
 export default async function ComponentsIndex() {

--- a/app/(showcase)/theme/page.tsx
+++ b/app/(showcase)/theme/page.tsx
@@ -1,9 +1,40 @@
+import type { Metadata } from "next"
+
+import { SITE } from "@/lib/site"
 import { ThemePlayground } from "./playground"
 
-export const metadata = {
+const THEME_DESCRIPTION =
+  "Preview every MSH UI component against your own theme. Paste CSS variables, pick a preset, and see the registry render live."
+
+export const metadata: Metadata = {
   title: "Theme playground",
-  description:
-    "Preview every MSH UI component against your own theme. Paste CSS variables, pick a preset, and see the registry render live.",
+  description: THEME_DESCRIPTION,
+  alternates: {
+    canonical: "/theme",
+  },
+  openGraph: {
+    type: "website",
+    url: `${SITE.url}/theme`,
+    siteName: SITE.name,
+    title: `Theme playground — ${SITE.name}`,
+    description: THEME_DESCRIPTION,
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: `Theme playground — ${SITE.name}`,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `Theme playground — ${SITE.name}`,
+    description: THEME_DESCRIPTION,
+    creator: SITE.twitterHandle,
+    site: SITE.twitterHandle,
+    images: ["/opengraph-image"],
+  },
 }
 
 export default function ThemePage() {

--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -1,0 +1,42 @@
+import { ImageResponse } from "next/og"
+
+export const size = { width: 180, height: 180 }
+export const contentType = "image/png"
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#0a0a0a",
+          borderRadius: 36,
+          fontFamily: "serif",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 180,
+            fontWeight: 700,
+            lineHeight: 1,
+            color: "transparent",
+            backgroundImage:
+              "linear-gradient(to bottom, #000000 0%, #000000 36%, #FFFFFF 36%, #FFFFFF 58%, #007A3D 58%, #007A3D 100%)",
+            backgroundClip: "text",
+            WebkitBackgroundClip: "text",
+          }}
+        >
+          M
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -1,0 +1,55 @@
+import { ImageResponse } from "next/og"
+
+export const size = { width: 512, height: 512 }
+export const contentType = "image/png"
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#0a0a0a",
+          fontFamily: "serif",
+          position: "relative",
+        }}
+      >
+        <div
+          style={{
+            position: "relative",
+            display: "flex",
+            width: 360,
+            height: 360,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <div
+            style={{
+              position: "absolute",
+              inset: 0,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 460,
+              fontWeight: 700,
+              lineHeight: 1,
+              color: "transparent",
+              backgroundImage:
+                "linear-gradient(to bottom, #000000 0%, #000000 36%, #FFFFFF 36%, #FFFFFF 58%, #007A3D 58%, #007A3D 100%)",
+              backgroundClip: "text",
+              WebkitBackgroundClip: "text",
+            }}
+          >
+            M
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
-import type { Metadata } from "next"
+import type { Metadata, Viewport } from "next"
 import { Fraunces, Geist, Geist_Mono } from "next/font/google"
+import Script from "next/script"
 import "./globals.css"
 
 import { ThemeProvider } from "@/components/showcase/theme-provider"
@@ -23,24 +24,64 @@ const fraunces = Fraunces({
 })
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE.url),
   title: {
     default: `${SITE.name} — ${SITE.description}`,
     template: `%s — ${SITE.name}`,
   },
   description: SITE.longDescription,
+  applicationName: SITE.name,
+  keywords: [...SITE.keywords],
   authors: [{ name: SITE.author, url: SITE.authorUrl }],
   creator: SITE.author,
+  publisher: SITE.author,
+  alternates: {
+    canonical: "/",
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
+  },
   openGraph: {
     type: "website",
+    locale: "en_US",
+    url: SITE.url,
     title: `${SITE.name} — ${SITE.description}`,
     description: SITE.longDescription,
     siteName: SITE.name,
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: `${SITE.name} — ${SITE.description}`,
+      },
+    ],
   },
   twitter: {
     card: "summary_large_image",
     title: `${SITE.name} — ${SITE.description}`,
     description: SITE.longDescription,
+    creator: SITE.twitterHandle,
+    site: SITE.twitterHandle,
+    images: ["/opengraph-image"],
   },
+  category: "technology",
+}
+
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+    { media: "(prefers-color-scheme: dark)", color: "#0a0a0a" },
+  ],
+  colorScheme: "light dark",
 }
 
 export default function RootLayout({
@@ -53,6 +94,42 @@ export default function RootLayout({
       <head>
         <script
           dangerouslySetInnerHTML={{ __html: themePrehydrationScript() }}
+        />
+
+        <Script
+          id="msh-ui-jsonld"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "SoftwareApplication",
+              name: SITE.name,
+              alternateName: ["MSH UI", "msh-ui", "shadcn registry"],
+              description: SITE.longDescription,
+              url: SITE.url,
+              applicationCategory: "DeveloperApplication",
+              operatingSystem: "Any",
+              softwareVersion: SITE.version,
+              license: "https://opensource.org/licenses/MIT",
+              isAccessibleForFree: true,
+              offers: {
+                "@type": "Offer",
+                price: "0",
+                priceCurrency: "USD",
+              },
+              author: {
+                "@type": "Person",
+                name: SITE.author,
+                url: SITE.authorUrl,
+              },
+              creator: {
+                "@type": "Person",
+                name: SITE.author,
+                url: SITE.authorUrl,
+              },
+              sameAs: [SITE.twitterUrl, SITE.githubUrl],
+            }),
+          }}
         />
       </head>
       <body

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,36 @@
+import type { MetadataRoute } from "next"
+
+import { SITE } from "@/lib/site"
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: SITE.fullName,
+    short_name: SITE.name,
+    description: SITE.longDescription,
+    start_url: "/",
+    display: "standalone",
+    background_color: "#0a0a0a",
+    theme_color: "#0a0a0a",
+    categories: ["developer", "design", "productivity"],
+    icons: [
+      {
+        src: "/icon",
+        sizes: "192x192",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/icon",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/apple-icon",
+        sizes: "180x180",
+        type: "image/png",
+        purpose: "any",
+      },
+    ],
+  }
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,210 @@
+import { ImageResponse } from "next/og"
+
+import { SITE } from "@/lib/site"
+
+export const alt = `${SITE.name} — ${SITE.description}`
+export const size = { width: 1200, height: 630 }
+export const contentType = "image/png"
+
+export default async function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          backgroundColor: "#0a0a0a",
+          backgroundImage:
+            "radial-gradient(ellipse 60% 50% at 50% 30%, rgba(255,255,255,0.06), transparent 70%)",
+          color: "#f5f5f5",
+          fontFamily: "serif",
+          padding: 64,
+          position: "relative",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            backgroundImage:
+              "linear-gradient(to right, rgba(255,255,255,0.04) 1px, transparent 1px), linear-gradient(to bottom, rgba(255,255,255,0.04) 1px, transparent 1px)",
+            backgroundSize: "48px 48px",
+          }}
+        />
+
+        <div
+          style={{
+            position: "absolute",
+            top: 56,
+            left: 56,
+            width: 24,
+            height: 24,
+            borderTop: "2px solid #f5f5f5",
+            borderLeft: "2px solid #f5f5f5",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            top: 56,
+            right: 56,
+            width: 24,
+            height: 24,
+            borderTop: "2px solid #f5f5f5",
+            borderRight: "2px solid #f5f5f5",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            bottom: 56,
+            left: 56,
+            width: 24,
+            height: 24,
+            borderBottom: "2px solid #f5f5f5",
+            borderLeft: "2px solid #f5f5f5",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            bottom: 56,
+            right: 56,
+            width: 24,
+            height: 24,
+            borderBottom: "2px solid #f5f5f5",
+            borderRight: "2px solid #f5f5f5",
+          }}
+        />
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            fontFamily: "monospace",
+            fontSize: 18,
+            textTransform: "uppercase",
+            letterSpacing: "0.2em",
+            color: "rgba(245,245,245,0.6)",
+          }}
+        >
+          <span>{SITE.registry.name}</span>
+          <span style={{ color: "rgba(245,245,245,0.3)" }}>/</span>
+          <span>v{SITE.version}</span>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            flex: 1,
+            gap: 32,
+            position: "relative",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 32,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: 200,
+                height: 200,
+                fontSize: 260,
+                fontWeight: 700,
+                lineHeight: 1,
+                color: "transparent",
+                backgroundImage:
+                  "linear-gradient(to bottom, #000000 0%, #000000 36%, #FFFFFF 36%, #FFFFFF 58%, #007A3D 58%, #007A3D 100%)",
+                backgroundClip: "text",
+                WebkitBackgroundClip: "text",
+              }}
+            >
+              M
+            </div>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 8,
+              }}
+            >
+              <div
+                style={{
+                  fontSize: 128,
+                  fontWeight: 700,
+                  letterSpacing: "-0.04em",
+                  lineHeight: 0.95,
+                  color: "#f5f5f5",
+                }}
+              >
+                MSH UI
+              </div>
+              <div
+                style={{
+                  fontFamily: "monospace",
+                  fontSize: 16,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.2em",
+                  color: "rgba(245,245,245,0.5)",
+                }}
+              >
+                peer registry · shadcn cli
+              </div>
+            </div>
+          </div>
+
+          <div
+            style={{
+              fontSize: 40,
+              lineHeight: 1.2,
+              letterSpacing: "-0.02em",
+              maxWidth: 1000,
+              color: "#f5f5f5",
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 10,
+            }}
+          >
+            <span style={{ color: "rgba(245,245,245,0.55)" }}>
+              The components shadcn doesn&apos;t ship —
+            </span>
+            <span style={{ fontWeight: 600 }}>
+              multi-select, combobox, tag input, file dropzone
+            </span>
+            <span style={{ color: "rgba(245,245,245,0.55)" }}>
+              and the rest.
+            </span>
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            fontFamily: "monospace",
+            fontSize: 18,
+            color: "rgba(245,245,245,0.55)",
+          }}
+        >
+          <span>{SITE.url.replace(/^https?:\/\//, "")}</span>
+          <span>{SITE.author}</span>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,10 +17,31 @@ import {
 export const metadata: Metadata = {
   title: `${SITE.name} — ${SITE.description}`,
   description: SITE.longDescription,
+  alternates: {
+    canonical: "/",
+  },
   openGraph: {
+    type: "website",
+    url: SITE.url,
+    siteName: SITE.name,
     title: `${SITE.name} — ${SITE.description}`,
     description: SITE.longDescription,
-    type: "website",
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: `${SITE.name} — ${SITE.description}`,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${SITE.name} — ${SITE.description}`,
+    description: SITE.longDescription,
+    creator: SITE.twitterHandle,
+    site: SITE.twitterHandle,
+    images: ["/opengraph-image"],
   },
 }
 

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next"
+
+import { SITE } from "@/lib/site"
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: "/embed/",
+      },
+    ],
+    sitemap: `${SITE.url}/sitemap.xml`,
+    host: SITE.url,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,72 @@
+import type { MetadataRoute } from "next"
+
+import { CATEGORY_REGISTRY } from "@/components/showcase/block-categories"
+import { SITE } from "@/lib/site"
+import { REGISTRY } from "@/registry/msh-ui/registry-meta"
+
+export const dynamic = "force-static"
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date()
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: `${SITE.url}/`,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${SITE.url}/components`,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    {
+      url: `${SITE.url}/blocks`,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    {
+      url: `${SITE.url}/theme`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+  ]
+
+  const componentRoutes: MetadataRoute.Sitemap = REGISTRY.filter(
+    (entry) => entry.category !== "blocks" && entry.status === "stable"
+  ).map((entry) => ({
+    url: `${SITE.url}/${entry.name}`,
+    lastModified: now,
+    changeFrequency: "monthly",
+    priority: 0.8,
+  }))
+
+  const blockRoutes: MetadataRoute.Sitemap = REGISTRY.filter(
+    (entry) => entry.category === "blocks"
+  ).map((entry) => ({
+    url: `${SITE.url}/blocks/${entry.name}`,
+    lastModified: now,
+    changeFrequency: "monthly",
+    priority: 0.7,
+  }))
+
+  const blockCategoryRoutes: MetadataRoute.Sitemap = CATEGORY_REGISTRY.filter(
+    (category) => !category.comingSoon
+  ).map((category) => ({
+    url: `${SITE.url}/blocks/${category.slug}`,
+    lastModified: now,
+    changeFrequency: "monthly",
+    priority: 0.7,
+  }))
+
+  return [
+    ...staticRoutes,
+    ...componentRoutes,
+    ...blockRoutes,
+    ...blockCategoryRoutes,
+  ]
+}

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -4,14 +4,34 @@
 
 export const SITE = {
   name: "MSH UI",
-  fullName: "MSH UI",
+  fullName: "MSH UI — shadcn's missing pieces",
   description: "shadcn's missing pieces",
   longDescription:
     "A peer registry for the components every real product needs but shadcn doesn't ship — multi-select, combobox, tag input, currency input, file dropzone, and more.",
+  url: "https://msh-ui.dev",
   version: "0.1",
   author: "Mohammad Shehadeh",
   authorUrl: "https://mohammadshehadeh.com",
+  twitterHandle: "@mohammadshhadeh",
   twitterUrl: "https://x.com/mohammadshhadeh",
+  githubUrl: "https://github.com/mohammadshehadeh/forgecn",
+  keywords: [
+    "shadcn",
+    "shadcn ui",
+    "shadcn registry",
+    "react components",
+    "ui library",
+    "tailwind css",
+    "multi-select",
+    "combobox",
+    "tag input",
+    "currency input",
+    "file dropzone",
+    "next.js components",
+    "msh ui",
+    "msh-ui",
+    "react 19",
+  ],
   registry: {
     name: "msh-ui",
     /** Public origin used when generating install URLs server-side. */


### PR DESCRIPTION
## Summary
This PR significantly improves the site's SEO and social media sharing capabilities by adding comprehensive metadata, Open Graph images, web manifest, sitemap, and robots.txt configuration.

## Key Changes

### New Files
- **`app/opengraph-image.tsx`** - Dynamic Open Graph image (1200x630) with branded design featuring the MSH UI logo and tagline
- **`app/icon.tsx`** - Dynamic favicon (512x512) with the branded "M" logo
- **`app/apple-icon.tsx`** - Dynamic Apple touch icon (180x180) for iOS devices
- **`app/manifest.ts`** - Web app manifest for PWA support with app metadata and icon definitions
- **`app/sitemap.ts`** - Dynamic XML sitemap generation covering all static routes, components, blocks, and block categories
- **`app/robots.ts`** - Robots.txt configuration allowing all crawlers except `/embed/` paths

### Enhanced Metadata
- **`app/layout.tsx`** - Expanded root metadata with:
  - Keywords array for better search visibility
  - Robots indexing rules and Google Bot directives
  - Canonical URLs and alternates
  - Open Graph images with proper dimensions
  - Twitter card configuration with creator/site handles
  - JSON-LD structured data (SoftwareApplication schema) for rich search results
  - Viewport configuration with theme color support for light/dark modes

- **`app/page.tsx`** - Added canonical URLs, Open Graph images, and Twitter card metadata to homepage

- **`app/(showcase)/components/page.tsx`** - Added canonical URLs, Open Graph images, and Twitter metadata to components page

- **`app/(showcase)/blocks/page.tsx`** - Added canonical URLs, Open Graph images, and Twitter metadata to blocks page

- **`app/(showcase)/blocks/[block]/page.tsx`** - Enhanced dynamic metadata for block categories and individual blocks with proper canonical URLs and social sharing metadata

- **`app/(showcase)/[component]/page.tsx`** - Enhanced dynamic metadata for individual components with canonical URLs and social sharing metadata

- **`app/(showcase)/theme/page.tsx`** - Added canonical URLs, Open Graph images, and Twitter metadata to theme playground

### Configuration Updates
- **`lib/site.ts`** - Extended SITE configuration with:
  - Full site URL (`https://msh-ui.dev`)
  - Twitter handle (`@mohammadshhadeh`)
  - GitHub URL
  - Comprehensive keywords array for SEO
  - Updated full name with tagline

## Notable Implementation Details
- Open Graph images are dynamically generated using Next.js `ImageResponse` API with a sophisticated design including gradient text, grid background, and corner decorations
- All page metadata follows consistent patterns with canonical URLs, Open Graph, and Twitter card configurations
- Sitemap dynamically filters stable components and includes block categories
- JSON-LD structured data provides rich search result snippets for the application
- Theme colors adapt to user's color scheme preference (light/dark mode)

https://claude.ai/code/session_0176TpAtWhkpDv4Hb7fmnqEW