### PR TITLE
Convert showcase to fully static export

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ match your `components.json`.
 | Script                 | What it does                                              |
 | ---------------------- | --------------------------------------------------------- |
 | `pnpm dev`             | Next.js dev server with Turbopack on port 3000            |
-| `pnpm build`           | `registry:build` then `next build`                        |
-| `pnpm start`           | Serve the production build                                |
+| `pnpm build`           | `registry:build` then `next build` (static export → `out/`) |
+| `pnpm start`           | Serve the static export in `out/` locally                 |
 | `pnpm lint`            | ESLint via `next lint` (`next/core-web-vitals` + TS)      |
 | `pnpm typecheck`       | `tsc --noEmit`                                            |
 | `pnpm registry:build`  | `shadcn build` — generates `/public/r/<name>.json`        |
@@ -249,14 +249,16 @@ identifiers. Motion stays short (120–180ms, ease-out).
 
 ## Deployment
 
-The showcase site is a standard Next.js 15 App Router app. `pnpm build`
-runs `registry:build` first so the generated `/public/r/*.json` files
-travel with the build, then runs `next build`. `pnpm start` serves the
-production output.
+The showcase site is a Next.js 15 App Router app built as a fully
+static export (`output: "export"`). `pnpm build` runs `registry:build`
+first so the generated `/public/r/*.json` files travel with the build,
+then runs `next build`, which pre-renders every route to plain
+HTML/CSS/JS in `out/`. `pnpm start` serves that directory locally.
 
 The canonical deployment runs at [hirael.com](https://hirael.com).
 `.vercel` is gitignored, so Vercel-style deployment is supported out of
-the box; any host that runs a Next.js production server will work.
+the box; because the output is fully static, any static host or CDN
+can serve it — no Node server required.
 
 > **TODO** — document hosting-specific build, env, and domain
 > configuration once the production deployment pipeline is finalized.

--- a/app/(showcase)/components/page.tsx
+++ b/app/(showcase)/components/page.tsx
@@ -37,7 +37,7 @@ const COMPOSE_SNIPPET = `import {
 </MultiSelect>`
 
 const COMPONENTS_DESCRIPTION =
-  "Browse the full Hirael component registry — multi-select, combobox, tag input, currency input, file dropzone, and the rest of the components shadcn doesn't ship."
+  "Browse the full Hirael component registry — multi-select, combobox, tag input, currency input, file dropzone, and the rest of the components shadcn/ui doesn't ship."
 
 export const metadata: Metadata = {
   title: "Components",
@@ -90,7 +90,7 @@ export default async function ComponentsIndex() {
           The registry, in full.
         </h1>
         <p className="max-w-2xl text-base text-muted-foreground">
-          Production-grade components shadcn doesn&apos;t ship — multi-select,
+          Production-grade components shadcn/ui doesn&apos;t ship — multi-select,
           combobox, tag input, currency input, file dropzone — plus {blocks.length} section
           blocks across {BLOCK_KIND_ORDER.length} categories. Distributed via the shadcn
           CLI: source lands in your repo, no Hirael runtime, no breaking

--- a/app/(showcase)/layout.tsx
+++ b/app/(showcase)/layout.tsx
@@ -1,5 +1,3 @@
-import { cookies } from "next/headers"
-
 import { ShowcaseSidebar } from "@/components/showcase/sidebar"
 import { ShowcaseTopbar } from "@/components/showcase/topbar"
 import { SiteFooter } from "@/components/showcase/site-footer"
@@ -8,16 +6,13 @@ import {
   SidebarProvider,
 } from "@/registry/hirael/ui/sidebar"
 
-export default async function ShowcaseLayout({
+export default function ShowcaseLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const cookieStore = await cookies()
-  const defaultOpen = cookieStore.get("sidebar_state")?.value !== "false"
-
   return (
-    <SidebarProvider defaultOpen={defaultOpen}>
+    <SidebarProvider>
       <ShowcaseSidebar />
       <SidebarInset className="min-w-0">
         <ShowcaseTopbar />

--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -1,5 +1,7 @@
 import { ImageResponse } from "next/og"
 
+export const dynamic = "force-static"
+
 export const size = { width: 180, height: 180 }
 export const contentType = "image/png"
 

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -1,5 +1,7 @@
 import { ImageResponse } from "next/og"
 
+export const dynamic = "force-static"
+
 export const size = { width: 64, height: 64 }
 export const contentType = "image/png"
 

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -2,6 +2,8 @@ import type { MetadataRoute } from "next"
 
 import { SITE } from "@/lib/site"
 
+export const dynamic = "force-static"
+
 export default function manifest(): MetadataRoute.Manifest {
   return {
     name: SITE.fullName,

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -3,6 +3,8 @@ import { ImageResponse } from "next/og"
 import { SITE } from "@/lib/site"
 import { REGISTRY } from "@/registry/hirael/registry-meta"
 
+export const dynamic = "force-static"
+
 export const size = { width: 1200, height: 630 }
 export const contentType = "image/png"
 export const alt = `${SITE.name} — ${SITE.description}`

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -82,7 +82,7 @@ function Hero() {
         </span>
 
         <h1 className="text-balance text-4xl font-semibold tracking-tight sm:text-5xl md:text-6xl">
-          The components shadcn doesn&apos;t ship.
+          The components shadcn/ui doesn&apos;t ship.
         </h1>
 
         <p className="max-w-xl text-balance text-base text-muted-foreground sm:text-lg">

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -2,6 +2,8 @@ import type { MetadataRoute } from "next"
 
 import { SITE } from "@/lib/site"
 
+export const dynamic = "force-static"
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [

--- a/components/showcase/sidebar.tsx
+++ b/components/showcase/sidebar.tsx
@@ -45,16 +45,16 @@ export function ShowcaseSidebar() {
   }
 
   return (
-    <Sidebar collapsible="icon" className="border-r border-sidebar-border">
+    <Sidebar collapsible="offcanvas" className="border-r border-sidebar-border">
       <SidebarHeader>
         <Link
           href="/"
-          className="group/brand flex items-center gap-3 rounded-sm px-2 py-2 transition-[width,height,padding,background-color] duration-200 ease-linear hover:bg-sidebar-accent group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:p-2!"
+          className="group/brand flex items-center gap-3 rounded-sm px-2 py-2 transition-colors hover:bg-sidebar-accent"
           aria-label={`${SITE.name} — home`}
         >
-          <LogoMarkM className="size-8 shrink-0 transition-[width,height] duration-200 ease-linear group-data-[collapsible=icon]:size-6" />
+          <LogoMarkM className="size-8 shrink-0" />
           <span
-            className="truncate whitespace-nowrap text-xl leading-none text-foreground group-data-[collapsible=icon]:hidden"
+            className="truncate whitespace-nowrap text-xl leading-none text-foreground"
             style={{
               fontFamily: "var(--font-cormorant), ui-serif, serif",
               fontWeight: 500,
@@ -72,11 +72,7 @@ export function ShowcaseSidebar() {
           <SidebarGroupContent>
             <SidebarMenu>
               <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  isActive={isActive("/components")}
-                  tooltip="All components"
-                >
+                <SidebarMenuButton asChild isActive={isActive("/components")}>
                   <Link href="/components">
                     <Boxes />
                     <span>All components</span>
@@ -84,26 +80,18 @@ export function ShowcaseSidebar() {
                 </SidebarMenuButton>
               </SidebarMenuItem>
               <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  isActive={isActive("/blocks")}
-                  tooltip="Blocks"
-                >
+                <SidebarMenuButton asChild isActive={isActive("/blocks")}>
                   <Link href="/blocks">
                     <LayoutTemplate />
                     <span>Blocks</span>
-                    <span className="ml-auto font-mono text-[10px] tabular-nums text-muted-foreground group-data-[collapsible=icon]:hidden">
+                    <span className="ml-auto font-mono text-[10px] tabular-nums text-muted-foreground">
                       {blockCount}
                     </span>
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>
               <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  isActive={isActive("/theme")}
-                  tooltip="Theme playground"
-                >
+                <SidebarMenuButton asChild isActive={isActive("/theme")}>
                   <Link href="/theme">
                     <Sparkles />
                     <span>Theme playground</span>
@@ -127,11 +115,7 @@ export function ShowcaseSidebar() {
                     const active = isActive(href)
                     return (
                       <SidebarMenuItem key={entry.name}>
-                        <SidebarMenuButton
-                          asChild
-                          isActive={active}
-                          tooltip={entry.title}
-                        >
+                        <SidebarMenuButton asChild isActive={active}>
                           <Link href={href}>
                             <span>{entry.title}</span>
                           </Link>
@@ -147,8 +131,8 @@ export function ShowcaseSidebar() {
       </SidebarContent>
 
       <SidebarFooter>
-        <div className="flex items-center justify-between gap-2 rounded-sm border border-sidebar-border bg-sidebar-accent/30 px-2 py-1.5 group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:border-0 group-data-[collapsible=icon]:bg-transparent group-data-[collapsible=icon]:p-0">
-          <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground group-data-[collapsible=icon]:hidden">
+        <div className="flex items-center justify-between gap-2 rounded-sm border border-sidebar-border bg-sidebar-accent/30 px-2 py-1.5">
+          <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
             peer of shadcn
           </span>
           <ThemeSheetTrigger />

--- a/components/showcase/topbar.tsx
+++ b/components/showcase/topbar.tsx
@@ -21,8 +21,8 @@ export function ShowcaseTopbar() {
 
   return (
     <header className="sticky top-0 z-30 flex h-14 shrink-0 items-center gap-2 border-b border-border bg-background/85 px-3 backdrop-blur-md sm:px-4">
-      <SidebarTrigger className="-ml-1" />
-      <Separator orientation="vertical" className="mx-1 h-5" />
+      <SidebarTrigger className="-ml-1 md:hidden" />
+      <Separator orientation="vertical" className="mx-1 h-5 md:hidden" />
       <Link
         href="/"
         className="flex items-center gap-2 rounded-sm py-1 transition-colors md:hidden"

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,21 +1,16 @@
 import type { NextConfig } from "next"
 
 const nextConfig: NextConfig = {
+  // Fully static site: every route is pre-rendered to plain HTML at build
+  // time (`out/`), so any static host can serve it and client navigation
+  // never waits on a server render. The component/block routes read their
+  // source TSX off disk via fs.readFile, which is fine here because with
+  // `output: "export"` those reads only ever happen during the build.
+  output: "export",
   images: {
-    remotePatterns: [
-      { protocol: "https", hostname: "images.unsplash.com" },
-    ],
-  },
-  // The component/block routes read their source TSX off disk at build time
-  // via fs.readFile(path.join(process.cwd(), ...)). Those files aren't
-  // imported by the route, so Next's tracer doesn't include them in the
-  // server bundle by default — which makes `fs.readFile` miss on hosts that
-  // re-evaluate the route at runtime, and the page falls back to the
-  // "// (unable to read source)" stub. Explicitly tracing the registry
-  // source ensures the files travel with the build.
-  outputFileTracingIncludes: {
-    "/[component]": ["./registry/hirael/**/*.{ts,tsx}"],
-    "/blocks/[block]": ["./registry/hirael/**/*.{ts,tsx}"],
+    // The image optimization endpoint needs a server, which a static
+    // export doesn't have — serve image sources as-is.
+    unoptimized: true,
   },
 }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "node scripts/check-registry.mjs && pnpm registry:build && next build",
-    "start": "next start",
+    "start": "npx serve out",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "registry:build": "shadcn build",


### PR DESCRIPTION
## Summary
Converts the showcase site from a server-rendered Next.js app to a fully static export, enabling deployment on any static host or CDN without requiring a Node server.

## Key Changes

**Build & Deployment Configuration**
- Updated `next.config.ts` to use `output: "export"` for static export
- Removed `outputFileTracingIncludes` (no longer needed with static export)
- Set `images.unoptimized: true` since image optimization requires a server
- Updated `package.json` to serve the static `out/` directory with `npx serve` instead of `next start`

**Route Static Generation**
- Added `export const dynamic = "force-static"` to all metadata/icon routes:
  - `app/icon.tsx`
  - `app/apple-icon.tsx`
  - `app/manifest.ts`
  - `app/opengraph-image.tsx`
  - `app/robots.ts`
- Ensures these routes are pre-rendered at build time rather than on-demand

**Layout & Component Simplification**
- Removed cookie-based sidebar state management from `app/(showcase)/layout.tsx`
  - Changed from async component to sync component
  - Removed `cookies()` import and `defaultOpen` logic
  - Sidebar now uses default open state
- Simplified `ShowcaseSidebar` component:
  - Changed `collapsible="icon"` to `collapsible="offcanvas"` for better mobile UX
  - Removed responsive icon-collapse styles from brand link and menu items
  - Removed `tooltip` props from menu buttons (no longer needed)
  - Removed `group-data-[collapsible=icon]` conditional classes throughout

**Topbar Responsive Updates**
- Added `md:hidden` to `SidebarTrigger` and separator to hide on desktop (sidebar always visible)

**Documentation Updates**
- Updated README.md to clarify that build output is a static export in `out/`
- Updated deployment section to explain the fully static nature and compatibility with any static host

## Implementation Details
The static export approach means:
- Every route is pre-rendered to plain HTML/CSS/JS at build time
- Client-side navigation works without server requests
- Component/block source code is read from disk during build (via `fs.readFile`)
- No runtime server required for deployment
- Compatible with any static host, CDN, or traditional web server

https://claude.ai/code/session_01LUb1Mew6sqhgRdYJhw2CKz