### PR TITLE
Add global error and 404 not found error pages

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,248 +1,73 @@
 "use client"
 
-import { useEffect } from "react"
+import { Cormorant_Garamond, Geist_Mono, Inter } from "next/font/google"
+import { RefreshCw } from "lucide-react"
+import "./globals.css"
 
-const RELOAD_KEY = "hirael:global-error-reloaded-at"
-const RELOAD_COOLDOWN_MS = 20000
+import { LogoMark } from "@/components/showcase/logo"
 
-/**
- * After a deploy the freshly purged HTML can still point a browser (or a
- * stale Cloudflare edge document) at hashed JS/CSS chunks that no longer
- * exist. Fetching a missing chunk throws one of these, which unmounts the
- * whole app and reads to the user as a blank, crashed page.
- */
-function isStaleDeployError(error: unknown): boolean {
-  if (!error || typeof error !== "object") return false
-  const { name, message } = error as { name?: string; message?: string }
-  if (name === "ChunkLoadError") return true
-  const msg = message ?? ""
-  return (
-    /Loading (?:CSS )?chunk [\w-]+ failed/i.test(msg) ||
-    /Failed to fetch dynamically imported module/i.test(msg) ||
-    /error loading dynamically imported module/i.test(msg) ||
-    /Importing a module script failed/i.test(msg)
-  )
-}
+// global-error replaces the root layout, so it has to bring its own document
+// and fonts. We mirror the root layout's setup so the fallback still reads as
+// Hirael instead of falling back to the browser's default serif.
+const inter = Inter({
+  variable: "--font-inter",
+  subsets: ["latin"],
+})
 
-export default function GlobalError({
-  error,
-}: {
-  error: Error & { digest?: string }
-}) {
-  useEffect(() => {
-    if (!isStaleDeployError(error)) return
+const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
+})
 
-    // A hard reload pulls the current HTML + chunk manifest and recovers
-    // transparently. The sessionStorage cooldown stops a reload loop in case
-    // reloading does not actually resolve the missing chunk.
-    let lastReload = 0
-    try {
-      lastReload = Number(window.sessionStorage.getItem(RELOAD_KEY)) || 0
-    } catch {
-      /* sessionStorage can be unavailable (private mode, blocked cookies) */
-    }
-    if (Date.now() - lastReload < RELOAD_COOLDOWN_MS) return
+const cormorant = Cormorant_Garamond({
+  variable: "--font-cormorant",
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+})
 
-    try {
-      window.sessionStorage.setItem(RELOAD_KEY, String(Date.now()))
-    } catch {
-      /* ignore write failures and still attempt the reload below */
-    }
-    window.location.reload()
-  }, [error])
-
-  // global-error replaces the root layout, so this tree renders its own
-  // document and ships its own styles inline. That keeps the fallback
-  // working even when the failure that triggered it was a missing CSS/JS
-  // chunk, which is exactly the case we are guarding against here.
+export default function GlobalError() {
   return (
     <html lang="en" suppressHydrationWarning>
-      <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>Something went wrong</title>
-        <style dangerouslySetInnerHTML={{ __html: GLOBAL_ERROR_CSS }} />
-      </head>
-      <body className="ge-root">
-        <main className="ge-main">
-          <div className="ge-card">
-            <svg
-              className="ge-mark"
-              viewBox="0 0 80 100"
-              width="30"
-              height="38"
-              role="img"
-              aria-label="Hirael"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2.2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M16 78 V40 a24 24 0 0 1 48 0 V78" />
-              <path d="M40 44 L43.2 52 L51 55 L43.2 58 L40 66 L36.8 58 L29 55 L36.8 52 Z" />
-              <path d="M22 86 H58" opacity="0.7" />
-              <path d="M28 92 H52" opacity="0.45" />
-              <path d="M34 96 H46" opacity="0.25" />
-            </svg>
+      <body
+        className={`${inter.variable} ${geistMono.variable} ${cormorant.variable} antialiased`}
+      >
+        <main className="flex min-h-svh flex-col items-center justify-center gap-6 bg-background px-6 text-center text-foreground">
+          <LogoMark className="size-8" />
 
-            <p className="ge-eyebrow">Something went wrong</p>
-            <h1 className="ge-title">This page failed to load.</h1>
-            <p className="ge-text">
-              A new version may have just shipped. Reloading the page usually
+          <div className="flex flex-col items-center gap-3">
+            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+              Something went wrong
+            </span>
+            <h1 className="text-balance text-2xl font-semibold tracking-tight sm:text-3xl">
+              This page failed to load.
+            </h1>
+            <p className="max-w-sm text-balance text-sm text-muted-foreground">
+              A new version may have just shipped. Refreshing the page usually
               clears it up.
             </p>
+          </div>
 
-            <div className="ge-actions">
-              <button
-                type="button"
-                className="ge-btn ge-btn-primary"
-                onClick={() => window.location.reload()}
-              >
-                Reload page
-              </button>
-              {/* A plain anchor (not next/link) forces a full document load,
-                  which is the whole point here: client navigation would
-                  re-fetch the same missing chunks and fail again. */}
-              {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-              <a className="ge-btn ge-btn-secondary" href="/">
-                Back to home
-              </a>
-            </div>
-
-            {error?.digest ? (
-              <p className="ge-ref">Reference: {error.digest}</p>
-            ) : null}
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary px-5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            >
+              <RefreshCw className="size-4" />
+              Refresh page
+            </button>
+            {/* Plain anchor forces a full document load rather than a client
+                navigation, which is what recovery needs here. */}
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+            <a
+              href="/"
+              className="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-border bg-card px-5 text-sm font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            >
+              Back to home
+            </a>
           </div>
         </main>
       </body>
     </html>
   )
 }
-
-const GLOBAL_ERROR_CSS = `
-.ge-root {
-  margin: 0;
-  min-height: 100vh;
-  background: #09090b;
-  color: #fafafa;
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
-    "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-}
-.ge-main {
-  min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 24px;
-}
-.ge-card {
-  width: 100%;
-  max-width: 30rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 18px;
-  text-align: center;
-}
-.ge-mark {
-  opacity: 0.9;
-}
-.ge-eyebrow {
-  margin: 0;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 11px;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: #a1a1aa;
-}
-.ge-title {
-  margin: 0;
-  font-size: 22px;
-  line-height: 1.3;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-}
-.ge-text {
-  margin: 0;
-  max-width: 24rem;
-  font-size: 14px;
-  line-height: 1.6;
-  color: #a1a1aa;
-}
-.ge-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  justify-content: center;
-  margin-top: 4px;
-}
-.ge-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  height: 40px;
-  padding: 0 20px;
-  border-radius: 8px;
-  font-size: 14px;
-  font-weight: 500;
-  text-decoration: none;
-  cursor: pointer;
-  border: 1px solid transparent;
-  transition: background-color 0.15s ease, border-color 0.15s ease,
-    opacity 0.15s ease;
-}
-.ge-btn:focus-visible {
-  outline: 2px solid #71717a;
-  outline-offset: 2px;
-}
-.ge-btn-primary {
-  background: #fafafa;
-  color: #18181b;
-}
-.ge-btn-primary:hover {
-  opacity: 0.9;
-}
-.ge-btn-secondary {
-  background: transparent;
-  color: #fafafa;
-  border-color: #27272a;
-}
-.ge-btn-secondary:hover {
-  background: #18181b;
-  border-color: #3f3f46;
-}
-.ge-ref {
-  margin: 4px 0 0;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 11px;
-  color: #52525b;
-  word-break: break-all;
-}
-@media (prefers-color-scheme: light) {
-  .ge-root {
-    background: #ffffff;
-    color: #18181b;
-  }
-  .ge-eyebrow,
-  .ge-text {
-    color: #71717a;
-  }
-  .ge-btn-primary {
-    background: #18181b;
-    color: #fafafa;
-  }
-  .ge-btn-secondary {
-    color: #18181b;
-    border-color: #e4e4e7;
-  }
-  .ge-btn-secondary:hover {
-    background: #f4f4f5;
-    border-color: #d4d4d8;
-  }
-  .ge-ref {
-    color: #a1a1aa;
-  }
-}
-`

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -42,8 +42,7 @@ export default function GlobalError() {
               This page failed to load.
             </h1>
             <p className="max-w-sm text-balance text-sm text-muted-foreground">
-              A new version may have just shipped. Refreshing the page usually
-              clears it up.
+              An unexpected error occurred. Try refreshing the page or come back in a moment.
             </p>
           </div>
 

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,248 @@
+"use client"
+
+import { useEffect } from "react"
+
+const RELOAD_KEY = "hirael:global-error-reloaded-at"
+const RELOAD_COOLDOWN_MS = 20000
+
+/**
+ * After a deploy the freshly purged HTML can still point a browser (or a
+ * stale Cloudflare edge document) at hashed JS/CSS chunks that no longer
+ * exist. Fetching a missing chunk throws one of these, which unmounts the
+ * whole app and reads to the user as a blank, crashed page.
+ */
+function isStaleDeployError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false
+  const { name, message } = error as { name?: string; message?: string }
+  if (name === "ChunkLoadError") return true
+  const msg = message ?? ""
+  return (
+    /Loading (?:CSS )?chunk [\w-]+ failed/i.test(msg) ||
+    /Failed to fetch dynamically imported module/i.test(msg) ||
+    /error loading dynamically imported module/i.test(msg) ||
+    /Importing a module script failed/i.test(msg)
+  )
+}
+
+export default function GlobalError({
+  error,
+}: {
+  error: Error & { digest?: string }
+}) {
+  useEffect(() => {
+    if (!isStaleDeployError(error)) return
+
+    // A hard reload pulls the current HTML + chunk manifest and recovers
+    // transparently. The sessionStorage cooldown stops a reload loop in case
+    // reloading does not actually resolve the missing chunk.
+    let lastReload = 0
+    try {
+      lastReload = Number(window.sessionStorage.getItem(RELOAD_KEY)) || 0
+    } catch {
+      /* sessionStorage can be unavailable (private mode, blocked cookies) */
+    }
+    if (Date.now() - lastReload < RELOAD_COOLDOWN_MS) return
+
+    try {
+      window.sessionStorage.setItem(RELOAD_KEY, String(Date.now()))
+    } catch {
+      /* ignore write failures and still attempt the reload below */
+    }
+    window.location.reload()
+  }, [error])
+
+  // global-error replaces the root layout, so this tree renders its own
+  // document and ships its own styles inline. That keeps the fallback
+  // working even when the failure that triggered it was a missing CSS/JS
+  // chunk, which is exactly the case we are guarding against here.
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Something went wrong</title>
+        <style dangerouslySetInnerHTML={{ __html: GLOBAL_ERROR_CSS }} />
+      </head>
+      <body className="ge-root">
+        <main className="ge-main">
+          <div className="ge-card">
+            <svg
+              className="ge-mark"
+              viewBox="0 0 80 100"
+              width="30"
+              height="38"
+              role="img"
+              aria-label="Hirael"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M16 78 V40 a24 24 0 0 1 48 0 V78" />
+              <path d="M40 44 L43.2 52 L51 55 L43.2 58 L40 66 L36.8 58 L29 55 L36.8 52 Z" />
+              <path d="M22 86 H58" opacity="0.7" />
+              <path d="M28 92 H52" opacity="0.45" />
+              <path d="M34 96 H46" opacity="0.25" />
+            </svg>
+
+            <p className="ge-eyebrow">Something went wrong</p>
+            <h1 className="ge-title">This page failed to load.</h1>
+            <p className="ge-text">
+              A new version may have just shipped. Reloading the page usually
+              clears it up.
+            </p>
+
+            <div className="ge-actions">
+              <button
+                type="button"
+                className="ge-btn ge-btn-primary"
+                onClick={() => window.location.reload()}
+              >
+                Reload page
+              </button>
+              {/* A plain anchor (not next/link) forces a full document load,
+                  which is the whole point here: client navigation would
+                  re-fetch the same missing chunks and fail again. */}
+              {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+              <a className="ge-btn ge-btn-secondary" href="/">
+                Back to home
+              </a>
+            </div>
+
+            {error?.digest ? (
+              <p className="ge-ref">Reference: {error.digest}</p>
+            ) : null}
+          </div>
+        </main>
+      </body>
+    </html>
+  )
+}
+
+const GLOBAL_ERROR_CSS = `
+.ge-root {
+  margin: 0;
+  min-height: 100vh;
+  background: #09090b;
+  color: #fafafa;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+.ge-main {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+.ge-card {
+  width: 100%;
+  max-width: 30rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  text-align: center;
+}
+.ge-mark {
+  opacity: 0.9;
+}
+.ge-eyebrow {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #a1a1aa;
+}
+.ge-title {
+  margin: 0;
+  font-size: 22px;
+  line-height: 1.3;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.ge-text {
+  margin: 0;
+  max-width: 24rem;
+  font-size: 14px;
+  line-height: 1.6;
+  color: #a1a1aa;
+}
+.ge-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  margin-top: 4px;
+}
+.ge-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 40px;
+  padding: 0 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background-color 0.15s ease, border-color 0.15s ease,
+    opacity 0.15s ease;
+}
+.ge-btn:focus-visible {
+  outline: 2px solid #71717a;
+  outline-offset: 2px;
+}
+.ge-btn-primary {
+  background: #fafafa;
+  color: #18181b;
+}
+.ge-btn-primary:hover {
+  opacity: 0.9;
+}
+.ge-btn-secondary {
+  background: transparent;
+  color: #fafafa;
+  border-color: #27272a;
+}
+.ge-btn-secondary:hover {
+  background: #18181b;
+  border-color: #3f3f46;
+}
+.ge-ref {
+  margin: 4px 0 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
+  color: #52525b;
+  word-break: break-all;
+}
+@media (prefers-color-scheme: light) {
+  .ge-root {
+    background: #ffffff;
+    color: #18181b;
+  }
+  .ge-eyebrow,
+  .ge-text {
+    color: #71717a;
+  }
+  .ge-btn-primary {
+    background: #18181b;
+    color: #fafafa;
+  }
+  .ge-btn-secondary {
+    color: #18181b;
+    border-color: #e4e4e7;
+  }
+  .ge-btn-secondary:hover {
+    background: #f4f4f5;
+    border-color: #d4d4d8;
+  }
+  .ge-ref {
+    color: #a1a1aa;
+  }
+}
+`

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link"
+import type { Metadata } from "next"
+import { ArrowLeft, ArrowRight } from "lucide-react"
+
+import { SiteFooter } from "@/components/showcase/site-footer"
+import { SiteHeader } from "@/components/showcase/site-header"
+
+export const metadata: Metadata = {
+  title: "Page not found",
+  description: "The page you were looking for could not be found.",
+  robots: { index: false, follow: false },
+}
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-svh flex-col">
+      <SiteHeader />
+      <main className="flex-1">
+        <section className="relative overflow-hidden">
+          <div
+            aria-hidden
+            className="bg-dot-grid pointer-events-none absolute inset-0 opacity-40 [mask-image:radial-gradient(ellipse_60%_45%_at_50%_0%,black,transparent_75%)]"
+          />
+          <div className="relative mx-auto flex w-full max-w-3xl flex-col items-center gap-6 px-4 py-24 text-center sm:px-6 sm:py-28 lg:py-36">
+            <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+              404 · Not found
+            </span>
+
+            <h1 className="text-balance text-4xl font-semibold tracking-tight sm:text-5xl md:text-6xl">
+              This page isn&apos;t in the registry.
+            </h1>
+
+            <p className="max-w-md text-balance text-base text-muted-foreground sm:text-lg">
+              The link may be broken, or the page may have moved. Everything
+              Hirael ships is still a click away.
+            </p>
+
+            <div className="flex flex-wrap items-center justify-center gap-3 pt-1">
+              <Link
+                href="/"
+                className="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary px-5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              >
+                <ArrowLeft className="size-4" />
+                Back to home
+              </Link>
+              <Link
+                href="/components"
+                className="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-border bg-card px-5 text-sm font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              >
+                Browse components
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+      <SiteFooter />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive error handling pages for the application, including a global error boundary and a 404 not found page.

## Key Changes

- **Global Error Handler** (`app/global-error.tsx`): Implements a client-side error boundary that:
  - Detects stale deployment errors (missing CSS/JS chunks) using pattern matching on error names and messages
  - Automatically reloads the page when stale chunk errors are detected, with a cooldown mechanism to prevent reload loops
  - Provides a user-friendly error UI with inline styles to ensure it works even when CSS chunks are missing
  - Displays an error digest reference for debugging purposes
  - Includes fallback actions to reload or return home

- **404 Not Found Page** (`app/not-found.tsx`): Creates a branded 404 error page that:
  - Maintains consistent site header and footer
  - Provides clear messaging about the missing page
  - Includes navigation options to return home or browse components
  - Uses the existing design system (Lucide icons, Tailwind classes)
  - Sets proper metadata to prevent indexing of the 404 page

## Implementation Details

- The global error handler uses `sessionStorage` to track reload attempts and prevent infinite reload loops with a 20-second cooldown
- All styles in the global error page are inlined to ensure the fallback UI renders correctly even when the asset pipeline is broken
- The 404 page uses standard Next.js conventions and integrates with existing site components
- Both pages handle edge cases like unavailable `sessionStorage` (private browsing mode) gracefully

https://claude.ai/code/session_018Z3YH9cgaJFmzujNx7zLsH