### PR TITLE
Add RTL support across components and blocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,6 +177,16 @@ reformatting committed files.
   color. Light is a faithful inverse of dark; both must work.
 - **`cn` helper.** Compose class names with `cn(...)` from
   `@/lib/utils`. Don't ad-hoc-concatenate `className` strings.
+- **RTL.** Use logical utilities instead of physical ones — `ms-*`/`me-*`
+  over `ml-*`/`mr-*`, `ps-*`/`pe-*` over `pl-*`/`pr-*`, `start-*`/`end-*`
+  over `left-*`/`right-*`, `text-start`/`text-end`, `border-s`/`border-e`,
+  `rounded-s-*`/`rounded-e-*`. Flip directional icons with
+  `rtl:rotate-180` (e.g. prev/next chevrons) and mirror horizontal
+  arrow-key handlers when they move focus through a visual grid.
+  Physical positioning is fine where the geometry genuinely is
+  physical: Radix `data-[side=…]` animations, canvas-like surfaces
+  (color picker), and `side="left|right"` props on Sheet/Sidebar.
+  Verify with the RTL toggle on the component's preview.
 - **Comments.** Comments in registry source are stripped by
   `scripts/strip-comments.mjs` before publishing. Keep helpful
   reasoning in commit messages, PR descriptions, or design docs —

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Hirael
 
-**Tools for builders who think in systems.** A component registry for the
-pieces every real product needs — multi-select, number range, year
-picker, tag input, phone input, file dropzone, the lot. A peer of shadcn,
-not a replacement. Minimal. Thoughtful. Built to last.
+The components shadcn/ui doesn't ship: multi-select, number range, year
+picker, tag input, phone input, file dropzone, and a few dozen more,
+plus full section blocks. Hirael is a shadcn-compatible registry, so it
+works alongside shadcn rather than replacing it. The CLI copies the
+source into your repo and there's no package to depend on.
 
 [![Next.js](https://img.shields.io/badge/Next.js-15-000?logo=nextdotjs&logoColor=white)](https://nextjs.org)
 [![React](https://img.shields.io/badge/React-19-149eca?logo=react&logoColor=white)](https://react.dev)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ npx shadcn@latest add https://hirael.com/r/multi-select.json
 - **Flat compound APIs** — same composition style shadcn ships, with a
   `data-slot="…"` attribute on every rendered slot for downstream
   styling.
+- **RTL support** — components and blocks use CSS logical properties
+  (`ms-*`, `pe-*`, `start-*`, `text-start`, …), mirror directional
+  icons and arrow-key navigation, and work under `dir="rtl"` with no
+  extra configuration. Every preview on the site has an RTL toggle.
 - **Design-token driven** — tokens reuse `--background / --foreground /
   --border / --primary / --accent` and friends, never hard-coded colors.
 

--- a/app/(showcase)/blocks/page.tsx
+++ b/app/(showcase)/blocks/page.tsx
@@ -5,7 +5,7 @@ import { SITE } from "@/lib/site"
 import { BLOCK_KIND_ORDER, REGISTRY } from "@/registry/hirael/registry-meta"
 
 const BLOCKS_DESCRIPTION =
-  "Top-tier, copy-into-your-repo section blocks — heroes, FAQs, CTAs and login screens that share the Hirael aesthetic."
+  "Section blocks for heroes, FAQs, pricing, login screens and dashboards, all in the Hirael style. Copy them into your repo with the shadcn CLI."
 
 export const metadata: Metadata = {
   title: "Blocks",
@@ -53,12 +53,12 @@ export default function BlocksIndex() {
           </span>
         </div>
         <h1 className="text-balance text-4xl font-semibold leading-[1.05] tracking-tight sm:text-5xl md:text-6xl">
-          Blocks that compose, not decorate.
+          Page sections, ready to copy.
         </h1>
         <p className="max-w-2xl text-base text-muted-foreground">
-          Heroes, CTAs, FAQs and auth screens — built on top of the Hirael
-          component registry and aesthetic. Copy a block in one command, then
-          shape it like any other source file in your repo.
+          Heroes, CTAs, FAQs, auth screens and dashboards, all built from
+          the same Hirael components. Copy one in with a single command and
+          edit it like any other file in your repo.
         </p>
         <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
           {blockCount} blocks · {BLOCK_KIND_ORDER.length} categories

--- a/app/(showcase)/components/page.tsx
+++ b/app/(showcase)/components/page.tsx
@@ -37,7 +37,7 @@ const COMPOSE_SNIPPET = `import {
 </MultiSelect>`
 
 const COMPONENTS_DESCRIPTION =
-  "Browse the full Hirael component registry — multi-select, combobox, tag input, currency input, file dropzone, and the rest of the components shadcn/ui doesn't ship."
+  "Every component in the Hirael registry: multi-select, combobox, tag input, currency input, file dropzone, and the rest shadcn/ui leaves out."
 
 export const metadata: Metadata = {
   title: "Components",
@@ -87,14 +87,14 @@ export default async function ComponentsIndex() {
           </span>
         </div>
         <h1 className="text-balance text-4xl font-semibold leading-[1.05] tracking-tight sm:text-5xl">
-          The registry, in full.
+          The full registry.
         </h1>
         <p className="max-w-2xl text-base text-muted-foreground">
-          Production-grade components shadcn/ui doesn&apos;t ship — multi-select,
-          combobox, tag input, currency input, file dropzone — plus {blocks.length} section
-          blocks across {BLOCK_KIND_ORDER.length} categories. Distributed via the shadcn
-          CLI: source lands in your repo, no Hirael runtime, no breaking
-          version bumps.
+          The components shadcn/ui doesn&apos;t ship: multi-select, combobox,
+          tag input, currency input, file dropzone, plus {blocks.length} section blocks
+          across {BLOCK_KIND_ORDER.length} categories. Everything installs through the
+          shadcn CLI, so the source ends up in your repo and stays yours to
+          edit.
         </p>
         <InstallBlock name="multi-select" className="mt-2 max-w-2xl" />
         <CountersStrip

--- a/app/embed/blocks/[block]/embed-shell.tsx
+++ b/app/embed/blocks/[block]/embed-shell.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import * as React from "react"
+
+/**
+ * Client wrapper for statically exported block embeds. Reads the `dir`
+ * query param at runtime so the block viewer can preview blocks in RTL.
+ */
+export function BlockEmbedShell({ children }: { children: React.ReactNode }) {
+  const [dir, setDir] = React.useState<"ltr" | "rtl">("ltr")
+
+  React.useEffect(() => {
+    const param = new URLSearchParams(window.location.search).get("dir")
+    if (param === "rtl") setDir("rtl")
+  }, [])
+
+  return (
+    <div dir={dir} className="min-h-svh bg-background">
+      {children}
+    </div>
+  )
+}

--- a/app/embed/blocks/[block]/page.tsx
+++ b/app/embed/blocks/[block]/page.tsx
@@ -4,6 +4,8 @@ import type { Metadata } from "next"
 import { RegistryDemo } from "@/registry/hirael/registry-demos"
 import { REGISTRY, REGISTRY_BY_NAME } from "@/registry/hirael/registry-meta"
 
+import { BlockEmbedShell } from "./embed-shell"
+
 export const dynamicParams = false
 
 export function generateStaticParams() {
@@ -23,8 +25,8 @@ export default async function BlockEmbedRoute({
   const entry = REGISTRY_BY_NAME[block]
   if (!entry || entry.category !== "blocks") notFound()
   return (
-    <div className="min-h-svh bg-background">
+    <BlockEmbedShell>
       <RegistryDemo name={entry.name} />
-    </div>
+    </BlockEmbedShell>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -86,10 +86,9 @@ function Hero() {
         </h1>
 
         <p className="max-w-xl text-balance text-base text-muted-foreground sm:text-lg">
-          Production-grade React components and section blocks — multi-select,
-          combobox, tag input, file dropzone, and more. Installed with the
-          shadcn CLI, so the source lands in your repo with no runtime
-          dependency.
+          Multi-select, combobox, tag input, file dropzone, plus full
+          section blocks. Install them with the shadcn CLI and the source
+          lands in your repo. No package to update, no runtime dependency.
         </p>
 
         <div className="flex flex-wrap items-center justify-center gap-3 pt-1">
@@ -144,13 +143,12 @@ function LiveRegistry() {
               Live registry
             </span>
             <h2 className="text-balance text-2xl font-semibold tracking-tight sm:text-3xl">
-              Real components, running live.
+              Working demos, not screenshots.
             </h2>
           </div>
           <div className="flex items-center gap-4 self-start sm:self-auto">
             <span className="font-mono text-[10px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
-              {LIVE_DEMOS.length} of {componentCount} · the exact source the CLI
-              installs
+              {LIVE_DEMOS.length} of {componentCount} components
             </span>
             <Link
               href="/components"
@@ -194,7 +192,7 @@ function LiveRegistry() {
         </div>
 
         <p className="mt-4 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
-          Not screenshots — click around. Every demo is the shipped source.
+          Click around. Each demo runs the same source the CLI installs.
         </p>
       </div>
     </section>
@@ -223,7 +221,7 @@ function CategoryGrid() {
               Section blocks
             </span>
             <h2 className="text-balance text-2xl font-semibold tracking-tight sm:text-3xl">
-              Compose full pages, faster.
+              Blocks for whole sections of a page.
             </h2>
           </div>
           <div className="flex items-center gap-4 self-start sm:self-auto">

--- a/components/showcase/block-viewer.tsx
+++ b/components/showcase/block-viewer.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import { ExternalLink, Monitor, RefreshCw, Smartphone, Tablet } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { DirectionToggle } from "@/components/showcase/direction-toggle"
 
 type Viewport = "mobile" | "tablet" | "desktop"
 
@@ -32,6 +33,9 @@ export function BlockViewer({
 }) {
   const [viewport, setViewport] = React.useState<Viewport>("desktop")
   const [key, setKey] = React.useState(0)
+  const [rtl, setRtl] = React.useState(false)
+
+  const src = `/embed/blocks/${name}${rtl ? "?dir=rtl" : ""}`
 
   const sizing =
     viewport === "desktop"
@@ -82,6 +86,7 @@ export function BlockViewer({
         </div>
 
         <div className="flex items-center gap-1">
+          <DirectionToggle rtl={rtl} onToggle={setRtl} className="me-1" />
           <button
             type="button"
             onClick={() => setKey((k) => k + 1)}
@@ -91,7 +96,7 @@ export function BlockViewer({
             <RefreshCw className="size-3.5" />
           </button>
           <a
-            href={`/embed/blocks/${name}`}
+            href={src}
             target="_blank"
             rel="noopener noreferrer"
             aria-label="Open preview in new tab"
@@ -105,7 +110,7 @@ export function BlockViewer({
       <div className="flex justify-center overflow-x-auto bg-card/20 p-3 sm:p-4">
         <iframe
           key={key}
-          src={`/embed/blocks/${name}`}
+          src={src}
           title={`${title} preview`}
           loading="lazy"
           className="block border-0 bg-background transition-[width,max-width] duration-300 ease-out"

--- a/components/showcase/component-page.tsx
+++ b/components/showcase/component-page.tsx
@@ -5,6 +5,7 @@ import * as React from "react"
 import { cn } from "@/lib/utils"
 import { BlockViewer } from "@/components/showcase/block-viewer"
 import { CodeBlock, type CodeBlockTab } from "@/components/showcase/code-block"
+import { DirectionToggle } from "@/components/showcase/direction-toggle"
 import { InstallBlock } from "@/components/showcase/install-block"
 import { RegistryDemo } from "@/registry/hirael/registry-demos"
 import type { RegistryEntryMeta } from "@/registry/hirael/registry-meta"
@@ -29,6 +30,7 @@ export function ComponentPage({
   demoSource?: SourceFile | null
 }) {
   const [tab, setTab] = React.useState<Tab>("preview")
+  const [rtl, setRtl] = React.useState(false)
 
   const isBlock = entry.category === "blocks"
 
@@ -144,8 +146,18 @@ export function ComponentPage({
               (isBlock ? (
                 <BlockViewer name={entry.name} title={entry.title} />
               ) : (
-                <div className="flex min-h-[360px] items-center justify-center rounded-sm border border-border bg-card/40 p-6 sm:min-h-[420px] sm:p-8 md:p-10">
-                  <RegistryDemo name={entry.name} />
+                <div className="relative rounded-sm border border-border bg-card/40">
+                  <DirectionToggle
+                    rtl={rtl}
+                    onToggle={setRtl}
+                    className="absolute right-3 top-3 z-10"
+                  />
+                  <div
+                    dir={rtl ? "rtl" : undefined}
+                    className="flex min-h-[360px] items-center justify-center p-6 sm:min-h-[420px] sm:p-8 md:p-10"
+                  >
+                    <RegistryDemo name={entry.name} />
+                  </div>
                 </div>
               ))}
 

--- a/components/showcase/direction-toggle.tsx
+++ b/components/showcase/direction-toggle.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+
+export function DirectionToggle({
+  rtl,
+  onToggle,
+  className,
+}: {
+  rtl: boolean
+  onToggle: (rtl: boolean) => void
+  className?: string
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={rtl}
+      aria-label="Toggle right-to-left preview"
+      onClick={() => onToggle(!rtl)}
+      className={cn(
+        "inline-flex h-6 items-center rounded-sm border border-border px-2 font-mono text-[10px] uppercase tracking-[0.1em] transition-colors",
+        rtl
+          ? "bg-accent text-foreground"
+          : "bg-background text-muted-foreground hover:text-foreground",
+        className
+      )}
+    >
+      RTL
+    </button>
+  )
+}

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -5,9 +5,9 @@
 export const SITE = {
   name: "Hirael",
   fullName: "Hirael",
-  description: "Tools for builders who think in systems.",
+  description: "The components shadcn/ui doesn't ship.",
   longDescription:
-    "A component registry for the pieces every real product needs. Minimal. Thoughtful. Built to last.",
+    "A shadcn-compatible registry of the inputs and section blocks most products end up needing. The CLI copies the source into your repo, so there's no package to depend on.",
   url: "https://hirael.com",
   version: "0.1",
   author: "Mohammad Shehadeh",

--- a/registry/hirael/blocks/app-shell-01/app-shell-01.tsx
+++ b/registry/hirael/blocks/app-shell-01/app-shell-01.tsx
@@ -125,7 +125,7 @@ export default function AppShell01() {
                 <span className="flex aspect-square size-8 shrink-0 items-center justify-center rounded-md bg-sidebar-primary font-mono text-sm font-semibold text-sidebar-primary-foreground">
                   ◆
                 </span>
-                <div className="grid flex-1 text-left leading-tight">
+                <div className="grid flex-1 text-start leading-tight">
                   <span className="truncate text-sm font-semibold tracking-[-0.01em]">
                     Hirael
                   </span>
@@ -192,7 +192,7 @@ export default function AppShell01() {
                 <span className="flex aspect-square size-8 shrink-0 items-center justify-center rounded-md bg-sidebar-primary font-mono text-[10px] font-medium text-sidebar-primary-foreground">
                   MS
                 </span>
-                <div className="grid flex-1 text-left leading-tight">
+                <div className="grid flex-1 text-start leading-tight">
                   <span className="truncate text-xs font-medium">
                     Mohammad Shehadeh
                   </span>
@@ -208,7 +208,7 @@ export default function AppShell01() {
 
       <SidebarInset className="min-w-0">
         <header className="sticky top-0 z-10 flex h-14 items-center gap-2 border-b border-border bg-background/80 px-3 backdrop-blur sm:px-4">
-          <SidebarTrigger className="-ml-1" />
+          <SidebarTrigger className="-ms-1" />
           <Separator orientation="vertical" className="mx-1 hidden h-5 sm:block" />
           <nav
             aria-label="Breadcrumb"
@@ -219,7 +219,7 @@ export default function AppShell01() {
             <span className="text-foreground">Dashboard</span>
           </nav>
 
-          <InputGroup className="ml-auto h-8 max-w-xs">
+          <InputGroup className="ms-auto h-8 max-w-xs">
             <InputGroupAddon align="inline-start">
               <Search className="size-3.5" />
             </InputGroupAddon>
@@ -244,7 +244,7 @@ export default function AppShell01() {
             className="relative size-8"
           >
             <Bell className="size-3.5" />
-            <span className="absolute right-1.5 top-1.5 size-1.5 rounded-full bg-foreground" />
+            <span className="absolute end-1.5 top-1.5 size-1.5 rounded-full bg-foreground" />
           </Button>
           <Button size="sm" className="hidden sm:inline-flex">
             <Plus className="size-3" />
@@ -286,7 +286,7 @@ export default function AppShell01() {
               <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
                 · recent accounts
                 {query && (
-                  <span className="ml-2 text-foreground">
+                  <span className="ms-2 text-foreground">
                     ({filteredRows.length} of {ROWS.length})
                   </span>
                 )}
@@ -319,14 +319,14 @@ export default function AppShell01() {
               <div className="overflow-x-auto">
                 <table className="w-full">
                   <thead>
-                    <tr className="text-left font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+                    <tr className="text-start font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
                       <th className="px-4 py-2 font-normal">Account</th>
                       <th className="px-4 py-2 font-normal">Plan</th>
                       <th className="hidden px-4 py-2 font-normal sm:table-cell">
                         MRR
                       </th>
                       <th className="px-4 py-2 font-normal">Status</th>
-                      <th className="px-4 py-2 text-right font-normal">
+                      <th className="px-4 py-2 text-end font-normal">
                         <span className="sr-only">Actions</span>
                       </th>
                     </tr>
@@ -364,7 +364,7 @@ export default function AppShell01() {
                             </span>
                           </span>
                         </td>
-                        <td className="px-4 py-2.5 text-right">
+                        <td className="px-4 py-2.5 text-end">
                           <Button
                             variant="ghost"
                             size="icon"

--- a/registry/hirael/blocks/app-shell-02/app-shell-02.tsx
+++ b/registry/hirael/blocks/app-shell-02/app-shell-02.tsx
@@ -114,7 +114,7 @@ export default function AppShell02() {
             ))}
           </nav>
 
-          <InputGroup className="ml-auto h-8 max-w-[200px]">
+          <InputGroup className="ms-auto h-8 max-w-[200px]">
             <InputGroupAddon align="inline-start">
               <Search className="size-3.5" />
             </InputGroupAddon>
@@ -128,7 +128,7 @@ export default function AppShell02() {
             className="relative size-8"
           >
             <Bell className="size-3.5" />
-            <span className="absolute right-1.5 top-1.5 size-1.5 rounded-full bg-foreground" />
+            <span className="absolute end-1.5 top-1.5 size-1.5 rounded-full bg-foreground" />
           </Button>
           <span className="inline-flex size-8 items-center justify-center rounded-full bg-foreground font-mono text-[10px] font-medium text-background">
             MS
@@ -158,7 +158,7 @@ export default function AppShell02() {
                       type="button"
                       onClick={() => setActive(t.id)}
                       aria-current={isActive ? "page" : undefined}
-                      className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-accent aria-[current=page]:bg-accent aria-[current=page]:font-medium"
+                      className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-start text-sm transition-colors hover:bg-accent aria-[current=page]:bg-accent aria-[current=page]:font-medium"
                     >
                       <t.icon className="size-4 shrink-0 text-muted-foreground" />
                       <span className="whitespace-nowrap">{t.label}</span>

--- a/registry/hirael/blocks/app-shell-03/app-shell-03.tsx
+++ b/registry/hirael/blocks/app-shell-03/app-shell-03.tsx
@@ -247,7 +247,7 @@ export default function AppShell03() {
     <div className="flex min-h-[640px] bg-background">
       <aside
         aria-label="Mailboxes"
-        className="flex w-14 shrink-0 flex-col items-center gap-1 border-r border-border py-3"
+        className="flex w-14 shrink-0 flex-col items-center gap-1 border-e border-border py-3"
       >
         <span
           role="img"
@@ -272,7 +272,7 @@ export default function AppShell03() {
               >
                 <item.icon className="size-4" />
                 {item.current && unreadCount > 0 && (
-                  <span className="absolute right-1.5 top-1.5 size-1.5 rounded-full bg-foreground" />
+                  <span className="absolute end-1.5 top-1.5 size-1.5 rounded-full bg-foreground" />
                 )}
               </button>
             </TooltipTrigger>
@@ -300,7 +300,7 @@ export default function AppShell03() {
 
       <section
         aria-label="Conversations"
-        className="hidden w-80 shrink-0 flex-col border-r border-border md:flex"
+        className="hidden w-80 shrink-0 flex-col border-e border-border md:flex"
       >
         <div className="flex h-14 shrink-0 items-center justify-between gap-2 px-4">
           <h2 className="text-sm font-medium tracking-[-0.01em]">Inbox</h2>
@@ -360,7 +360,7 @@ export default function AppShell03() {
                   onClick={() => openConversation(c.id)}
                   aria-current={active ? "true" : undefined}
                   className={cn(
-                    "flex w-full flex-col gap-0.5 border-b border-border px-4 py-3 text-left transition-colors",
+                    "flex w-full flex-col gap-0.5 border-b border-border px-4 py-3 text-start transition-colors",
                     active ? "bg-accent/70" : "hover:bg-accent/40"
                   )}
                 >
@@ -379,7 +379,7 @@ export default function AppShell03() {
                     >
                       {c.sender}
                     </span>
-                    <span className="ml-auto shrink-0 font-mono text-[10px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
+                    <span className="ms-auto shrink-0 font-mono text-[10px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
                       {c.time}
                     </span>
                   </span>
@@ -464,7 +464,7 @@ export default function AppShell03() {
                   {m.initials}
                 </span>
                 <span className="text-xs font-medium">{m.from}</span>
-                <span className="ml-auto font-mono text-[10px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
+                <span className="ms-auto font-mono text-[10px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
                   {m.time}
                 </span>
               </div>

--- a/registry/hirael/blocks/app-shell-04/app-shell-04.tsx
+++ b/registry/hirael/blocks/app-shell-04/app-shell-04.tsx
@@ -81,7 +81,7 @@ export default function AppShell04() {
                 <span className="flex aspect-square size-8 shrink-0 items-center justify-center rounded-md bg-sidebar-primary font-mono text-sm font-semibold text-sidebar-primary-foreground">
                   ◆
                 </span>
-                <div className="grid flex-1 text-left leading-tight">
+                <div className="grid flex-1 text-start leading-tight">
                   <span className="truncate text-sm font-semibold tracking-[-0.01em]">
                     Plinth Labs
                   </span>
@@ -170,7 +170,7 @@ export default function AppShell04() {
               aria-label="Notifications · 3 unread"
             >
               <Bell className="size-4" />
-              <Badge className="absolute -right-1 -top-1 size-4 justify-center rounded-full p-0 font-mono text-[9px]">
+              <Badge className="absolute -end-1 -top-1 size-4 justify-center rounded-full p-0 font-mono text-[9px]">
                 3
               </Badge>
             </Button>

--- a/registry/hirael/blocks/cta-01/cta-01.tsx
+++ b/registry/hirael/blocks/cta-01/cta-01.tsx
@@ -67,7 +67,7 @@ export default function Cta01() {
               >
                 <a href="#">Browse blocks</a>
               </Button>
-              <p className="text-right font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+              <p className="text-end font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
                 No runtime dependency
               </p>
             </div>

--- a/registry/hirael/blocks/dashboard-01/dashboard-01.tsx
+++ b/registry/hirael/blocks/dashboard-01/dashboard-01.tsx
@@ -254,7 +254,7 @@ export default function Dashboard01() {
                   </CardTitle>
                 </div>
                 <div className="flex items-center gap-3">
-                  <div className="text-right">
+                  <div className="text-end">
                     <span className="block font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
                       Conversion
                     </span>

--- a/registry/hirael/blocks/dashboard-02/dashboard-02.tsx
+++ b/registry/hirael/blocks/dashboard-02/dashboard-02.tsx
@@ -366,7 +366,7 @@ export default function Dashboard02() {
                         style={{ width: `${c.share}%` }}
                       />
                     </div>
-                    <span className="w-9 shrink-0 text-right font-mono text-xs tabular-nums text-muted-foreground">
+                    <span className="w-9 shrink-0 text-end font-mono text-xs tabular-nums text-muted-foreground">
                       {c.share}%
                     </span>
                   </div>

--- a/registry/hirael/blocks/dashboard-03/dashboard-03.tsx
+++ b/registry/hirael/blocks/dashboard-03/dashboard-03.tsx
@@ -156,7 +156,7 @@ export default function Dashboard03() {
               <Button
                 variant="ghost"
                 size="icon"
-                className="size-8 rounded-r-none"
+                className="size-8 rounded-e-none"
                 onClick={() => setMonthIndex((i) => Math.max(0, i - 1))}
                 disabled={monthIndex === 0}
                 aria-label="Previous month"
@@ -169,7 +169,7 @@ export default function Dashboard03() {
               <Button
                 variant="ghost"
                 size="icon"
-                className="size-8 rounded-l-none"
+                className="size-8 rounded-s-none"
                 onClick={() =>
                   setMonthIndex((i) => Math.min(MONTHS.length - 1, i + 1))
                 }
@@ -214,10 +214,10 @@ export default function Dashboard03() {
                         className={`size-2 rounded-xs ${p.dot}`}
                       />
                       <span className="text-xs text-foreground">{p.label}</span>
-                      <span className="ml-auto font-mono text-xs tabular-nums text-muted-foreground">
+                      <span className="ms-auto font-mono text-xs tabular-nums text-muted-foreground">
                         {p.share}%
                       </span>
-                      <span className="w-16 text-right font-mono text-xs tabular-nums">
+                      <span className="w-16 text-end font-mono text-xs tabular-nums">
                         {p.mrr}
                       </span>
                     </div>
@@ -240,10 +240,10 @@ export default function Dashboard03() {
                     <div className="flex items-center gap-2.5">
                       <span className={`size-1.5 rounded-full ${inv.dot}`} />
                       <span className="text-xs text-foreground">{inv.label}</span>
-                      <span className="ml-auto font-mono text-xs tabular-nums text-muted-foreground">
+                      <span className="ms-auto font-mono text-xs tabular-nums text-muted-foreground">
                         {inv.count}
                       </span>
-                      <span className="w-20 text-right font-mono text-xs tabular-nums">
+                      <span className="w-20 text-end font-mono text-xs tabular-nums">
                         {inv.amount}
                       </span>
                     </div>
@@ -272,7 +272,7 @@ export default function Dashboard03() {
                 <span>Customer</span>
                 <span>Status</span>
                 <span>Date</span>
-                <span className="text-right">Amount</span>
+                <span className="text-end">Amount</span>
               </div>
               <ul className="flex flex-col">
                 {TRANSACTIONS.map((t, i) => {
@@ -312,7 +312,7 @@ export default function Dashboard03() {
                         {t.date}
                       </span>
                       <span
-                        className={`text-right font-mono text-sm tabular-nums ${
+                        className={`text-end font-mono text-sm tabular-nums ${
                           t.status === "refunded"
                             ? "text-red-500"
                             : t.status === "open"

--- a/registry/hirael/blocks/dashboard-04/dashboard-04.tsx
+++ b/registry/hirael/blocks/dashboard-04/dashboard-04.tsx
@@ -312,7 +312,7 @@ export default function Dashboard04() {
                       ${BUDGET.spent.toFixed(2)}
                     </span>
                   </div>
-                  <div className="flex flex-col gap-0.5 text-right">
+                  <div className="flex flex-col gap-0.5 text-end">
                     <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
                       Daily cap
                     </span>

--- a/registry/hirael/blocks/dashboard-05/dashboard-05.tsx
+++ b/registry/hirael/blocks/dashboard-05/dashboard-05.tsx
@@ -326,7 +326,7 @@ export default function Dashboard05() {
                       style={{ width: `${row.pct}%` }}
                     />
                   </div>
-                  <span className="w-14 shrink-0 text-right font-mono text-xs tabular-nums">
+                  <span className="w-14 shrink-0 text-end font-mono text-xs tabular-nums">
                     {row.value}
                   </span>
                 </div>

--- a/registry/hirael/blocks/ecommerce-01/ecommerce-01.tsx
+++ b/registry/hirael/blocks/ecommerce-01/ecommerce-01.tsx
@@ -194,7 +194,7 @@ export default function Ecommerce01() {
                   {p.badge && (
                     <Badge
                       variant="outline"
-                      className="absolute left-2.5 top-2.5 bg-background/85 font-mono text-[10px] uppercase tracking-[0.08em] backdrop-blur"
+                      className="absolute start-2.5 top-2.5 bg-background/85 font-mono text-[10px] uppercase tracking-[0.08em] backdrop-blur"
                     >
                       {p.badge}
                     </Badge>
@@ -208,7 +208,7 @@ export default function Ecommerce01() {
                         ? `Remove ${p.name} from wishlist`
                         : `Add ${p.name} to wishlist`
                     }
-                    className="absolute right-2.5 top-2.5 inline-flex size-7 items-center justify-center rounded-full border border-border bg-background/85 text-foreground backdrop-blur transition-colors hover:border-foreground"
+                    className="absolute end-2.5 top-2.5 inline-flex size-7 items-center justify-center rounded-full border border-border bg-background/85 text-foreground backdrop-blur transition-colors hover:border-foreground"
                   >
                     <Heart
                       className={`size-3.5 ${isSaved ? "fill-current" : ""}`}

--- a/registry/hirael/blocks/ecommerce-02/ecommerce-02.tsx
+++ b/registry/hirael/blocks/ecommerce-02/ecommerce-02.tsx
@@ -172,7 +172,7 @@ export default function Ecommerce02() {
                       <Button
                         variant="ghost"
                         size="icon"
-                        className="size-7 rounded-r-none"
+                        className="size-7 rounded-e-none"
                         onClick={() => setQty(item.id, item.qty - 1)}
                         disabled={item.qty <= 1}
                         aria-label={`Decrease quantity of ${item.name}`}
@@ -185,7 +185,7 @@ export default function Ecommerce02() {
                       <Button
                         variant="ghost"
                         size="icon"
-                        className="size-7 rounded-l-none"
+                        className="size-7 rounded-s-none"
                         onClick={() => setQty(item.id, item.qty + 1)}
                         aria-label={`Increase quantity of ${item.name}`}
                       >

--- a/registry/hirael/blocks/faq-01/faq-01.tsx
+++ b/registry/hirael/blocks/faq-01/faq-01.tsx
@@ -94,7 +94,7 @@ export default function Faq01() {
                   </span>
                 </AccordionTrigger>
                 <AccordionContent>
-                  <div className="ml-10 max-w-2xl">{f.a}</div>
+                  <div className="ms-10 max-w-2xl">{f.a}</div>
                 </AccordionContent>
               </AccordionItem>
             ))}

--- a/registry/hirael/blocks/faq-02/faq-02.tsx
+++ b/registry/hirael/blocks/faq-02/faq-02.tsx
@@ -76,7 +76,7 @@ export default function Faq02() {
                     </span>
                   </AccordionTrigger>
                   <AccordionContent>
-                    <div className="ml-8">{f.a}</div>
+                    <div className="ms-8">{f.a}</div>
                   </AccordionContent>
                 </AccordionItem>
               ))}

--- a/registry/hirael/blocks/footer-01/footer-01.tsx
+++ b/registry/hirael/blocks/footer-01/footer-01.tsx
@@ -49,7 +49,7 @@ export default function Footer01() {
           <div className="col-span-2">
             <div className="flex flex-col gap-4">
               <span className="font-mono text-sm font-semibold tracking-[-0.02em] text-foreground">
-                <span aria-hidden className="mr-1.5">◆</span>
+                <span aria-hidden className="me-1.5">◆</span>
                 Hirael
               </span>
               <p className="max-w-xs text-sm leading-relaxed text-muted-foreground">

--- a/registry/hirael/blocks/header-01/header-01.tsx
+++ b/registry/hirael/blocks/header-01/header-01.tsx
@@ -23,7 +23,7 @@ export default function Header01() {
             href="#"
             className="inline-flex items-center font-mono text-sm font-semibold tracking-[-0.02em] text-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
-            <span aria-hidden className="mr-1.5">◆</span>
+            <span aria-hidden className="me-1.5">◆</span>
             Hirael
           </a>
 

--- a/registry/hirael/blocks/hero-01/hero-01.tsx
+++ b/registry/hirael/blocks/hero-01/hero-01.tsx
@@ -73,7 +73,7 @@ export default function Hero01() {
 
           <dl className="mt-4 grid grid-cols-3 divide-x divide-border border-y border-border">
             {STATS.map((s, i) => (
-              <div key={s.label} className={i === 0 ? "py-4 pr-4" : "p-4"}>
+              <div key={s.label} className={i === 0 ? "py-4 pe-4" : "p-4"}>
                 <dt className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
                   {s.label}
                 </dt>

--- a/registry/hirael/blocks/hero-02/hero-02.tsx
+++ b/registry/hirael/blocks/hero-02/hero-02.tsx
@@ -60,7 +60,7 @@ export default function Hero02() {
               aria-hidden
               viewBox="0 0 200 12"
               preserveAspectRatio="none"
-              className="absolute -bottom-1 left-0 h-2 w-full text-foreground/70"
+              className="absolute -bottom-1 start-0 h-2 w-full text-foreground/70"
             >
               <path
                 d="M2 8 Q 50 2, 100 7 T 198 6"

--- a/registry/hirael/blocks/image-gallery-01/image-gallery-01.tsx
+++ b/registry/hirael/blocks/image-gallery-01/image-gallery-01.tsx
@@ -171,13 +171,13 @@ export default function ImageGallery01() {
                   />
                   <Badge
                     variant="outline"
-                    className="absolute left-3 top-3 border-white/30 bg-black/20 text-white backdrop-blur-sm"
+                    className="absolute start-3 top-3 border-white/30 bg-black/20 text-white backdrop-blur-sm"
                   >
                     {t.tag}
                   </Badge>
                   <span
                     aria-hidden
-                    className="absolute right-3 top-3 inline-flex size-7 items-center justify-center rounded-sm border border-white/30 bg-black/20 text-white opacity-0 backdrop-blur-sm transition-all duration-200 ease-out group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:opacity-100"
+                    className="absolute end-3 top-3 inline-flex size-7 items-center justify-center rounded-sm border border-white/30 bg-black/20 text-white opacity-0 backdrop-blur-sm transition-all duration-200 ease-out group-hover:-translate-y-0.5 group-hover:translate-x-0.5 rtl:group-hover:-translate-x-0.5 group-hover:opacity-100"
                   >
                     <ArrowUpRight className="size-3.5" />
                   </span>

--- a/registry/hirael/blocks/integrations-01/integrations-01.tsx
+++ b/registry/hirael/blocks/integrations-01/integrations-01.tsx
@@ -85,7 +85,7 @@ export default function Integrations01() {
                       <s.icon className="size-3" />
                     </span>
                     <span className="font-medium">{s.name}</span>
-                    <Badge variant="outline" className="ml-auto sm:ml-0">
+                    <Badge variant="outline" className="ms-auto sm:ms-0">
                       {s.category}
                     </Badge>
                   </a>

--- a/registry/hirael/blocks/login-01/login-01.tsx
+++ b/registry/hirael/blocks/login-01/login-01.tsx
@@ -64,7 +64,7 @@ export default function Login01() {
               </span>
               <span
                 aria-hidden
-                className="absolute -bottom-1 -right-1 size-1.5 rounded-full bg-foreground"
+                className="absolute -bottom-1 -end-1 size-1.5 rounded-full bg-foreground"
               />
             </div>
             <div className="flex flex-col items-center gap-1 text-center">

--- a/registry/hirael/blocks/login-02/login-02.tsx
+++ b/registry/hirael/blocks/login-02/login-02.tsx
@@ -106,7 +106,7 @@ export default function Login02() {
         </div>
       </div>
 
-      <div className="relative isolate hidden overflow-hidden border-l border-border bg-card md:flex md:items-center md:justify-center">
+      <div className="relative isolate hidden overflow-hidden border-s border-border bg-card md:flex md:items-center md:justify-center">
         <div
           aria-hidden
           className="pointer-events-none absolute inset-0 -z-10 opacity-30"

--- a/registry/hirael/blocks/logo-cloud-01/logo-cloud-01.tsx
+++ b/registry/hirael/blocks/logo-cloud-01/logo-cloud-01.tsx
@@ -18,7 +18,7 @@ const LOGOS: readonly Logo[] = [
     href: "#",
     mark: (
       <span className="font-mono text-sm font-semibold tracking-[-0.02em]">
-        <span aria-hidden className="mr-1 text-primary">◈</span>
+        <span aria-hidden className="me-1 text-primary">◈</span>
         ACME / Co.
       </span>
     ),
@@ -28,7 +28,7 @@ const LOGOS: readonly Logo[] = [
     href: "#",
     mark: (
       <span className="text-sm font-semibold tracking-[-0.02em]">
-        <span aria-hidden className="mr-1">⌬</span>
+        <span aria-hidden className="me-1">⌬</span>
         Helix
       </span>
     ),
@@ -47,7 +47,7 @@ const LOGOS: readonly Logo[] = [
     href: "#",
     mark: (
       <span className="font-mono text-sm tracking-[-0.02em]">
-        <span aria-hidden className="mr-1">▲</span>
+        <span aria-hidden className="me-1">▲</span>
         vanta
       </span>
     ),
@@ -66,7 +66,7 @@ const LOGOS: readonly Logo[] = [
     href: "#",
     mark: (
       <span className="text-sm font-medium tracking-[-0.01em]">
-        <span aria-hidden className="mr-1">⬢</span>
+        <span aria-hidden className="me-1">⬢</span>
         Lattice
       </span>
     ),
@@ -94,7 +94,7 @@ const LOGOS: readonly Logo[] = [
     href: "#",
     mark: (
       <span className="font-mono text-sm tracking-[-0.02em]">
-        <span aria-hidden className="mr-1">◇</span>
+        <span aria-hidden className="me-1">◇</span>
         verbit
       </span>
     ),

--- a/registry/hirael/blocks/pricing-01/pricing-01.tsx
+++ b/registry/hirael/blocks/pricing-01/pricing-01.tsx
@@ -93,7 +93,7 @@ export default function Pricing01() {
               )}
             >
               {tier.featured && (
-                <span className="absolute -top-2.5 right-6 inline-flex items-center rounded-sm border border-border bg-background px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] text-foreground">
+                <span className="absolute -top-2.5 end-6 inline-flex items-center rounded-sm border border-border bg-background px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] text-foreground">
                   Most popular
                 </span>
               )}

--- a/registry/hirael/blocks/pricing-02/pricing-02.tsx
+++ b/registry/hirael/blocks/pricing-02/pricing-02.tsx
@@ -78,7 +78,7 @@ export default function Pricing02() {
         </div>
 
         <div className="mt-12 overflow-x-auto rounded-md border border-border bg-card">
-          <table className="w-full border-collapse text-left">
+          <table className="w-full border-collapse text-start">
             <thead className="sticky top-0 z-10 bg-card">
               <tr className="border-b border-border">
                 <th className="w-2/5 px-5 py-5 align-bottom">

--- a/registry/hirael/blocks/testimonial-01/testimonial-01.tsx
+++ b/registry/hirael/blocks/testimonial-01/testimonial-01.tsx
@@ -16,7 +16,7 @@ export default function Testimonial01() {
           <blockquote className="relative">
             <span
               aria-hidden
-              className="absolute -left-2 -top-6 font-serif text-6xl leading-none text-muted-foreground/40 sm:-left-4 sm:-top-8 sm:text-7xl"
+              className="absolute -start-2 -top-6 font-serif text-6xl leading-none text-muted-foreground/40 sm:-start-4 sm:-top-8 sm:text-7xl"
             >
               &ldquo;
             </span>

--- a/registry/hirael/ui/accordion.tsx
+++ b/registry/hirael/ui/accordion.tsx
@@ -45,7 +45,7 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          "group flex w-full flex-1 items-center justify-between gap-4 py-5 text-left text-base font-medium tracking-[-0.01em] outline-none transition-colors",
+          "group flex w-full flex-1 items-center justify-between gap-4 py-5 text-start text-base font-medium tracking-[-0.01em] outline-none transition-colors",
           "hover:text-foreground focus-visible:text-foreground",
           "data-[state=open]:text-foreground",
           className
@@ -76,7 +76,7 @@ function AccordionContent({
       )}
       {...props}
     >
-      <div className={cn("pb-5 pr-8", className)}>{children}</div>
+      <div className={cn("pb-5 pe-8", className)}>{children}</div>
     </AccordionPrimitive.Content>
   )
 }

--- a/registry/hirael/ui/announcement-bar.tsx
+++ b/registry/hirael/ui/announcement-bar.tsx
@@ -105,7 +105,7 @@ function AnnouncementBar({
           onClick={handleDismiss}
           aria-label="Dismiss announcement"
           className={cn(
-            "absolute right-2 inline-flex size-7 items-center justify-center rounded-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            "absolute end-2 inline-flex size-7 items-center justify-center rounded-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
             isPrimary
               ? "text-background/70 hover:bg-background/10 hover:text-background"
               : "text-muted-foreground hover:bg-accent hover:text-foreground"

--- a/registry/hirael/ui/avatar-stack.tsx
+++ b/registry/hirael/ui/avatar-stack.tsx
@@ -15,9 +15,9 @@ const sizeClasses: Record<NonNullable<AvatarStackProps["size"]>, string> = {
 }
 
 const spacingClasses: Record<NonNullable<AvatarStackProps["spacing"]>, string> = {
-  tight: "[&>[data-slot='avatar-stack-item']:not(:first-child)]:-ml-3",
-  normal: "[&>[data-slot='avatar-stack-item']:not(:first-child)]:-ml-2",
-  loose: "[&>[data-slot='avatar-stack-item']:not(:first-child)]:-ml-1",
+  tight: "[&>[data-slot='avatar-stack-item']:not(:first-child)]:-ms-3",
+  normal: "[&>[data-slot='avatar-stack-item']:not(:first-child)]:-ms-2",
+  loose: "[&>[data-slot='avatar-stack-item']:not(:first-child)]:-ms-1",
 }
 
 function AvatarStack({

--- a/registry/hirael/ui/callout.tsx
+++ b/registry/hirael/ui/callout.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const calloutVariants = cva(
-  "my-4 flex flex-col gap-2 overflow-hidden rounded-md border-l-4 p-4 text-sm",
+  "my-4 flex flex-col gap-2 overflow-hidden rounded-md border-s-4 p-4 text-sm",
   {
     variants: {
       variant: {

--- a/registry/hirael/ui/color-picker.tsx
+++ b/registry/hirael/ui/color-picker.tsx
@@ -301,7 +301,7 @@ function ColorPickerTrigger({
         data-slot="color-picker-trigger"
         data-state={ctx.open ? "open" : "closed"}
         className={cn(
-          "inline-flex h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-3 text-left text-sm font-mono tabular-nums uppercase outline-none transition-colors",
+          "inline-flex h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-3 text-start text-sm font-mono tabular-nums uppercase outline-none transition-colors",
           "hover:border-ring/60 focus-visible:border-ring data-[state=open]:border-ring",
           "disabled:cursor-not-allowed disabled:opacity-50",
           className

--- a/registry/hirael/ui/combobox.tsx
+++ b/registry/hirael/ui/combobox.tsx
@@ -180,7 +180,7 @@ function ComboboxTrigger({
         data-slot="combobox-trigger"
         data-state={ctx.open ? "open" : "closed"}
         className={cn(
-          "group flex h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-2.5 text-left text-sm outline-none transition-colors",
+          "group flex h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-2.5 text-start text-sm outline-none transition-colors",
           "hover:border-ring/60 focus-visible:border-ring",
           "data-[state=open]:border-ring",
           "disabled:cursor-not-allowed disabled:opacity-50",

--- a/registry/hirael/ui/input-group.tsx
+++ b/registry/hirael/ui/input-group.tsx
@@ -16,8 +16,8 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
       className={cn(
         "group/input-group relative flex w-full items-center rounded-sm border border-input transition-colors outline-none",
         "h-9 min-w-0 has-[>textarea]:h-auto",
-        "has-[>[data-align=inline-start]]:[&>input]:pl-2",
-        "has-[>[data-align=inline-end]]:[&>input]:pr-2",
+        "has-[>[data-align=inline-start]]:[&>input]:ps-2",
+        "has-[>[data-align=inline-end]]:[&>input]:pe-2",
         "has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3",
         "has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3",
         "has-[[data-slot=input-group-control]:focus-visible]:border-ring",
@@ -35,9 +35,9 @@ const inputGroupAddonVariants = cva(
     variants: {
       align: {
         "inline-start":
-          "order-first pl-3 has-[>button]:ml-[-0.45rem] has-[>kbd]:ml-[-0.35rem]",
+          "order-first ps-3 has-[>button]:ms-[-0.45rem] has-[>kbd]:ms-[-0.35rem]",
         "inline-end":
-          "order-last pr-3 has-[>button]:mr-[-0.45rem] has-[>kbd]:mr-[-0.35rem]",
+          "order-last pe-3 has-[>button]:me-[-0.45rem] has-[>kbd]:me-[-0.35rem]",
         "block-start":
           "order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-2.5 [.border-b]:pb-3",
         "block-end":

--- a/registry/hirael/ui/lazy-select.tsx
+++ b/registry/hirael/ui/lazy-select.tsx
@@ -224,7 +224,7 @@ function LazySelectTrigger({
         data-slot="lazy-select-trigger"
         data-state={ctx.open ? "open" : "closed"}
         className={cn(
-          "group flex h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-2.5 text-left text-sm outline-none transition-colors",
+          "group flex h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-2.5 text-start text-sm outline-none transition-colors",
           "hover:border-ring/60 focus-visible:border-ring",
           "data-[state=open]:border-ring",
           "disabled:cursor-not-allowed disabled:opacity-50",

--- a/registry/hirael/ui/month-picker.tsx
+++ b/registry/hirael/ui/month-picker.tsx
@@ -305,7 +305,7 @@ function MonthPickerTrigger({
         data-slot="month-picker-trigger"
         data-state={ctx.open ? "open" : "closed"}
         className={cn(
-          "inline-flex h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-3 text-left text-sm font-mono tabular-nums outline-none transition-colors",
+          "inline-flex h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-3 text-start text-sm font-mono tabular-nums outline-none transition-colors",
           "hover:border-ring/60 focus-visible:border-ring data-[state=open]:border-ring",
           empty && "text-muted-foreground font-sans",
           "disabled:cursor-not-allowed disabled:opacity-50",
@@ -351,14 +351,16 @@ function MonthPickerContent({
   }
 
   const handleKey = (e: React.KeyboardEvent, year: number, month: number) => {
+    const forward =
+      getComputedStyle(e.currentTarget).direction === "rtl" ? -1 : 1
     let nextYear = year
     let nextMonth = month
     switch (e.key) {
       case "ArrowLeft":
-        nextMonth = month - 1
+        nextMonth = month - forward
         break
       case "ArrowRight":
-        nextMonth = month + 1
+        nextMonth = month + forward
         break
       case "ArrowUp":
         nextMonth = month - 4
@@ -410,7 +412,7 @@ function MonthPickerContent({
           onClick={() => ctx.setDisplayYear(ctx.displayYear - 1)}
           className="size-7"
         >
-          <ChevronLeft className="size-3.5" />
+          <ChevronLeft className="size-3.5 rtl:rotate-180" />
         </Button>
         <span className="font-mono text-[11px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
           {ctx.displayYear}
@@ -424,7 +426,7 @@ function MonthPickerContent({
           onClick={() => ctx.setDisplayYear(ctx.displayYear + 1)}
           className="size-7"
         >
-          <ChevronRight className="size-3.5" />
+          <ChevronRight className="size-3.5 rtl:rotate-180" />
         </Button>
       </div>
       <div

--- a/registry/hirael/ui/multi-select.tsx
+++ b/registry/hirael/ui/multi-select.tsx
@@ -208,7 +208,7 @@ function MultiSelectTrigger({
         data-slot="multi-select-trigger"
         data-state={ctx.open ? "open" : "closed"}
         className={cn(
-          "group flex min-h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-2 py-1 text-left text-sm outline-none transition-colors",
+          "group flex min-h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-2 py-1 text-start text-sm outline-none transition-colors",
           "hover:border-ring/60 focus-visible:border-ring",
           "data-[state=open]:border-ring",
           "disabled:cursor-not-allowed disabled:opacity-50",
@@ -232,7 +232,7 @@ function MultiSelectTrigger({
                   <Badge
                     key={opt.value}
                     variant="default"
-                    className="gap-1 pr-1"
+                    className="gap-1 pe-1"
                   >
                     {opt.label}
                     <span
@@ -244,7 +244,7 @@ function MultiSelectTrigger({
                         e.stopPropagation()
                         ctx.remove(opt.value)
                       }}
-                      className="ml-0.5 inline-flex size-3.5 items-center justify-center rounded-[2px] text-foreground/70 hover:bg-foreground/20 hover:text-foreground"
+                      className="ms-0.5 inline-flex size-3.5 items-center justify-center rounded-[2px] text-foreground/70 hover:bg-foreground/20 hover:text-foreground"
                     >
                       <X className="size-2.5" />
                     </span>

--- a/registry/hirael/ui/number-range.tsx
+++ b/registry/hirael/ui/number-range.tsx
@@ -187,7 +187,7 @@ function NumberRangeInput({
   return (
     <div data-slot="number-range-input" className="relative">
       {ctx.prefix && (
-        <span className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 font-mono text-xs text-muted-foreground">
+        <span className="pointer-events-none absolute start-2 top-1/2 -translate-y-1/2 font-mono text-xs text-muted-foreground">
           {ctx.prefix}
         </span>
       )}
@@ -217,14 +217,14 @@ function NumberRangeInput({
         }}
         className={cn(
           "font-mono tabular-nums",
-          ctx.prefix && "pl-6",
-          ctx.suffix && "pr-8",
+          ctx.prefix && "ps-6",
+          ctx.suffix && "pe-8",
           className
         )}
         {...props}
       />
       {ctx.suffix && (
-        <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 font-mono text-xs text-muted-foreground">
+        <span className="pointer-events-none absolute end-2 top-1/2 -translate-y-1/2 font-mono text-xs text-muted-foreground">
           {ctx.suffix}
         </span>
       )}

--- a/registry/hirael/ui/phone-input.tsx
+++ b/registry/hirael/ui/phone-input.tsx
@@ -320,6 +320,7 @@ function PhoneInputField({
       type="tel"
       inputMode={inputMode}
       autoComplete="tel-national"
+      dir="ltr"
       value={ctx.national}
       placeholder={placeholder}
       disabled={ctx.disabled}

--- a/registry/hirael/ui/rating.tsx
+++ b/registry/hirael/ui/rating.tsx
@@ -96,9 +96,9 @@ function Rating({
               <Star
                 className={cn(
                   iconSize,
-                  "absolute inset-0 fill-yellow-400 text-yellow-400 transition-[clip-path]"
+                  "absolute inset-0 fill-yellow-400 text-yellow-400 transition-[clip-path]",
+                  half && "[clip-path:inset(0_50%_0_0)] rtl:[clip-path:inset(0_0_0_50%)]"
                 )}
-                style={half ? { clipPath: "inset(0 50% 0 0)" } : undefined}
                 aria-hidden
               />
             )}
@@ -110,7 +110,7 @@ function Rating({
                   role="radio"
                   aria-checked={value === halfValue}
                   aria-label={`${halfValue} of ${max}`}
-                  className="absolute inset-y-0 left-0 w-1/2 cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                  className="absolute inset-y-0 start-0 w-1/2 cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
                   onMouseEnter={() => setHover(halfValue)}
                   onClick={() => commit(value === halfValue ? 0 : halfValue)}
                 />
@@ -119,7 +119,7 @@ function Rating({
                   role="radio"
                   aria-checked={value === fullValue}
                   aria-label={`${fullValue} of ${max}`}
-                  className="absolute inset-y-0 right-0 w-1/2 cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                  className="absolute inset-y-0 end-0 w-1/2 cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
                   onMouseEnter={() => setHover(fullValue)}
                   onClick={() => commit(value === fullValue ? 0 : fullValue)}
                 />

--- a/registry/hirael/ui/select.tsx
+++ b/registry/hirael/ui/select.tsx
@@ -119,7 +119,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "relative flex w-full cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none",
+        "relative flex w-full cursor-default select-none items-center gap-2 rounded-sm py-1.5 ps-2 pe-8 text-sm outline-none",
         "focus:bg-accent focus:text-accent-foreground",
         "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
         "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
@@ -129,7 +129,7 @@ function SelectItem({
     >
       <span
         data-slot="select-item-indicator"
-        className="absolute right-2 flex size-3.5 items-center justify-center"
+        className="absolute end-2 flex size-3.5 items-center justify-center"
       >
         <SelectPrimitive.ItemIndicator>
           <Check className="size-3.5" />

--- a/registry/hirael/ui/sheet.tsx
+++ b/registry/hirael/ui/sheet.tsx
@@ -75,7 +75,7 @@ function SheetContent({
         {children}
         <DialogPrimitive.Close
           aria-label="Close"
-          className="absolute right-3 top-3 rounded-sm p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="absolute end-3 top-3 rounded-sm p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           <X className="size-4" />
         </DialogPrimitive.Close>

--- a/registry/hirael/ui/sidebar.tsx
+++ b/registry/hirael/ui/sidebar.tsx
@@ -295,7 +295,7 @@ function SidebarInset({
       data-slot="sidebar-inset"
       className={cn(
         "bg-background relative flex w-full flex-1 flex-col",
-        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2",
+        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ms-2",
         className
       )}
       {...props}
@@ -421,7 +421,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-sm p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-sm p-2 text-start text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -496,7 +496,7 @@ function SidebarMenuBadge({
       data-slot="sidebar-menu-badge"
       data-sidebar="menu-badge"
       className={cn(
-        "text-muted-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center rounded-sm px-1 font-mono text-[10px] font-medium tabular-nums",
+        "text-muted-foreground pointer-events-none absolute end-1 flex h-5 min-w-5 select-none items-center justify-center rounded-sm px-1 font-mono text-[10px] font-medium tabular-nums",
         "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
         "peer-data-[size=sm]/menu-button:top-1 peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5",
         "group-data-[collapsible=icon]:hidden",

--- a/registry/hirael/ui/stepper.tsx
+++ b/registry/hirael/ui/stepper.tsx
@@ -150,7 +150,7 @@ function StepperTrigger({
       disabled={disabled}
       onClick={() => setValue(step)}
       className={cn(
-        "flex items-center gap-3 rounded-md text-left outline-none transition-opacity",
+        "flex items-center gap-3 rounded-md text-start outline-none transition-opacity",
         "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         "disabled:cursor-not-allowed disabled:opacity-50",
         className
@@ -202,7 +202,7 @@ function StepperSeparator({
       className={cn(
         "bg-border transition-colors group-data-[state=completed]/step:bg-primary",
         "group-data-[orientation=horizontal]/stepper:mx-2 group-data-[orientation=horizontal]/stepper:h-0.5 group-data-[orientation=horizontal]/stepper:flex-1",
-        "group-data-[orientation=vertical]/stepper:absolute group-data-[orientation=vertical]/stepper:bottom-1 group-data-[orientation=vertical]/stepper:left-4 group-data-[orientation=vertical]/stepper:top-9 group-data-[orientation=vertical]/stepper:w-0.5 group-data-[orientation=vertical]/stepper:-translate-x-1/2",
+        "group-data-[orientation=vertical]/stepper:absolute group-data-[orientation=vertical]/stepper:bottom-1 group-data-[orientation=vertical]/stepper:start-4 group-data-[orientation=vertical]/stepper:top-9 group-data-[orientation=vertical]/stepper:w-0.5 group-data-[orientation=vertical]/stepper:-translate-x-1/2 rtl:group-data-[orientation=vertical]/stepper:translate-x-1/2",
         className
       )}
       {...props}

--- a/registry/hirael/ui/tag-input.tsx
+++ b/registry/hirael/ui/tag-input.tsx
@@ -228,7 +228,7 @@ function TagInputTag({ index, children, className, ...props }: TagInputTagProps)
     <Badge
       variant="default"
       data-slot="tag-input-tag"
-      className={cn("gap-1 pr-1 font-normal", className)}
+      className={cn("gap-1 pe-1 font-normal", className)}
       {...props}
     >
       <span className="min-w-0 truncate">{children ?? tag}</span>

--- a/registry/hirael/ui/time-picker.tsx
+++ b/registry/hirael/ui/time-picker.tsx
@@ -165,7 +165,7 @@ function TimePickerTrigger({
         data-slot="time-picker-trigger"
         data-state={ctx.open ? "open" : "closed"}
         className={cn(
-          "inline-flex h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-3 text-left text-sm font-mono tabular-nums outline-none transition-colors",
+          "inline-flex h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-3 text-start text-sm font-mono tabular-nums outline-none transition-colors",
           "hover:border-ring/60 focus-visible:border-ring data-[state=open]:border-ring",
           "disabled:cursor-not-allowed disabled:opacity-50",
           className

--- a/registry/hirael/ui/timeline.tsx
+++ b/registry/hirael/ui/timeline.tsx
@@ -22,7 +22,7 @@ function TimelineItem({ className, ...props }: TimelineItemProps) {
       data-slot="timeline-item"
       className={cn(
         "group relative flex gap-4 pb-6 last:pb-0",
-        "before:absolute before:left-[7px] before:top-4 before:bottom-0 before:w-px before:bg-border",
+        "before:absolute before:start-[7px] before:top-4 before:bottom-0 before:w-px before:bg-border",
         "last:before:hidden",
         className
       )}
@@ -56,7 +56,7 @@ function TimelineDot({
         data-slot="timeline-dot"
         data-tone={tone}
         className={cn(
-          "relative z-10 mt-0.5 inline-flex size-6 -translate-x-[5px] items-center justify-center rounded-full bg-background ring-1 ring-border [&_svg]:size-3",
+          "relative z-10 mt-0.5 inline-flex size-6 -translate-x-[5px] rtl:translate-x-[5px] items-center justify-center rounded-full bg-background ring-1 ring-border [&_svg]:size-3",
           className
         )}
         {...props}

--- a/registry/hirael/ui/tree-view.tsx
+++ b/registry/hirael/ui/tree-view.tsx
@@ -122,7 +122,7 @@ function TreeItem({
         }}
         style={{ paddingInlineStart: depth * 14 + 8 }}
         className={cn(
-          "flex h-7 w-full items-center gap-1.5 rounded-sm pr-2 text-left outline-none transition-colors",
+          "flex h-7 w-full items-center gap-1.5 rounded-sm pe-2 text-start outline-none transition-colors",
           "hover:bg-accent focus-visible:bg-accent focus-visible:ring-2 focus-visible:ring-ring",
           "disabled:cursor-not-allowed disabled:opacity-50",
           isSelected
@@ -136,7 +136,7 @@ function TreeItem({
           className={cn(
             "size-3.5 shrink-0 text-muted-foreground transition-transform duration-150",
             !hasChildren && "invisible",
-            expanded && "rotate-90"
+            expanded ? "rotate-90" : "rtl:rotate-180"
           )}
         />
         {leadingIcon != null && (

--- a/registry/hirael/ui/year-picker.tsx
+++ b/registry/hirael/ui/year-picker.tsx
@@ -259,7 +259,7 @@ function YearPickerTrigger({
         data-slot="year-picker-trigger"
         data-state={ctx.open ? "open" : "closed"}
         className={cn(
-          "inline-flex h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-3 text-left text-sm font-mono tabular-nums outline-none transition-colors",
+          "inline-flex h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-3 text-start text-sm font-mono tabular-nums outline-none transition-colors",
           "hover:border-ring/60 focus-visible:border-ring data-[state=open]:border-ring",
           empty && "text-muted-foreground font-sans",
           "disabled:cursor-not-allowed disabled:opacity-50",
@@ -306,13 +306,15 @@ function YearPickerContent({
   }
 
   const handleKey = (e: React.KeyboardEvent, year: number) => {
+    const forward =
+      getComputedStyle(e.currentTarget).direction === "rtl" ? -1 : 1
     let next = year
     switch (e.key) {
       case "ArrowLeft":
-        next = year - 1
+        next = year - forward
         break
       case "ArrowRight":
-        next = year + 1
+        next = year + forward
         break
       case "ArrowUp":
         next = year - 4
@@ -356,7 +358,7 @@ function YearPickerContent({
           onClick={() => ctx.setDecadeStart(ctx.decadeStart - DECADE)}
           className="size-7"
         >
-          <ChevronLeft className="size-3.5" />
+          <ChevronLeft className="size-3.5 rtl:rotate-180" />
         </Button>
         <span className="font-mono text-[11px] tabular-nums uppercase tracking-[0.08em] text-muted-foreground">
           {years[0]} – {years[years.length - 1]}
@@ -370,7 +372,7 @@ function YearPickerContent({
           onClick={() => ctx.setDecadeStart(ctx.decadeStart + DECADE)}
           className="size-7"
         >
-          <ChevronRight className="size-3.5" />
+          <ChevronRight className="size-3.5 rtl:rotate-180" />
         </Button>
       </div>
       <div


### PR DESCRIPTION
This PR adds comprehensive right-to-left (RTL) language support to the component library and all blocks.

## Summary
Implements RTL support by replacing physical CSS properties with logical equivalents, adding directional controls to component previews, and ensuring proper keyboard navigation and icon orientation in RTL contexts.

## Key Changes

**New Components:**
- `DirectionToggle` component for toggling RTL preview mode in component showcases
- `BlockEmbedShell` wrapper that reads `dir` query parameter to enable RTL preview for embedded blocks

**CSS Property Updates:**
- Replaced physical properties with logical equivalents across all components and blocks:
  - `ml-*`/`mr-*` → `ms-*`/`me-*` (margin-inline-start/end)
  - `pl-*`/`pr-*` → `ps-*`/`pe-*` (padding-inline-start/end)
  - `left-*`/`right-*` → `start-*`/`end-*` (inset-inline-start/end)
  - `text-left`/`text-right` → `text-start`/`text-end`
  - `border-l`/`border-r` → `border-s`/`border-e` (border-inline-start/end)
  - `rounded-l-*`/`rounded-r-*` → `rounded-s-*`/`rounded-e-*`

**Component Preview Enhancements:**
- Added RTL toggle button to `ComponentPage` preview section
- Added RTL toggle to `BlockViewer` with query parameter support
- Preview containers now respect `dir` attribute for proper RTL rendering

**Keyboard Navigation & Icons:**
- Updated arrow key handlers in `MonthPickerContent` and `YearPickerContent` to reverse direction in RTL
- Added `rtl:rotate-180` to directional chevron icons for proper orientation
- Fixed `PhoneInputField` with `dir="ltr"` to maintain correct phone number input behavior

**Rating Component:**
- Updated clip-path logic to use CSS classes instead of inline styles for RTL support

**Documentation:**
- Updated `CONTRIBUTING.md` with RTL guidelines
- Updated `README.md` to highlight RTL support as a key feature

## Implementation Details
- RTL support is non-breaking; components work seamlessly under `dir="rtl"` with no additional configuration
- All block embeds can be previewed in RTL via `?dir=rtl` query parameter
- Physical positioning is preserved where geometrically necessary (Radix animations, canvas-like surfaces, specific props)
- Every component preview now includes an RTL toggle for testing

https://claude.ai/code/session_0185g8CBMomhcsbyZ5bScv6t