### PR TITLE
Add Vercel production deployment workflow

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -1,0 +1,46 @@
+name: Vercel Production Deployment
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: vercel-production-deploy
+  cancel-in-progress: false
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: production
+      url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@54
+
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy Project Artifacts to Vercel
+        id: deploy
+        run: |
+          url=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }} | tail -n1)
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "Deployed: $url"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds automated production deployment to Vercel triggered by GitHub releases, with manual workflow dispatch as a fallback option.

## Key Changes
- **GitHub Actions Workflow** (`.github/workflows/release-deploy.yml`): New workflow that automatically deploys to Vercel production when a release is published, or can be manually triggered
  - Triggers on GitHub release publication or manual workflow dispatch
  - Uses concurrency controls to prevent simultaneous deployments
  - Checks out the release tag or current ref
  - Installs pnpm and Vercel CLI
  - Pulls production environment configuration from Vercel
  - Builds project artifacts with production optimizations
  - Deploys prebuilt artifacts to Vercel production
  - Outputs the deployment URL as an environment variable for GitHub

- **Vercel Configuration** (`vercel.json`): New configuration file that disables automatic deployments on the main branch, allowing only manual/workflow-triggered deployments

## Implementation Details
- Uses Vercel secrets (`VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, `VERCEL_TOKEN`) for authentication
- Deploys to the production environment with a 20-minute timeout
- Extracts and exposes the deployment URL for GitHub environment tracking
- Prevents concurrent deployments with concurrency group configuration

https://claude.ai/code/session_012qbxsR1tiWwyxAZTeEkEvo