### PR TITLE
Fix ref callbacks and value sync in inline edit and currency input

### DIFF
--- a/registry/hirael/mention-input/mention-input.demo.tsx
+++ b/registry/hirael/mention-input/mention-input.demo.tsx
@@ -9,11 +9,11 @@ import {
 } from "@/registry/hirael/ui/mention-input"
 
 const TEAM: MentionItem[] = [
-  { id: "1", label: "jane.doe", description: "Jane Doe · Design lead" },
-  { id: "2", label: "mohammad", description: "Mohammad Shehadeh · Frontend" },
-  { id: "3", label: "sara.k", description: "Sara Khalil · Product" },
-  { id: "4", label: "omar", description: "Omar Haddad · Backend" },
-  { id: "5", label: "lina", description: "Lina Aboud · QA" },
+  { id: "1", label: "john.doe", description: "John Doe · Design lead" },
+  { id: "2", label: "mohammad.shehadeh", description: "Mohammad Shehadeh · Frontend" },
+  { id: "3", label: "jane.doe", description: "Jane Doe · Product" },
+  { id: "4", label: "richard.roe", description: "Richard Roe · Backend" },
+  { id: "5", label: "mary.major", description: "Mary Major · QA" },
 ]
 
 const CHANNELS: MentionItem[] = [

--- a/registry/hirael/ui/currency-input.tsx
+++ b/registry/hirael/ui/currency-input.tsx
@@ -124,8 +124,15 @@ function CurrencyInput({
     defaultValue
   )
   const value = valueProp !== undefined ? valueProp : internalValue
+
+  // Tracks the value currently reflected in the view so the sync effect below
+  // can tell an external value change apart from one the field just made while
+  // typing — otherwise every keystroke gets reformatted (e.g. "1" → "1.00").
+  const lastSeenValue = React.useRef<number | null | undefined>(value)
+
   const setValue = React.useCallback(
     (next: number | null) => {
+      lastSeenValue.current = next
       if (valueProp === undefined) setInternalValue(next)
       onValueChange?.(next)
     },
@@ -138,7 +145,6 @@ function CurrencyInput({
       : formatNumber(value, locale, decimals)
   )
 
-  const lastSeenValue = React.useRef<number | null | undefined>(value)
   React.useEffect(() => {
     if (lastSeenValue.current === value) return
     lastSeenValue.current = value

--- a/registry/hirael/ui/inline-edit.tsx
+++ b/registry/hirael/ui/inline-edit.tsx
@@ -301,6 +301,18 @@ function InlineEditInput({
     cancel,
   } = useInlineEdit()
 
+  // Stable callback ref: focus/select run once when the input mounts. An inline
+  // ref would be re-invoked on every render, re-selecting the text mid-typing.
+  const focusOnMount = React.useCallback(
+    (node: HTMLInputElement | null) => {
+      if (node) {
+        node.focus()
+        if (selectOnFocus) node.select()
+      }
+    },
+    [selectOnFocus]
+  )
+
   if (!editing) return null
 
   return (
@@ -329,12 +341,7 @@ function InlineEditInput({
       }}
       className={cn("h-8", className)}
       {...props}
-      ref={(node) => {
-        if (node) {
-          node.focus()
-          if (selectOnFocus) node.select()
-        }
-      }}
+      ref={focusOnMount}
     />
   )
 }
@@ -359,6 +366,18 @@ function InlineEditTextarea({
     submit,
     cancel,
   } = useInlineEdit()
+
+  // Stable callback ref: focus/select run once when the textarea mounts. An
+  // inline ref would re-run every render, re-selecting the text mid-typing.
+  const focusOnMount = React.useCallback(
+    (node: HTMLTextAreaElement | null) => {
+      if (node) {
+        node.focus()
+        if (selectOnFocus) node.select()
+      }
+    },
+    [selectOnFocus]
+  )
 
   if (!editing) return null
 
@@ -388,12 +407,7 @@ function InlineEditTextarea({
       }}
       className={className}
       {...props}
-      ref={(node) => {
-        if (node) {
-          node.focus()
-          if (selectOnFocus) node.select()
-        }
-      }}
+      ref={focusOnMount}
     />
   )
 }


### PR DESCRIPTION
## Summary
This PR fixes performance and behavior issues in the inline edit components and currency input by converting inline ref callbacks to stable memoized callbacks and improving value synchronization tracking.

## Key Changes

- **InlineEditInput & InlineEditTextarea**: Converted inline ref callbacks to stable `useCallback` memoized functions (`focusOnMount`). This prevents the ref from being re-invoked on every render, which was causing text to be re-selected mid-typing.

- **CurrencyInput**: Moved `lastSeenValue` ref initialization before the `setValue` callback and updated it within the callback. This ensures the ref is properly initialized and synchronized when values change, preventing unwanted reformatting of user input during typing (e.g., "1" being reformatted to "1.00" mid-keystroke).

- **Demo data**: Updated sample team member data in mention-input demo with more realistic placeholder names.

## Implementation Details

The inline edit components now use a stable callback reference that only depends on `selectOnFocus`, ensuring focus and text selection happen once on mount rather than on every render. The currency input fix ensures that external value changes are properly distinguished from internal changes made while typing, preventing the formatter from interfering with user input.

https://claude.ai/code/session_01FKwJJALp33fLGhWdf4zsXt