### PR TITLE
Add Creative Studio template with cinematic animations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ registry/hirael/
     index.ts                 # re-export
   ui/                        # shadcn primitives the registry imports from
   blocks/<block>/            # marketing blocks
+  templates/<template>/      # full-page templates
   registry-meta.ts           # showcase metadata for sidebar / pages
 registry.json                # canonical declaration of every item
 ```
@@ -219,6 +220,12 @@ For each new component:
 Marketing blocks follow the same shape but live under
 `registry/hirael/blocks/<block>/` and have a `blockKind` plus
 `blockTagline` in `registry-meta.ts`.
+
+Templates are full-page, multi-section layouts. They live under
+`registry/hirael/templates/<template>/`, use `category: "templates"` in
+`registry-meta.ts`, and ship as a multi-file `registry:block` in
+`registry.json`. Like blocks, they are previewed full-bleed and do not
+need a `*.demo.tsx`.
 
 ## Testing requirements
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ npx shadcn@latest add https://hirael.com/r/multi-select.json
 - **Marketing blocks** — Hero, Feature, Pricing, Testimonial, CTA, FAQ,
   Login, Header, Footer, Not-Found, Logo Cloud, Contact, Blog,
   Dashboard, Integrations, Image Gallery, App Shell.
+- **Templates** — full-page, multi-section layouts (e.g. Creative
+  Studio) that compose blocks and components into a finished page.
 - **Flat compound APIs** — same composition style shadcn ships, with a
   `data-slot="…"` attribute on every rendered slot for downstream
   styling.
@@ -115,6 +117,7 @@ forgecn/
 │   ├── (showcase)/               # sidebar + main column
 │   │   ├── components/page.tsx   # component index
 │   │   ├── blocks/[block]/       # per-block preview
+│   │   ├── templates/[template]/ # per-template preview
 │   │   └── theme/playground.tsx  # theme playground
 │   ├── embed/blocks/             # framed block previews
 │   ├── layout.tsx
@@ -126,6 +129,7 @@ forgecn/
 │       ├── ui/                   # shadcn primitives the registry imports from
 │       ├── <component>/          # *.tsx, *.demo.tsx, index.ts
 │       ├── blocks/<block>/       # marketing blocks
+│       ├── templates/<template>/ # full-page templates
 │       └── registry-meta.ts      # showcase metadata for sidebar / pages
 ├── hooks/                        # shared client hooks
 ├── lib/                          # site config, theme, package-manager helpers

--- a/app/(showcase)/[component]/page.tsx
+++ b/app/(showcase)/[component]/page.tsx
@@ -7,14 +7,12 @@ import { ComponentPage } from "@/components/showcase/component-page"
 import type { SourceFile } from "@/components/showcase/component-page"
 import { highlightCode, langFromPath } from "@/lib/highlight"
 import { SITE } from "@/lib/site"
-import { REGISTRY, REGISTRY_BY_NAME } from "@/registry/hirael/registry-meta"
+import { COMPONENTS, REGISTRY_BY_NAME } from "@/registry/hirael/registry-meta"
 
 export const dynamicParams = false
 
 export function generateStaticParams() {
-  return REGISTRY.filter((entry) => entry.category !== "blocks").map(
-    (entry) => ({ component: entry.name })
-  )
+  return COMPONENTS.map((entry) => ({ component: entry.name }))
 }
 
 export async function generateMetadata({
@@ -24,7 +22,8 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { component } = await params
   const entry = REGISTRY_BY_NAME[component]
-  if (!entry || entry.category === "blocks") return {}
+  if (!entry || entry.category === "blocks" || entry.category === "templates")
+    return {}
   const url = `${SITE.url}/${entry.name}`
   const title = `${entry.title} | ${SITE.name}`
   return {
@@ -113,7 +112,8 @@ export default async function ComponentRoute({
 }) {
   const { component } = await params
   const entry = REGISTRY_BY_NAME[component]
-  if (!entry || entry.category === "blocks") notFound()
+  if (!entry || entry.category === "blocks" || entry.category === "templates")
+    notFound()
   const [source, demoSource] = await Promise.all([
     loadSource(entry.sourceFiles),
     loadDemoSource(entry),

--- a/app/(showcase)/components/page.tsx
+++ b/app/(showcase)/components/page.tsx
@@ -11,7 +11,7 @@ import {
   BLOCK_KIND_ORDER,
   BLOCKS_BY_KIND,
   CATEGORY_LABELS,
-  REGISTRY,
+  COMPONENTS,
   REGISTRY_BY_CATEGORY,
   type ComponentCategory,
 } from "@/registry/hirael/registry-meta"
@@ -69,7 +69,7 @@ export const metadata: Metadata = {
 }
 
 export default async function ComponentsIndex() {
-  const components = REGISTRY.filter((r) => r.category !== "blocks")
+  const components = COMPONENTS
   const blocks = REGISTRY_BY_CATEGORY.blocks
   const composeHtml = await highlightCode(COMPOSE_SNIPPET, "tsx")
 

--- a/app/(showcase)/templates/[template]/page.tsx
+++ b/app/(showcase)/templates/[template]/page.tsx
@@ -1,0 +1,94 @@
+import * as fs from "node:fs/promises"
+import * as path from "node:path"
+import { notFound } from "next/navigation"
+import type { Metadata } from "next"
+
+import { ComponentPage } from "@/components/showcase/component-page"
+import type { SourceFile } from "@/components/showcase/component-page"
+import { highlightCode, langFromPath } from "@/lib/highlight"
+import { SITE } from "@/lib/site"
+import { REGISTRY, REGISTRY_BY_NAME } from "@/registry/hirael/registry-meta"
+
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return REGISTRY.filter((entry) => entry.category === "templates").map(
+    (entry) => ({ template: entry.name })
+  )
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ template: string }>
+}): Promise<Metadata> {
+  const { template } = await params
+  const entry = REGISTRY_BY_NAME[template]
+  if (!entry || entry.category !== "templates") return {}
+  const url = `${SITE.url}/templates/${entry.name}`
+  const title = `${entry.title} template | ${SITE.name}`
+  return {
+    title: `${entry.title} template`,
+    description: entry.description,
+    alternates: {
+      canonical: `/templates/${entry.name}`,
+    },
+    openGraph: {
+      type: "article",
+      url,
+      siteName: SITE.name,
+      title,
+      description: entry.description,
+      images: [
+        {
+          url: "/opengraph-image",
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: entry.description,
+      images: ["/opengraph-image"],
+    },
+  }
+}
+
+async function loadSource(
+  files: string[] | undefined
+): Promise<Record<string, SourceFile>> {
+  const out: Record<string, SourceFile> = {}
+  if (!files) return out
+  await Promise.all(
+    files.map(async (f) => {
+      const abs = path.join(process.cwd(), f)
+      let code: string
+      try {
+        code = await fs.readFile(abs, "utf8")
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        console.error(`[loadSource] could not read ${abs}: ${msg}`)
+        code = `// (unable to read source: ${msg})`
+      }
+      const lang = langFromPath(f)
+      const html = await highlightCode(code, lang)
+      out[f] = { code, html, lang }
+    })
+  )
+  return out
+}
+
+export default async function TemplateRoute({
+  params,
+}: {
+  params: Promise<{ template: string }>
+}) {
+  const { template } = await params
+  const entry = REGISTRY_BY_NAME[template]
+  if (!entry || entry.category !== "templates") notFound()
+  const source = await loadSource(entry.sourceFiles)
+  return <ComponentPage entry={entry} source={source} />
+}

--- a/app/(showcase)/templates/page.tsx
+++ b/app/(showcase)/templates/page.tsx
@@ -1,0 +1,100 @@
+import Link from "next/link"
+import { ArrowUpRight } from "lucide-react"
+import type { Metadata } from "next"
+
+import { SITE } from "@/lib/site"
+import { TEMPLATES } from "@/registry/hirael/registry-meta"
+
+const TEMPLATES_DESCRIPTION =
+  "Full-page templates built in the Hirael style: complete, multi-section layouts you can copy into your repo with the shadcn CLI and edit like any other file."
+
+export const metadata: Metadata = {
+  title: "Templates",
+  description: TEMPLATES_DESCRIPTION,
+  alternates: {
+    canonical: "/templates",
+  },
+  openGraph: {
+    type: "website",
+    url: `${SITE.url}/templates`,
+    siteName: SITE.name,
+    title: `Templates | ${SITE.name}`,
+    description: TEMPLATES_DESCRIPTION,
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: `Templates | ${SITE.name}`,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `Templates | ${SITE.name}`,
+    description: TEMPLATES_DESCRIPTION,
+    images: ["/opengraph-image"],
+  },
+}
+
+export default function TemplatesIndex() {
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 py-10 sm:gap-12 sm:px-6 sm:py-12 md:px-10 md:py-16">
+      <header className="flex flex-col gap-5 border-b border-border pb-8 sm:pb-10">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-foreground">
+            ◆ templates
+          </span>
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            full-page compositions
+          </span>
+        </div>
+        <h1 className="text-balance text-4xl font-semibold leading-[1.05] tracking-tight sm:text-5xl md:text-6xl">
+          Full pages, ready to copy.
+        </h1>
+        <p className="max-w-2xl text-base text-muted-foreground">
+          Complete, multi-section layouts that compose Hirael blocks and
+          components into a finished page. Copy one in with a single command
+          and make it yours.
+        </p>
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          {TEMPLATES.length} template{TEMPLATES.length === 1 ? "" : "s"}
+        </p>
+      </header>
+
+      <section className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {TEMPLATES.map((entry) => (
+          <Link
+            key={entry.name}
+            href={`/templates/${entry.name}`}
+            className="group relative flex flex-col gap-4 overflow-hidden rounded-md border border-border bg-card/30 p-5 transition-all duration-200 hover:-translate-y-0.5 hover:border-foreground/30"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <h2 className="text-lg font-medium tracking-[-0.01em] text-foreground">
+                {entry.title}
+              </h2>
+              <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-sm border border-border text-muted-foreground transition-colors group-hover:border-foreground/40 group-hover:text-foreground">
+                <ArrowUpRight className="size-3.5" />
+              </span>
+            </div>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              {entry.description}
+            </p>
+            {entry.dependencies?.length ? (
+              <div className="mt-auto flex flex-wrap gap-1.5 pt-1">
+                {entry.dependencies.map((dep) => (
+                  <span
+                    key={dep}
+                    className="rounded-sm border border-border px-1.5 py-0 font-mono text-[10px] uppercase tracking-[0.06em] text-muted-foreground"
+                  >
+                    {dep}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </Link>
+        ))}
+      </section>
+    </div>
+  )
+}

--- a/app/(showcase)/theme/playground.tsx
+++ b/app/(showcase)/theme/playground.tsx
@@ -9,15 +9,13 @@ import { Label } from "@/registry/hirael/ui/label"
 import { ThemeSheetTrigger } from "@/components/showcase/theme-sheet"
 import { useTheme } from "@/components/showcase/theme-provider"
 import { RegistryDemo } from "@/registry/hirael/registry-demos"
-import { REGISTRY } from "@/registry/hirael/registry-meta"
+import { COMPONENTS } from "@/registry/hirael/registry-meta"
 
 export function ThemePlayground() {
   const { mode, theme } = useTheme()
   const overrideCount =
     Object.keys(theme.dark).length + Object.keys(theme.light).length
-  const components = REGISTRY.filter(
-    (r) => r.category !== "blocks"
-  )
+  const components = COMPONENTS
 
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10 sm:gap-10 sm:px-6 sm:py-12 md:px-10 md:py-14">

--- a/app/embed/templates/[template]/embed-shell.tsx
+++ b/app/embed/templates/[template]/embed-shell.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+
+/**
+ * Client wrapper for statically exported template embeds. Reads the `dir`
+ * query param at runtime so the viewer can preview templates in RTL.
+ */
+export function TemplateEmbedShell({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const [dir, setDir] = React.useState<"ltr" | "rtl">("ltr")
+
+  React.useEffect(() => {
+    const param = new URLSearchParams(window.location.search).get("dir")
+    if (param === "rtl") setDir("rtl")
+  }, [])
+
+  return (
+    <div dir={dir} className="min-h-svh bg-black">
+      {children}
+    </div>
+  )
+}

--- a/app/embed/templates/[template]/page.tsx
+++ b/app/embed/templates/[template]/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from "next/navigation"
+import type { Metadata } from "next"
+
+import { RegistryDemo } from "@/registry/hirael/registry-demos"
+import { REGISTRY, REGISTRY_BY_NAME } from "@/registry/hirael/registry-meta"
+
+import { TemplateEmbedShell } from "./embed-shell"
+
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return REGISTRY.filter((entry) => entry.category === "templates").map(
+    (entry) => ({ template: entry.name })
+  )
+}
+
+export const metadata: Metadata = { robots: { index: false } }
+
+export default async function TemplateEmbedRoute({
+  params,
+}: {
+  params: Promise<{ template: string }>
+}) {
+  const { template } = await params
+  const entry = REGISTRY_BY_NAME[template]
+  if (!entry || entry.category !== "templates") notFound()
+  return (
+    <TemplateEmbedShell>
+      <RegistryDemo name={entry.name} />
+    </TemplateEmbedShell>
+  )
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from "next/og"
 
 import { SITE } from "@/lib/site"
-import { REGISTRY } from "@/registry/hirael/registry-meta"
+import { COMPONENTS, REGISTRY } from "@/registry/hirael/registry-meta"
 
 export const dynamic = "force-static"
 
@@ -10,9 +10,7 @@ export const contentType = "image/png"
 export const alt = `${SITE.name} | ${SITE.description}`
 
 export default function OpenGraphImage() {
-  const components = REGISTRY.filter(
-    (r) => r.category !== "blocks"
-  ).length
+  const components = COMPONENTS.length
   const blocks = REGISTRY.filter((r) => r.category === "blocks").length
 
   return new ImageResponse(

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,7 @@ import { RegistryDemo } from "@/registry/hirael/registry-demos"
 import {
   BLOCK_KIND_ORDER,
   BLOCKS_BY_KIND,
-  REGISTRY,
+  COMPONENTS,
   REGISTRY_BY_CATEGORY,
   REGISTRY_BY_NAME,
 } from "@/registry/hirael/registry-meta"
@@ -64,7 +64,7 @@ export default function LandingPage() {
 /* -------------------------------------------------------------------------- */
 
 function Hero() {
-  const componentCount = REGISTRY.filter((r) => r.category !== "blocks").length
+  const componentCount = COMPONENTS.length
   const blocks = REGISTRY_BY_CATEGORY.blocks.length
 
   return (
@@ -125,9 +125,7 @@ const LIVE_DEMOS = [
 ] as const
 
 function LiveRegistry() {
-  const componentCount = REGISTRY.filter(
-    (r) => r.category !== "blocks"
-  ).length
+  const componentCount = COMPONENTS.length
 
   return (
     <section className="relative">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,7 +2,7 @@ import type { MetadataRoute } from "next"
 
 import { CATEGORY_REGISTRY } from "@/components/showcase/block-categories"
 import { SITE } from "@/lib/site"
-import { REGISTRY } from "@/registry/hirael/registry-meta"
+import { COMPONENTS, REGISTRY, TEMPLATES } from "@/registry/hirael/registry-meta"
 
 export const dynamic = "force-static"
 
@@ -29,6 +29,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.9,
     },
     {
+      url: `${SITE.url}/templates`,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    {
       url: `${SITE.url}/theme`,
       lastModified: now,
       changeFrequency: "monthly",
@@ -36,9 +42,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
   ]
 
-  const componentRoutes: MetadataRoute.Sitemap = REGISTRY.filter(
-    (entry) => entry.category !== "blocks"
-  ).map((entry) => ({
+  const componentRoutes: MetadataRoute.Sitemap = COMPONENTS.map((entry) => ({
     url: `${SITE.url}/${entry.name}`,
     lastModified: now,
     changeFrequency: "monthly",
@@ -63,10 +67,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.7,
   }))
 
+  const templateRoutes: MetadataRoute.Sitemap = TEMPLATES.map((entry) => ({
+    url: `${SITE.url}/templates/${entry.name}`,
+    lastModified: now,
+    changeFrequency: "monthly",
+    priority: 0.7,
+  }))
+
   return [
     ...staticRoutes,
     ...componentRoutes,
     ...blockRoutes,
     ...blockCategoryRoutes,
+    ...templateRoutes,
   ]
 }

--- a/components/showcase/block-viewer.tsx
+++ b/components/showcase/block-viewer.tsx
@@ -26,16 +26,18 @@ export function BlockViewer({
   name,
   title,
   minHeight = 800,
+  embedBase = "/embed/blocks",
 }: {
   name: string
   title: string
   minHeight?: number
+  embedBase?: string
 }) {
   const [viewport, setViewport] = React.useState<Viewport>("desktop")
   const [key, setKey] = React.useState(0)
   const [rtl, setRtl] = React.useState(false)
 
-  const src = `/embed/blocks/${name}${rtl ? "?dir=rtl" : ""}`
+  const src = `${embedBase}/${name}${rtl ? "?dir=rtl" : ""}`
 
   const sizing =
     viewport === "desktop"

--- a/components/showcase/command-palette.tsx
+++ b/components/showcase/command-palette.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { useRouter } from "next/navigation"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { Boxes, LayoutTemplate } from "lucide-react"
+import { Boxes, Frame, LayoutTemplate } from "lucide-react"
 
 import {
   Command,
@@ -15,7 +15,9 @@ import {
 } from "@/registry/hirael/ui/command"
 import {
   CATEGORY_LABELS,
+  COMPONENTS,
   REGISTRY,
+  TEMPLATES,
   type ComponentCategory,
 } from "@/registry/hirael/registry-meta"
 
@@ -41,8 +43,9 @@ export function CommandPalette({
     [router, onOpenChange]
   )
 
-  const components = REGISTRY.filter((r) => r.category !== "blocks")
+  const components = COMPONENTS
   const blocks = REGISTRY.filter((r) => r.category === "blocks")
+  const templates = TEMPLATES
 
   return (
     <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
@@ -85,6 +88,21 @@ export function CommandPalette({
                     <span>{b.title}</span>
                     <span className="ml-auto font-mono text-[10px] text-muted-foreground">
                       /{b.name}
+                    </span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+              <CommandGroup heading="Templates">
+                {templates.map((t) => (
+                  <CommandItem
+                    key={t.name}
+                    value={`${t.title} ${t.name}`}
+                    onSelect={() => go(`/templates/${t.name}`)}
+                  >
+                    <Frame className="text-muted-foreground" />
+                    <span>{t.title}</span>
+                    <span className="ml-auto font-mono text-[10px] text-muted-foreground">
+                      /{t.name}
                     </span>
                   </CommandItem>
                 ))}

--- a/components/showcase/component-page.tsx
+++ b/components/showcase/component-page.tsx
@@ -32,7 +32,10 @@ export function ComponentPage({
   const [tab, setTab] = React.useState<Tab>("preview")
   const [rtl, setRtl] = React.useState(false)
 
-  const isBlock = entry.category === "blocks"
+  const isComposite =
+    entry.category === "blocks" || entry.category === "templates"
+  const embedBase =
+    entry.category === "templates" ? "/embed/templates" : "/embed/blocks"
 
   const codeTabs: CodeBlockTab[] = React.useMemo(
     () =>
@@ -40,14 +43,14 @@ export function ComponentPage({
         .map((f, i) => {
           const file = source[f]
           if (!file) return null
-          const label = isBlock ? entry.installTargets?.[i] ?? f : f
+          const label = isComposite ? entry.installTargets?.[i] ?? f : f
           return { label, code: file.code, html: file.html }
         })
         .filter((t): t is CodeBlockTab => t !== null),
-    [entry.sourceFiles, entry.installTargets, source, isBlock]
+    [entry.sourceFiles, entry.installTargets, source, isComposite]
   )
 
-  const showUsageTab = !isBlock && !!demoSource
+  const showUsageTab = !isComposite && !!demoSource
 
   const tabs = React.useMemo<Array<[Tab, string]>>(() => {
     const list: Array<[Tab, string]> = [["preview", "Preview"]]
@@ -143,8 +146,12 @@ export function ComponentPage({
             className="focus-visible:outline-none"
           >
             {tab === "preview" &&
-              (isBlock ? (
-                <BlockViewer name={entry.name} title={entry.title} />
+              (isComposite ? (
+                <BlockViewer
+                  name={entry.name}
+                  title={entry.title}
+                  embedBase={embedBase}
+                />
               ) : (
                 <div className="relative rounded-sm border border-border bg-card/40">
                   <DirectionToggle
@@ -174,7 +181,7 @@ export function ComponentPage({
             )}
 
             {tab === "code" && codeTabs.length > 0 && (
-              <CodeBlock tabs={codeTabs} layout={isBlock ? "tree" : "tabs"} />
+              <CodeBlock tabs={codeTabs} layout={isComposite ? "tree" : "tabs"} />
             )}
 
             {tab === "install" && (

--- a/components/showcase/sidebar.tsx
+++ b/components/showcase/sidebar.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { Boxes, LayoutTemplate, Sparkles } from "lucide-react"
+import { Boxes, Frame, LayoutTemplate, Sparkles } from "lucide-react"
 
 import { LogoMarkM } from "@/components/showcase/logo"
 import { ThemeSheetTrigger } from "@/components/showcase/theme-sheet"
@@ -38,6 +38,7 @@ const CATEGORY_ORDER: ComponentCategory[] = [
 export function ShowcaseSidebar() {
   const pathname = usePathname()
   const blockCount = REGISTRY_BY_CATEGORY.blocks.length
+  const templateCount = REGISTRY_BY_CATEGORY.templates.length
 
   const isActive = (href: string) => {
     if (href === "/") return pathname === "/"
@@ -86,6 +87,17 @@ export function ShowcaseSidebar() {
                     <span>Blocks</span>
                     <span className="ml-auto font-mono text-[10px] tabular-nums text-muted-foreground">
                       {blockCount}
+                    </span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton asChild isActive={isActive("/templates")}>
+                  <Link href="/templates">
+                    <Frame />
+                    <span>Templates</span>
+                    <span className="ml-auto font-mono text-[10px] tabular-nums text-muted-foreground">
+                      {templateCount}
                     </span>
                   </Link>
                 </SidebarMenuButton>

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -41,5 +41,6 @@ export const NAV_LINKS: { href: string; label: string; external?: boolean }[] =
   [
     { href: "/components", label: "Components" },
     { href: "/blocks", label: "Blocks" },
+    { href: "/templates", label: "Templates" },
     { href: "/theme", label: "Theme" },
   ]

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "framer-motion": "^12.40.0",
     "lucide-react": "^1.18.0",
     "next": "16.2.9",
     "react": "19.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      framer-motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       lucide-react:
         specifier: ^1.18.0
         version: 1.18.0(react@19.2.7)
@@ -2068,6 +2071,20 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  framer-motion@12.40.0:
+    resolution: {integrity: sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -2670,6 +2687,12 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  motion-dom@12.40.0:
+    resolution: {integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==}
+
+  motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -5580,6 +5603,15 @@ snapshots:
 
   forwarded@0.2.0: {}
 
+  framer-motion@12.40.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      motion-dom: 12.40.0
+      motion-utils: 12.39.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   fresh@2.0.0: {}
 
   fs-extra@11.3.5:
@@ -6130,6 +6162,12 @@ snapshots:
       brace-expansion: 1.1.15
 
   minimist@1.2.8: {}
+
+  motion-dom@12.40.0:
+    dependencies:
+      motion-utils: 12.39.0
+
+  motion-utils@12.39.0: {}
 
   ms@2.1.3: {}
 

--- a/registry.json
+++ b/registry.json
@@ -1342,6 +1342,47 @@
           "target": "components/ui/tour.tsx"
         }
       ]
+    },
+    {
+      "name": "creative-studio",
+      "type": "registry:block",
+      "title": "Creative Studio",
+      "description": "Dark, cinematic creative-studio landing page: a full-viewport hero with an animated backdrop and pull-up wordmark, a scroll-revealed about section, and a staggered feature-card grid. Framer Motion throughout, with a self-contained warm-cream palette.",
+      "categories": ["templates"],
+      "dependencies": ["framer-motion", "lucide-react"],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/hirael/templates/creative-studio/creative-studio.tsx",
+          "type": "registry:component",
+          "target": "components/templates/creative-studio/creative-studio.tsx"
+        },
+        {
+          "path": "registry/hirael/templates/creative-studio/hero.tsx",
+          "type": "registry:component",
+          "target": "components/templates/creative-studio/hero.tsx"
+        },
+        {
+          "path": "registry/hirael/templates/creative-studio/about.tsx",
+          "type": "registry:component",
+          "target": "components/templates/creative-studio/about.tsx"
+        },
+        {
+          "path": "registry/hirael/templates/creative-studio/features.tsx",
+          "type": "registry:component",
+          "target": "components/templates/creative-studio/features.tsx"
+        },
+        {
+          "path": "registry/hirael/templates/creative-studio/primitives.tsx",
+          "type": "registry:component",
+          "target": "components/templates/creative-studio/primitives.tsx"
+        },
+        {
+          "path": "registry/hirael/templates/creative-studio/fonts.ts",
+          "type": "registry:component",
+          "target": "components/templates/creative-studio/fonts.ts"
+        }
+      ]
     }
   ]
 }

--- a/registry/hirael/registry-demos.tsx
+++ b/registry/hirael/registry-demos.tsx
@@ -94,6 +94,8 @@ const DEMO_LOADERS: Record<
   "audio-player": () => import("@/registry/hirael/audio-player/audio-player.demo"),
   "media-input": () => import("@/registry/hirael/media-input/media-input.demo"),
   "tour": () => import("@/registry/hirael/tour/tour.demo"),
+  "creative-studio": () =>
+    import("@/registry/hirael/templates/creative-studio/creative-studio"),
 }
 
 const cache = new Map<string, React.LazyExoticComponent<React.ComponentType>>()

--- a/registry/hirael/registry-meta.ts
+++ b/registry/hirael/registry-meta.ts
@@ -6,6 +6,7 @@ export type ComponentCategory =
   | "display"
   | "navigation"
   | "blocks"
+  | "templates"
 
 export type BlockKind =
   | "hero"
@@ -1009,6 +1010,31 @@ export const REGISTRY: RegistryEntryMeta[] = [
     registryDependencies: ["button"],
     dependencies: [],
   },
+  {
+    name: "creative-studio",
+    title: "Creative Studio",
+    description:
+      "Dark, cinematic creative-studio landing page: a full-viewport hero with an animated backdrop and pull-up wordmark, a scroll-revealed about section, and a staggered feature-card grid. Framer Motion throughout, with a self-contained warm-cream palette.",
+    category: "templates",
+    sourceFiles: [
+      "registry/hirael/templates/creative-studio/creative-studio.tsx",
+      "registry/hirael/templates/creative-studio/hero.tsx",
+      "registry/hirael/templates/creative-studio/about.tsx",
+      "registry/hirael/templates/creative-studio/features.tsx",
+      "registry/hirael/templates/creative-studio/primitives.tsx",
+      "registry/hirael/templates/creative-studio/fonts.ts",
+    ],
+    installTargets: [
+      "components/templates/creative-studio/creative-studio.tsx",
+      "components/templates/creative-studio/hero.tsx",
+      "components/templates/creative-studio/about.tsx",
+      "components/templates/creative-studio/features.tsx",
+      "components/templates/creative-studio/primitives.tsx",
+      "components/templates/creative-studio/fonts.ts",
+    ],
+    registryDependencies: [],
+    dependencies: ["framer-motion", "lucide-react"],
+  },
 ]
 
 export const REGISTRY_BY_NAME = Object.fromEntries(
@@ -1023,6 +1049,7 @@ export const CATEGORY_LABELS: Record<ComponentCategory, string> = {
   display: "Display",
   navigation: "Navigation",
   blocks: "Blocks",
+  templates: "Templates",
 }
 
 export const REGISTRY_BY_CATEGORY = (() => {
@@ -1034,10 +1061,17 @@ export const REGISTRY_BY_CATEGORY = (() => {
     display: [],
     navigation: [],
     blocks: [],
+    templates: [],
   }
   for (const entry of REGISTRY) groups[entry.category].push(entry)
   return groups
 })()
+
+export const TEMPLATES = REGISTRY_BY_CATEGORY.templates
+
+export const COMPONENTS = REGISTRY.filter(
+  (entry) => entry.category !== "blocks" && entry.category !== "templates"
+)
 
 export const BLOCK_KIND_LABELS: Record<BlockKind, string> = {
   hero: "Hero sections",

--- a/registry/hirael/templates/creative-studio/about.tsx
+++ b/registry/hirael/templates/creative-studio/about.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import { ScrollRevealText, WordsPullUpMultiStyle } from "./primitives"
+
+const HEADING_SEGMENTS = [
+  { text: "Hirael is a creative studio,", className: "font-normal" },
+  {
+    text: "born from restless curiosity.",
+    className: "italic [font-family:var(--font-instrument-serif)]",
+  },
+  {
+    text: "We shape color, light and story into work that lingers.",
+    className: "font-normal",
+  },
+]
+
+const BODY =
+  "Over the last seven years we have partnered with directors, brands and festivals across Berlin, Paris and beyond, crafting cinema and series that have earned acclaim on stages worldwide."
+
+export function About() {
+  return (
+    <section className="bg-black px-4 py-20 sm:px-6 sm:py-28 md:py-32">
+      <div className="mx-auto flex max-w-6xl flex-col items-center gap-10 rounded-[2rem] bg-[#101010] px-6 py-16 text-center sm:px-10 sm:py-20 md:px-16 md:py-24">
+        <span className="text-[10px] font-medium uppercase tracking-[0.24em] text-[#DEDBC8] sm:text-xs">
+          Visual arts
+        </span>
+
+        <h2
+          className="mx-auto max-w-3xl text-3xl leading-[0.95] sm:text-4xl sm:leading-[0.9] md:text-5xl lg:text-6xl xl:text-7xl"
+          style={{ color: "#E1E0CC" }}
+        >
+          <WordsPullUpMultiStyle segments={HEADING_SEGMENTS} />
+        </h2>
+
+        <ScrollRevealText
+          text={BODY}
+          className="mx-auto max-w-2xl text-xs leading-relaxed text-[#DEDBC8] sm:text-sm md:text-base"
+        />
+      </div>
+    </section>
+  )
+}

--- a/registry/hirael/templates/creative-studio/creative-studio.tsx
+++ b/registry/hirael/templates/creative-studio/creative-studio.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+
+import { About } from "./about"
+import { Features } from "./features"
+import { almarai, instrumentSerif } from "./fonts"
+import { Hero } from "./hero"
+
+export default function CreativeStudio() {
+  return (
+    <div
+      className={cn(
+        almarai.variable,
+        instrumentSerif.variable,
+        "bg-black text-[#DEDBC8] antialiased"
+      )}
+      style={{
+        fontFamily: "var(--font-almarai), ui-sans-serif, system-ui, sans-serif",
+      }}
+    >
+      <Hero />
+      <About />
+      <Features />
+    </div>
+  )
+}

--- a/registry/hirael/templates/creative-studio/features.tsx
+++ b/registry/hirael/templates/creative-studio/features.tsx
@@ -1,0 +1,236 @@
+"use client"
+
+import * as React from "react"
+import { ArrowRight, Check } from "lucide-react"
+import { motion, useInView, useReducedMotion } from "framer-motion"
+
+import { cn } from "@/lib/utils"
+import { CinematicBackground, NoiseOverlay, WordsPullUp } from "./primitives"
+
+const CREAM = "#E1E0CC"
+const PRIMARY = "#DEDBC8"
+
+const EASE_CARD: [number, number, number, number] = [0.22, 1, 0.36, 1]
+
+function IconStoryboard({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      <rect x="3" y="5" width="18" height="14" rx="2" />
+      <path d="M9 5v14M15 5v14" />
+      <path d="M3 9.5h6M3 14.5h6M15 9.5h6M15 14.5h6" />
+    </svg>
+  )
+}
+
+function IconCritique({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      <path d="M21 11.5a8 8 0 0 1-11.5 7.2L4 20l1.3-4A8 8 0 1 1 21 11.5Z" />
+      <path d="m13 7 1 2.2 2.2 1-2.2 1L13 13.5 12 11.2 9.8 10.2 12 9.2Z" />
+    </svg>
+  )
+}
+
+function IconImmersion({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      <circle cx="12" cy="12" r="2.5" />
+      <path d="M7.5 7.5a6.5 6.5 0 0 0 0 9M16.5 7.5a6.5 6.5 0 0 1 0 9" />
+      <path d="M4.5 4.5a11 11 0 0 0 0 15M19.5 4.5a11 11 0 0 1 0 15" />
+    </svg>
+  )
+}
+
+type InfoCard = {
+  index: number
+  number: string
+  title: string
+  Icon: (props: { className?: string }) => React.ReactElement
+  items: string[]
+}
+
+const INFO_CARDS: InfoCard[] = [
+  {
+    index: 1,
+    number: "01",
+    title: "Project Storyboard.",
+    Icon: IconStoryboard,
+    items: [
+      "Frame-by-frame shot planning",
+      "Drag and drop scene ordering",
+      "Shared boards for the whole crew",
+      "Version history on every cut",
+    ],
+  },
+  {
+    index: 2,
+    number: "02",
+    title: "Smart Critiques.",
+    Icon: IconCritique,
+    items: [
+      "AI analysis of pacing and tone",
+      "Inline creative notes and markups",
+      "Integrations with your editing tools",
+    ],
+  },
+  {
+    index: 3,
+    number: "03",
+    title: "Immersion Capsule.",
+    Icon: IconImmersion,
+    items: [
+      "Notification silencing while you create",
+      "Ambient soundscapes for deep focus",
+      "Schedule syncing across your devices",
+    ],
+  },
+]
+
+function FeatureCard({
+  index,
+  className,
+  children,
+}: {
+  index: number
+  className?: string
+  children: React.ReactNode
+}) {
+  const ref = React.useRef<HTMLDivElement>(null)
+  const inView = useInView(ref, { once: true, margin: "-100px" })
+  const reduce = useReducedMotion()
+  const show = reduce || inView
+  return (
+    <motion.div
+      ref={ref}
+      initial={reduce ? false : { scale: 0.95, opacity: 0 }}
+      animate={show ? { scale: 1, opacity: 1 } : undefined}
+      transition={{ duration: 0.6, delay: index * 0.15, ease: EASE_CARD }}
+      className={cn("relative overflow-hidden rounded-2xl", className)}
+    >
+      {children}
+    </motion.div>
+  )
+}
+
+export function Features({ videoSrc }: { videoSrc?: string }) {
+  return (
+    <section className="relative min-h-screen overflow-hidden bg-black px-4 py-20 sm:px-6 sm:py-28 md:py-32">
+      <NoiseOverlay variant="bg" className="opacity-[0.15]" />
+
+      <div className="relative mx-auto flex max-w-6xl flex-col gap-12 md:gap-16">
+        <div className="flex flex-col items-center gap-1 text-center">
+          <WordsPullUp
+            text="Studio-grade craft for visionary creators."
+            className="justify-center text-xl font-normal text-[#E1E0CC] sm:text-2xl md:text-3xl lg:text-4xl"
+          />
+          <WordsPullUp
+            text="Built for pure vision. Powered by art."
+            className="justify-center text-xl font-normal text-gray-500 sm:text-2xl md:text-3xl lg:text-4xl"
+          />
+        </div>
+
+        <div className="grid grid-cols-1 gap-3 sm:gap-2 md:grid-cols-2 md:gap-1 lg:grid-cols-4 lg:h-[480px]">
+          <FeatureCard
+            index={0}
+            className="min-h-[320px] lg:h-full lg:min-h-0"
+          >
+            {videoSrc ? (
+              <video
+                className="absolute inset-0 h-full w-full object-cover"
+                src={videoSrc}
+                autoPlay
+                loop
+                muted
+                playsInline
+              />
+            ) : (
+              <CinematicBackground variant="card" />
+            )}
+            <div
+              aria-hidden
+              className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/10 to-transparent"
+            />
+            <div className="absolute inset-x-0 bottom-0 p-5">
+              <p className="text-lg font-medium" style={{ color: CREAM }}>
+                Your creative canvas.
+              </p>
+            </div>
+          </FeatureCard>
+
+          {INFO_CARDS.map((card) => (
+            <FeatureCard
+              key={card.number}
+              index={card.index}
+              className="min-h-[300px] bg-[#212121] lg:h-full lg:min-h-0"
+            >
+              <div className="flex h-full flex-col gap-4 p-5">
+                <div className="flex items-start justify-between">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-black/40 sm:h-12 sm:w-12">
+                    <card.Icon className="h-5 w-5 text-[#DEDBC8] sm:h-6 sm:w-6" />
+                  </div>
+                  <span className="font-mono text-[10px] tabular-nums text-gray-500">
+                    {card.number}
+                  </span>
+                </div>
+
+                <h3 className="text-base font-medium" style={{ color: CREAM }}>
+                  {card.title}
+                </h3>
+
+                <ul className="flex flex-col gap-2">
+                  {card.items.map((item) => (
+                    <li
+                      key={item}
+                      className="flex items-start gap-2 text-xs text-gray-400 sm:text-sm"
+                    >
+                      <Check
+                        className="mt-0.5 h-3.5 w-3.5 shrink-0"
+                        style={{ color: PRIMARY }}
+                      />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                <a
+                  href="#"
+                  className="group mt-auto inline-flex items-center gap-1.5 text-xs font-medium text-[#DEDBC8] sm:text-sm"
+                >
+                  Learn more
+                  <ArrowRight className="h-3.5 w-3.5 -rotate-45 transition-transform duration-200 group-hover:translate-x-0.5" />
+                </a>
+              </div>
+            </FeatureCard>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/registry/hirael/templates/creative-studio/fonts.ts
+++ b/registry/hirael/templates/creative-studio/fonts.ts
@@ -1,0 +1,16 @@
+import { Almarai, Instrument_Serif } from "next/font/google"
+
+export const almarai = Almarai({
+  variable: "--font-almarai",
+  subsets: ["latin"],
+  weight: ["300", "400", "700", "800"],
+  display: "swap",
+})
+
+export const instrumentSerif = Instrument_Serif({
+  variable: "--font-instrument-serif",
+  subsets: ["latin", "latin-ext"],
+  weight: "400",
+  style: ["normal", "italic"],
+  display: "swap",
+})

--- a/registry/hirael/templates/creative-studio/hero.tsx
+++ b/registry/hirael/templates/creative-studio/hero.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import { ArrowRight } from "lucide-react"
+import { motion, useReducedMotion } from "framer-motion"
+
+import { CinematicBackground, NoiseOverlay, WordsPullUp } from "./primitives"
+
+const NAV_ITEMS = ["Our story", "Collective", "Workshops", "Programs", "Inquiries"]
+
+const CREAM = "#E1E0CC"
+
+const EASE_OUT_EXPO: [number, number, number, number] = [0.16, 1, 0.3, 1]
+
+export function Hero({
+  videoSrc,
+  posterSrc,
+}: {
+  videoSrc?: string
+  posterSrc?: string
+}) {
+  const reduce = useReducedMotion()
+
+  const fade = (delay: number) => ({
+    initial: reduce ? false : { y: 20, opacity: 0 },
+    animate: { y: 0, opacity: 1 },
+    transition: { duration: 0.8, delay, ease: EASE_OUT_EXPO },
+  })
+
+  return (
+    <section className="h-screen w-full bg-black p-4 md:p-6">
+      <div className="relative h-full w-full overflow-hidden rounded-2xl bg-black md:rounded-[2rem]">
+        {videoSrc ? (
+          <video
+            className="absolute inset-0 h-full w-full object-cover"
+            src={videoSrc}
+            poster={posterSrc}
+            autoPlay
+            loop
+            muted
+            playsInline
+          />
+        ) : (
+          <CinematicBackground variant="hero" />
+        )}
+
+        <NoiseOverlay className="opacity-[0.7] mix-blend-overlay" />
+
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/30 via-transparent to-black/60"
+        />
+
+        <nav className="absolute left-1/2 top-0 z-20 -translate-x-1/2 rounded-b-2xl bg-black px-4 py-2 md:px-8 md:rounded-b-3xl">
+          <ul className="flex items-center gap-3 sm:gap-6 md:gap-12 lg:gap-14">
+            {NAV_ITEMS.map((item) => (
+              <li key={item}>
+                <a
+                  href="#"
+                  className="text-[10px] text-[#E1E0CC]/80 transition-colors hover:text-[#E1E0CC] sm:text-xs md:text-sm"
+                >
+                  {item}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+
+        <div className="absolute inset-x-0 bottom-0 z-10 p-4 sm:p-6 md:p-8 lg:p-10">
+          <div className="grid grid-cols-12 items-end gap-4 md:gap-6">
+            <div className="col-span-12 lg:col-span-8">
+              <h1
+                className="text-[26vw] font-medium leading-[0.85] tracking-[-0.07em] sm:text-[24vw] md:text-[22vw] lg:text-[20vw] xl:text-[19vw] 2xl:text-[20vw]"
+                style={{ color: CREAM }}
+              >
+                <WordsPullUp text="Hirael" showAsterisk />
+              </h1>
+            </div>
+
+            <div className="col-span-12 flex flex-col gap-4 lg:col-span-4 md:gap-6">
+              <motion.p
+                {...fade(0.5)}
+                className="max-w-md text-xs text-[#DEDBC8]/70 sm:text-sm md:text-base"
+                style={{ lineHeight: 1.2 }}
+              >
+                Hirael is a worldwide network of visual artists, filmmakers and
+                storytellers bound not by place, status or labels but by passion
+                and hunger to unlock potential through our unique perspectives.
+              </motion.p>
+
+              <motion.div {...fade(0.7)}>
+                <a
+                  href="#"
+                  className="group inline-flex w-fit items-center gap-2 rounded-full bg-[#DEDBC8] py-1.5 pe-1.5 ps-5 text-sm font-medium text-black transition-all duration-300 hover:gap-3 sm:text-base"
+                >
+                  Join the lab
+                  <span className="flex h-9 w-9 items-center justify-center rounded-full bg-black transition-transform duration-300 group-hover:scale-110 sm:h-10 sm:w-10">
+                    <ArrowRight
+                      className="h-4 w-4 rtl:rotate-180"
+                      style={{ color: CREAM }}
+                    />
+                  </span>
+                </a>
+              </motion.div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/registry/hirael/templates/creative-studio/index.ts
+++ b/registry/hirael/templates/creative-studio/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./creative-studio"

--- a/registry/hirael/templates/creative-studio/primitives.tsx
+++ b/registry/hirael/templates/creative-studio/primitives.tsx
@@ -1,0 +1,285 @@
+"use client"
+
+import * as React from "react"
+import {
+  motion,
+  useInView,
+  useReducedMotion,
+  useScroll,
+  useTransform,
+  type MotionValue,
+} from "framer-motion"
+
+import { cn } from "@/lib/utils"
+
+const EASE_OUT_EXPO: [number, number, number, number] = [0.16, 1, 0.3, 1]
+
+function noiseDataUri(baseFrequency: number, numOctaves: number) {
+  const svg =
+    `<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'>` +
+    `<filter id='n'><feTurbulence type='fractalNoise' baseFrequency='${baseFrequency}' numOctaves='${numOctaves}' stitchTiles='stitch'/>` +
+    `<feColorMatrix values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.55 0'/></filter>` +
+    `<rect width='100%' height='100%' filter='url(#n)'/></svg>`
+  return `url("data:image/svg+xml;utf8,${encodeURIComponent(svg)}")`
+}
+
+const OVERLAY_NOISE = noiseDataUri(0.85, 3)
+const BG_NOISE = noiseDataUri(0.9, 4)
+
+const HERO_GRADIENT =
+  "radial-gradient(45% 45% at 28% 30%, rgba(222,219,200,0.16), transparent 70%)," +
+  "radial-gradient(42% 42% at 73% 62%, rgba(196,162,120,0.22), transparent 72%)," +
+  "radial-gradient(70% 55% at 50% 112%, rgba(36,30,22,0.92), transparent 72%)," +
+  "#070707"
+
+const CARD_GRADIENT =
+  "radial-gradient(55% 55% at 32% 28%, rgba(222,219,200,0.14), transparent 70%)," +
+  "radial-gradient(50% 50% at 72% 78%, rgba(150,138,116,0.20), transparent 72%)," +
+  "#0b0a09"
+
+const VIGNETTE =
+  "radial-gradient(125% 120% at 50% 0%, transparent 52%, rgba(0,0,0,0.55) 100%)"
+
+export function NoiseOverlay({
+  variant = "overlay",
+  className,
+}: {
+  variant?: "overlay" | "bg"
+  className?: string
+}) {
+  return (
+    <div
+      aria-hidden
+      className={cn("pointer-events-none absolute inset-0", className)}
+      style={{
+        backgroundImage: variant === "overlay" ? OVERLAY_NOISE : BG_NOISE,
+        backgroundSize: "160px 160px",
+      }}
+    />
+  )
+}
+
+export function CinematicBackground({
+  variant = "hero",
+  className,
+}: {
+  variant?: "hero" | "card"
+  className?: string
+}) {
+  const reduce = useReducedMotion()
+  return (
+    <div
+      aria-hidden
+      className={cn("absolute inset-0 overflow-hidden bg-black", className)}
+    >
+      <motion.div
+        className="absolute -inset-1/3"
+        style={{
+          background: variant === "hero" ? HERO_GRADIENT : CARD_GRADIENT,
+          filter: "blur(40px)",
+        }}
+        animate={
+          reduce
+            ? undefined
+            : {
+                x: ["-3%", "3%", "-3%"],
+                y: ["-2%", "2%", "-2%"],
+                rotate: [0, 6, 0],
+                scale: [1, 1.12, 1],
+              }
+        }
+        transition={{
+          duration: 34,
+          repeat: Infinity,
+          repeatType: "mirror",
+          ease: "easeInOut",
+        }}
+      />
+      <div className="absolute inset-0" style={{ background: VIGNETTE }} />
+    </div>
+  )
+}
+
+function WithAsterisk({ word }: { word: string }) {
+  const chars = Array.from(word)
+  const last = chars.pop() ?? ""
+  return (
+    <>
+      {chars.join("")}
+      <span className="relative inline-block">
+        {last}
+        <span className="absolute -right-[0.3em] top-[0.1em] text-[0.31em]">*</span>
+      </span>
+    </>
+  )
+}
+
+export function WordsPullUp({
+  text,
+  className,
+  wordClassName,
+  showAsterisk = false,
+  startDelay = 0,
+  stagger = 0.08,
+}: {
+  text: string
+  className?: string
+  wordClassName?: string
+  showAsterisk?: boolean
+  startDelay?: number
+  stagger?: number
+}) {
+  const ref = React.useRef<HTMLSpanElement>(null)
+  const inView = useInView(ref, { once: true })
+  const reduce = useReducedMotion()
+  const words = text.split(" ")
+  const show = reduce || inView
+
+  return (
+    <span
+      ref={ref}
+      className={cn("inline-flex flex-wrap", className)}
+      style={{ columnGap: "0.25em" }}
+    >
+      {words.map((word, i) => {
+        const last = i === words.length - 1
+        return (
+          <motion.span
+            key={i}
+            className={cn("inline-block", wordClassName)}
+            initial={reduce ? false : { y: 20, opacity: 0 }}
+            animate={show ? { y: 0, opacity: 1 } : undefined}
+            transition={{
+              duration: 0.6,
+              delay: startDelay + i * stagger,
+              ease: EASE_OUT_EXPO,
+            }}
+          >
+            {last && showAsterisk ? <WithAsterisk word={word} /> : word}
+          </motion.span>
+        )
+      })}
+    </span>
+  )
+}
+
+export type StyledSegment = { text: string; className?: string }
+
+export function WordsPullUpMultiStyle({
+  segments,
+  className,
+  startDelay = 0,
+  stagger = 0.08,
+}: {
+  segments: StyledSegment[]
+  className?: string
+  startDelay?: number
+  stagger?: number
+}) {
+  const ref = React.useRef<HTMLSpanElement>(null)
+  const inView = useInView(ref, { once: true })
+  const reduce = useReducedMotion()
+  const show = reduce || inView
+
+  const words: StyledSegment[] = []
+  for (const seg of segments) {
+    for (const part of seg.text.split(" ")) {
+      if (part.length > 0) words.push({ text: part, className: seg.className })
+    }
+  }
+
+  return (
+    <span
+      ref={ref}
+      className={cn("inline-flex flex-wrap justify-center", className)}
+      style={{ columnGap: "0.25em" }}
+    >
+      {words.map((word, i) => (
+        <motion.span
+          key={i}
+          className={cn("inline-block", word.className)}
+          initial={reduce ? false : { y: 20, opacity: 0 }}
+          animate={show ? { y: 0, opacity: 1 } : undefined}
+          transition={{
+            duration: 0.6,
+            delay: startDelay + i * stagger,
+            ease: EASE_OUT_EXPO,
+          }}
+        >
+          {word.text}
+        </motion.span>
+      ))}
+    </span>
+  )
+}
+
+function AnimatedLetter({
+  char,
+  index,
+  total,
+  progress,
+}: {
+  char: string
+  index: number
+  total: number
+  progress: MotionValue<number>
+}) {
+  const reduce = useReducedMotion()
+  const charProgress = index / total
+  const opacity = useTransform(
+    progress,
+    [charProgress - 0.1, charProgress + 0.05],
+    [0.2, 1]
+  )
+  return (
+    <motion.span
+      aria-hidden
+      className="inline-block whitespace-pre"
+      style={reduce ? undefined : { opacity }}
+    >
+      {char}
+    </motion.span>
+  )
+}
+
+export function ScrollRevealText({
+  text,
+  className,
+}: {
+  text: string
+  className?: string
+}) {
+  const ref = React.useRef<HTMLParagraphElement>(null)
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ["start 0.8", "end 0.2"],
+  })
+  const words = text.split(" ")
+  const total = text.length
+  let cursor = 0
+
+  return (
+    <p ref={ref} aria-label={text} className={className}>
+      {words.map((word, wi) => {
+        const start = cursor
+        cursor += word.length + 1
+        return (
+          <React.Fragment key={wi}>
+            <span className="inline-block whitespace-nowrap">
+              {Array.from(word).map((ch, ci) => (
+                <AnimatedLetter
+                  key={ci}
+                  char={ch}
+                  index={start + ci}
+                  total={total}
+                  progress={scrollYProgress}
+                />
+              ))}
+            </span>
+            {wi < words.length - 1 ? " " : null}
+          </React.Fragment>
+        )
+      })}
+    </p>
+  )
+}

--- a/scripts/check-registry.mjs
+++ b/scripts/check-registry.mjs
@@ -53,8 +53,8 @@ while ((m = entryRe.exec(meta)) !== null) {
     }
   }
 
-  const isBlock = /category: "blocks"/.test(body)
-  if (!isBlock) {
+  const isComposite = /category: "(?:blocks|templates)"/.test(body)
+  if (!isComposite) {
     const demo = `registry/hirael/${name}/${name}.demo.tsx`
     if (!existsSync(demo)) {
       fail(`registry-meta: component "${name}" → missing demo ${demo}`)


### PR DESCRIPTION
## Summary
Introduces a new full-page template system to the registry, starting with the "Creative Studio" template—a dark, cinematic landing page featuring animated backgrounds, scroll-reveal text effects, and staggered feature cards built with Framer Motion.

## Key Changes

- **New Template System**: Added `/templates` route and infrastructure to support full-page template compositions alongside existing components and blocks
  - Created `app/(showcase)/templates/page.tsx` for template index
  - Created `app/(showcase)/templates/[template]/page.tsx` for individual template pages
  - Added `app/embed/templates/[template]/page.tsx` for embeddable template previews
  - Added `TemplateEmbedShell` component for RTL preview support

- **Creative Studio Template**: Complete multi-section landing page with:
  - **Hero section** (`hero.tsx`): Full-viewport hero with animated cinematic background, navigation bar, large wordmark with pull-up animation, and CTA button
  - **About section** (`about.tsx`): Centered content block with multi-styled heading and scroll-reveal body text
  - **Features section** (`features.tsx`): Staggered grid of feature cards with icons, descriptions, and links
  - **Primitives** (`primitives.tsx`): Reusable animation components including:
    - `NoiseOverlay`: SVG-based procedural noise texture
    - `CinematicBackground`: Animated gradient backdrop with blur and vignette
    - `WordsPullUp`: Word-by-word entrance animation with optional asterisk
    - `WordsPullUpMultiStyle`: Multi-styled variant for mixed typography
    - `ScrollRevealText`: Character-by-character reveal on scroll
  - **Fonts** (`fonts.ts`): Google Fonts integration (Almarai, Instrument Serif)

- **Registry Updates**:
  - Added `"templates"` as new `ComponentCategory` type
  - Registered Creative Studio template in `registry-meta.ts` with source files and install targets
  - Updated `registry.json` with template entry and file mappings
  - Added `TEMPLATES` and `COMPONENTS` exports to registry metadata for cleaner filtering

- **UI/Navigation Updates**:
  - Added Templates link to main navigation (`lib/site.ts`)
  - Updated sidebar to include Templates section with Frame icon
  - Updated command palette to include template search
  - Updated component page viewer to support template embeds with configurable base path
  - Updated sitemap generation to include `/templates` route

- **Documentation**:
  - Updated `CONTRIBUTING.md` to document template directory structure
  - Updated `README.md` to mention marketing templates

- **Dependencies**:
  - Added `framer-motion@^12.40.0` for animation primitives

## Implementation Details

- Templates use the same registry system as blocks but with `category: "templates"` for distinction
- Cinematic background uses radial gradients with animated transforms and blur filters
- Animations respect `prefers-reduced-motion` via `useReducedMotion()` hook
- Scroll reveal text uses `useScroll()` to track viewport position and animate character opacity
- Feature cards use staggered entrance animations with configurable delays
- All color values are self-contained in the template (warm cream palette: #E1E0CC, #DEDBC8)
- Template can accept optional `videoSrc` and `posterSrc` props to replace animated backgrounds with video

https://claude.ai/code/session_01QeJaHsrP5UKCzteiSMt6r3