### PR TITLE
Replace Twitter references with GitHub social links

### DIFF
--- a/app/(showcase)/[component]/page.tsx
+++ b/app/(showcase)/[component]/page.tsx
@@ -52,8 +52,6 @@ export async function generateMetadata({
       card: "summary_large_image",
       title,
       description: entry.description,
-      creator: SITE.twitterHandle,
-      site: SITE.twitterHandle,
       images: ["/opengraph-image"],
     },
   }

--- a/app/(showcase)/blocks/[block]/page.tsx
+++ b/app/(showcase)/blocks/[block]/page.tsx
@@ -59,8 +59,6 @@ export async function generateMetadata({
         card: "summary_large_image",
         title,
         description: category.description,
-        creator: SITE.twitterHandle,
-        site: SITE.twitterHandle,
         images: ["/opengraph-image"],
       },
     }
@@ -94,8 +92,6 @@ export async function generateMetadata({
       card: "summary_large_image",
       title,
       description: entry.description,
-      creator: SITE.twitterHandle,
-      site: SITE.twitterHandle,
       images: ["/opengraph-image"],
     },
   }

--- a/app/(showcase)/blocks/page.tsx
+++ b/app/(showcase)/blocks/page.tsx
@@ -32,8 +32,6 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: `Blocks — ${SITE.name}`,
     description: BLOCKS_DESCRIPTION,
-    creator: SITE.twitterHandle,
-    site: SITE.twitterHandle,
     images: ["/opengraph-image"],
   },
 }

--- a/app/(showcase)/components/page.tsx
+++ b/app/(showcase)/components/page.tsx
@@ -64,8 +64,6 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: `Components — ${SITE.name}`,
     description: COMPONENTS_DESCRIPTION,
-    creator: SITE.twitterHandle,
-    site: SITE.twitterHandle,
     images: ["/opengraph-image"],
   },
 }

--- a/app/(showcase)/theme/page.tsx
+++ b/app/(showcase)/theme/page.tsx
@@ -31,8 +31,6 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: `Theme playground — ${SITE.name}`,
     description: THEME_DESCRIPTION,
-    creator: SITE.twitterHandle,
-    site: SITE.twitterHandle,
     images: ["/opengraph-image"],
   },
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -69,8 +69,6 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: `${SITE.name} — ${SITE.description}`,
     description: SITE.longDescription,
-    creator: SITE.twitterHandle,
-    site: SITE.twitterHandle,
     images: ["/opengraph-image"],
   },
   category: "technology",
@@ -126,7 +124,7 @@ export default function RootLayout({
                 name: SITE.author,
                 url: SITE.authorUrl,
               },
-              sameAs: [SITE.twitterUrl],
+              sameAs: [SITE.githubUrl],
             }),
           }}
         />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -41,8 +41,6 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: `${SITE.name} — ${SITE.description}`,
     description: SITE.longDescription,
-    creator: SITE.twitterHandle,
-    site: SITE.twitterHandle,
     images: ["/opengraph-image"],
   },
 }

--- a/components/showcase/site-footer.tsx
+++ b/components/showcase/site-footer.tsx
@@ -30,7 +30,7 @@ const FOOTER_LINKS: {
     label: "Author",
     links: [
       { href: SITE.authorUrl, label: "Portfolio", external: true },
-      { href: SITE.twitterUrl, label: "Twitter / X", external: true },
+      { href: SITE.githubUrl, label: "GitHub", external: true },
     ],
   },
 ]

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -12,8 +12,8 @@ export const SITE = {
   version: "0.1",
   author: "Mohammad Shehadeh",
   authorUrl: "https://mohammadshehadeh.com",
-  twitterHandle: "@mohammadshhadeh",
-  twitterUrl: "https://x.com/mohammadshhadeh",
+  githubHandle: "mohammadshehadeh",
+  githubUrl: "https://github.com/mohammadshehadeh/",
   keywords: [
     "shadcn",
     "shadcn ui",


### PR DESCRIPTION
## Summary
This PR removes Twitter/X social media references throughout the codebase and replaces them with GitHub links as the primary social profile connection.

## Key Changes
- **Site configuration** (`lib/site.ts`): Replaced `twitterHandle` and `twitterUrl` with `githubHandle` and `githubUrl`
- **Open Graph metadata**: Removed `creator` and `site` Twitter meta tags from all page metadata files:
  - `app/layout.tsx`
  - `app/page.tsx`
  - `app/(showcase)/blocks/page.tsx`
  - `app/(showcase)/blocks/[block]/page.tsx`
  - `app/(showcase)/[component]/page.tsx`
  - `app/(showcase)/components/page.tsx`
  - `app/(showcase)/theme/page.tsx`
- **Schema.org structured data** (`app/layout.tsx`): Updated `sameAs` field from Twitter URL to GitHub URL
- **Footer navigation** (`components/showcase/site-footer.tsx`): Changed author social link from "Twitter / X" to "GitHub"

## Implementation Details
The removal of Twitter-specific Open Graph tags (`creator` and `site`) simplifies the metadata while maintaining the `summary_large_image` card type and image references. The GitHub URL now serves as the canonical social profile link across the site.

https://claude.ai/code/session_01St8XMaGc4xF4F2ruR5e7tC