### PR TITLE
Clarify changelog guidance and remove implementation details

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,9 +165,13 @@ secrets, plus `RELEASES_TOKEN` (a public-repo-read PAT) so the changelog
 fetch during the production build isn't rate-limited.
 
 When you ship anything user-visible, make the next release note describe it
-before the tag is pushed:
+before the tag is pushed. A release note is for visitors and consumers, so
+keep it to what they get — new components, blocks, features, and bug fixes.
+Leave out how the site is built, rendered, or deployed (static export, the
+GitHub Releases fetch, Vercel, CI, the registry pipeline) and other
+repo-internal tooling; none of that concerns the reader of a changelog.
 
-- Keep release titles short and visitor-facing, e.g. `Static export & RTL`.
+- Keep release titles short and visitor-facing, e.g. `RTL across the catalog`.
 - Put detail in the annotated tag/release body under `Highlights:` and
   `Fixes:` headings, each followed by `- ` bullets — that's exactly what the
   changelog parser groups.

--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -6,7 +6,7 @@ import { SITE } from "@/lib/site"
 
 export const metadata: Metadata = {
   title: "Changelog",
-  description: `Release notes for ${SITE.name} — new components, blocks, fixes, and polish.`,
+  description: `Release notes for ${SITE.name}: new components, blocks, fixes, and polish.`,
   alternates: { canonical: "/changelog" },
 }
 

--- a/components/showcase/changelog-view.tsx
+++ b/components/showcase/changelog-view.tsx
@@ -20,8 +20,8 @@ export function ChangelogView({ releases, lastUpdated }: Changelog) {
             Release notes
           </h1>
           <p className="mt-4 max-w-xl text-balance text-base text-muted-foreground sm:text-lg">
-            Every shipped version of Hirael — new components, blocks, fixes,
-            and polish. Rendered from GitHub Releases.
+            Every shipped version of Hirael: new components, blocks, fixes,
+            and polish.
           </p>
 
           {releases.length === 0 ? (


### PR DESCRIPTION
This PR updates documentation and UI copy to better clarify what belongs in release notes and removes references to implementation details from user-facing changelog descriptions.

**Changes made:**

- **AGENTS.md**: Expanded release note guidelines to explicitly state that release notes should focus on user-visible changes (new components, blocks, features, bug fixes) and exclude internal tooling and build/deployment details. Updated the example release title from "Static export & RTL" to "RTL across the catalog" to better reflect user-facing language.

- **changelog-view.tsx**: Removed the phrase "Rendered from GitHub Releases" from the changelog description, as this is an implementation detail that doesn't concern readers. Changed punctuation from em-dash to colon for consistency.

- **changelog/page.tsx**: Updated metadata description to use colon instead of em-dash for consistency with the UI copy.

These changes ensure that changelog content remains focused on what matters to users and consumers of the project, while keeping internal implementation details out of public-facing documentation.

https://claude.ai/code/session_01KDrmuwqJLVC6Y74wRr3vNo