### PR TITLE
Add scroll-spy table of contents rail to detail pages

### DIFF
--- a/components/showcase/block-viewer.tsx
+++ b/components/showcase/block-viewer.tsx
@@ -115,7 +115,7 @@ export function BlockViewer({
         </div>
       </div>
 
-      <div className="flex justify-center overflow-x-auto bg-card/20 p-3 sm:p-4">
+      <div className="bg-dot-grid flex justify-center overflow-x-auto bg-card/20 p-3 sm:p-4">
         <iframe
           key={key}
           src={src}

--- a/components/showcase/component-page.tsx
+++ b/components/showcase/component-page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { Hash } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { BlockViewer } from "@/components/showcase/block-viewer";
@@ -8,6 +9,7 @@ import { Breadcrumbs, type Crumb } from "@/components/showcase/breadcrumbs";
 import { CodeBlock, type CodeBlockTab } from "@/components/showcase/code-block";
 import { DirectionToggle } from "@/components/showcase/direction-toggle";
 import { InstallBlock } from "@/components/showcase/install-block";
+import { Pager } from "@/components/showcase/pager";
 import { SectionLabel } from "@/components/showcase/page-header";
 import { Toc, type TocItem } from "@/components/showcase/toc";
 import { RegistryExample } from "@/registry/hirael/registry-demos";
@@ -21,6 +23,7 @@ import {
 } from "@/registry/hirael/ui/table";
 import {
   entryEmbedHref,
+  entrySiblings,
   type RegistryEntryMeta,
 } from "@/registry/hirael/registry-meta";
 
@@ -167,6 +170,7 @@ export function ComponentPage({
   }
 
   const tocItems: TocItem[] = sections.map(({ id, label }) => ({ id, label }));
+  const { prev, next } = entrySiblings(entry);
 
   return (
     <div className="container py-10 sm:py-12 md:py-16">
@@ -205,6 +209,8 @@ export function ComponentPage({
               {section.content}
             </Section>
           ))}
+
+          <Pager prev={prev} next={next} />
         </div>
 
         <aside className="hidden xl:block">
@@ -230,7 +236,17 @@ function Section({
 }) {
   return (
     <section id={id} className="flex scroll-mt-24 flex-col gap-4">
-      <SectionLabel>{label}</SectionLabel>
+      <a
+        href={`#${id}`}
+        className="group/anchor inline-flex w-fit items-center gap-1.5"
+        aria-label={`${label} section`}
+      >
+        <SectionLabel>{label}</SectionLabel>
+        <Hash
+          className="size-3 text-muted-foreground opacity-0 transition-opacity group-hover/anchor:opacity-100"
+          aria-hidden
+        />
+      </a>
       {children}
     </section>
   );
@@ -255,8 +271,8 @@ function ExampleBlock({
           {example.title}
         </h3>
       )}
-      <div className="relative overflow-hidden rounded-sm border border-border bg-card/40">
-        <div className="flex items-center justify-between gap-2 border-b border-border/70 px-3 py-2">
+      <div className="relative overflow-hidden rounded-md border border-border">
+        <div className="flex items-center justify-between gap-2 border-b border-border/70 bg-card/40 px-3 py-2">
           <div
             role="tablist"
             aria-label="Example view"
@@ -292,7 +308,7 @@ function ExampleBlock({
         {view === "preview" ? (
           <div
             dir={rtl ? "rtl" : undefined}
-            className="flex min-h-90 items-center justify-center p-6 sm:min-h-105 sm:p-8 md:p-10"
+            className="bg-dot-grid flex min-h-90 items-center justify-center p-6 sm:min-h-105 sm:p-8 md:p-10"
           >
             <RegistryExample name={example.slug} />
           </div>

--- a/components/showcase/component-page.tsx
+++ b/components/showcase/component-page.tsx
@@ -9,6 +9,7 @@ import { CodeBlock, type CodeBlockTab } from "@/components/showcase/code-block";
 import { DirectionToggle } from "@/components/showcase/direction-toggle";
 import { InstallBlock } from "@/components/showcase/install-block";
 import { SectionLabel } from "@/components/showcase/page-header";
+import { Toc, type TocItem } from "@/components/showcase/toc";
 import { RegistryExample } from "@/registry/hirael/registry-demos";
 import {
   Table,
@@ -88,91 +89,147 @@ export function ComponentPage({
   );
 
   const exampleList = examples ?? [];
+  const registryDeps = entry.registryDependencies ?? [];
+  const npmDeps = entry.dependencies ?? [];
+
+  // One descriptor list drives both the rendered sections and the "On this
+  // page" rail, so the two can never drift. Order mirrors shadcn/ui's docs:
+  // the showcase first, then how to install it, then the reference material.
+  const sections: PageSection[] = [];
+
+  if (isComposite) {
+    sections.push({
+      id: "preview",
+      label: "Preview",
+      content: <BlockViewer title={entry.title} embedHref={embedHref} />,
+    });
+  } else {
+    sections.push({
+      id: "examples",
+      label: exampleList.length > 1 ? "Examples" : "Example",
+      content: (
+        <div className="flex flex-col gap-8">
+          {exampleList.map((example) => (
+            <ExampleBlock
+              key={example.slug}
+              example={example}
+              showTitle={exampleList.length > 1}
+            />
+          ))}
+        </div>
+      ),
+    });
+  }
+
+  sections.push({
+    id: "installation",
+    label: "Installation",
+    content: <InstallBlock name={entry.name} />,
+  });
+
+  if (!isComposite && api?.length) {
+    sections.push({
+      id: "api",
+      label: "API",
+      content: <ApiPanel parts={api} />,
+    });
+  }
+
+  if (codeTabs.length > 0) {
+    sections.push(
+      isComposite
+        ? {
+            id: "code",
+            label: "Code",
+            content: <CodeBlock tabs={codeTabs} layout="tree" />,
+          }
+        : {
+            id: "component-source",
+            label: "Component source",
+            content: <CodeBlock tabs={codeTabs} layout="tabs" />,
+          },
+    );
+  }
+
+  if (registryDeps.length || npmDeps.length) {
+    sections.push({
+      id: "dependencies",
+      label: "Dependencies",
+      content: (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {registryDeps.length > 0 && (
+            <DepGroup title="shadcn registry" deps={registryDeps} />
+          )}
+          {npmDeps.length > 0 && <DepGroup title="npm" deps={npmDeps} />}
+        </div>
+      ),
+    });
+  }
+
+  const tocItems: TocItem[] = sections.map(({ id, label }) => ({ id, label }));
 
   return (
-    <div className="container flex w-full flex-col gap-10 py-10 sm:gap-12 sm:py-12 md:py-16">
-      <header className="flex flex-col gap-3 border-b border-border pb-6">
-        {breadcrumb ? (
-          <Breadcrumbs items={breadcrumb} />
-        ) : (
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-              {entry.category}
-            </span>
-            {entry.blockKind && (
-              <>
-                <span className="font-mono text-[10px] text-muted-foreground">
-                  ·
+    <div className="container py-10 sm:py-12 md:py-16">
+      <div className="xl:grid xl:grid-cols-[minmax(0,1fr)_14rem] xl:gap-10">
+        <div className="flex min-w-0 flex-col gap-10 sm:gap-12">
+          <header className="flex flex-col gap-3 border-b border-border pb-6">
+            {breadcrumb ? (
+              <Breadcrumbs items={breadcrumb} />
+            ) : (
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                  {entry.category}
                 </span>
-                <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-foreground">
-                  {entry.blockKind}
-                </span>
-              </>
+                {entry.blockKind && (
+                  <>
+                    <span className="font-mono text-[10px] text-muted-foreground">
+                      ·
+                    </span>
+                    <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-foreground">
+                      {entry.blockKind}
+                    </span>
+                  </>
+                )}
+              </div>
             )}
+            <h1 className="text-3xl font-semibold leading-[1.05] tracking-tight sm:text-4xl">
+              {entry.title}
+            </h1>
+            <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
+              {entry.description}
+            </p>
+          </header>
+
+          {sections.map((section) => (
+            <Section key={section.id} id={section.id} label={section.label}>
+              {section.content}
+            </Section>
+          ))}
+        </div>
+
+        <aside className="hidden xl:block">
+          <div className="sticky top-24">
+            <Toc items={tocItems} />
           </div>
-        )}
-        <h1 className="text-3xl font-semibold leading-[1.05] tracking-tight sm:text-4xl">
-          {entry.title}
-        </h1>
-        <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
-          {entry.description}
-        </p>
-        <InstallBlock name={entry.name} className="mt-1" />
-      </header>
-
-      {isComposite ? (
-        <>
-          <Section label="Preview">
-            <BlockViewer title={entry.title} embedHref={embedHref} />
-          </Section>
-          {codeTabs.length > 0 && (
-            <Section label="Code">
-              <CodeBlock tabs={codeTabs} layout="tree" />
-            </Section>
-          )}
-        </>
-      ) : (
-        <>
-          <Section label={exampleList.length > 1 ? "Examples" : "Example"}>
-            <div className="flex flex-col gap-8">
-              {exampleList.map((example) => (
-                <ExampleBlock
-                  key={example.slug}
-                  example={example}
-                  showTitle={exampleList.length > 1}
-                />
-              ))}
-            </div>
-          </Section>
-
-          {api?.length ? (
-            <Section label="API">
-              <ApiPanel parts={api} />
-            </Section>
-          ) : null}
-
-          {codeTabs.length > 0 && (
-            <Section label="Component source">
-              <CodeBlock tabs={codeTabs} layout="tabs" />
-            </Section>
-          )}
-        </>
-      )}
-
-      <DependenciesSection entry={entry} />
+        </aside>
+      </div>
     </div>
   );
 }
 
+type PageSection = { id: string; label: string; content: React.ReactNode };
+
 function Section({
+  id,
   label,
   children,
 }: {
+  id: string;
   label: string;
   children: React.ReactNode;
 }) {
   return (
-    <section className="flex flex-col gap-4">
+    <section id={id} className="flex scroll-mt-24 flex-col gap-4">
       <SectionLabel>{label}</SectionLabel>
       {children}
     </section>
@@ -252,23 +309,6 @@ function ExampleBlock({
         ) : null}
       </div>
     </section>
-  );
-}
-
-function DependenciesSection({ entry }: { entry: RegistryEntryMeta }) {
-  const registryDeps = entry.registryDependencies ?? [];
-  const npmDeps = entry.dependencies ?? [];
-  if (!registryDeps.length && !npmDeps.length) return null;
-
-  return (
-    <Section label="Dependencies">
-      <div className="grid gap-4 sm:grid-cols-2">
-        {registryDeps.length > 0 && (
-          <DepGroup title="shadcn registry" deps={registryDeps} />
-        )}
-        {npmDeps.length > 0 && <DepGroup title="npm" deps={npmDeps} />}
-      </div>
-    </Section>
   );
 }
 

--- a/components/showcase/pager.tsx
+++ b/components/showcase/pager.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import {
+  entryHref,
+  type RegistryEntryMeta,
+} from "@/registry/hirael/registry-meta";
+
+/**
+ * Previous / next navigation at the foot of a detail page, the way the
+ * shadcn/ui docs let you walk the catalog. Siblings come from
+ * `entrySiblings` (a linear walk of the item's collection), so this steps
+ * through every component, block, or template in order. RTL-safe: the cards
+ * sit on the inline edges and the chevrons flip with `rtl:rotate-180`.
+ */
+export function Pager({
+  prev,
+  next,
+}: {
+  prev: RegistryEntryMeta | null;
+  next: RegistryEntryMeta | null;
+}) {
+  if (!prev && !next) return null;
+
+  return (
+    <nav
+      aria-label="Catalog"
+      className="flex items-stretch justify-between gap-3 border-t border-border pt-6"
+    >
+      {prev ? (
+        <PagerLink entry={prev} direction="prev" />
+      ) : (
+        <span aria-hidden />
+      )}
+      {next ? (
+        <PagerLink entry={next} direction="next" />
+      ) : (
+        <span aria-hidden />
+      )}
+    </nav>
+  );
+}
+
+function PagerLink({
+  entry,
+  direction,
+}: {
+  entry: RegistryEntryMeta;
+  direction: "prev" | "next";
+}) {
+  const isPrev = direction === "prev";
+  const Chevron = isPrev ? ChevronLeft : ChevronRight;
+  const chevron = (
+    <Chevron className="size-3.5 shrink-0 rtl:rotate-180" aria-hidden />
+  );
+
+  return (
+    <Link
+      href={entryHref(entry)}
+      rel={isPrev ? "prev" : "next"}
+      className={cn(
+        "group flex max-w-[48%] flex-col gap-1 rounded-md border border-border bg-card/40 px-4 py-3 transition-colors hover:bg-accent",
+        isPrev ? "items-start text-start" : "items-end text-end",
+      )}
+    >
+      <span className="flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+        {isPrev && chevron}
+        {isPrev ? "Previous" : "Next"}
+        {!isPrev && chevron}
+      </span>
+      <span className="truncate text-sm font-medium tracking-[-0.01em] text-foreground">
+        {entry.title}
+      </span>
+    </Link>
+  );
+}

--- a/components/showcase/toc.tsx
+++ b/components/showcase/toc.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export type TocItem = { id: string; label: string };
+
+/**
+ * "On this page" rail — the right-column table of contents shadcn/ui's docs
+ * carry. It mirrors the sections ComponentPage renders (single source of
+ * truth: the same descriptor list feeds the content and this nav) and
+ * scroll-spies the active one. The section ids it points at carry
+ * scroll-margin so the sticky topbar never covers a heading you jump to.
+ *
+ * Logical properties throughout (`border-s`, `ms`/`ps`) so the rail sits on
+ * the inline-start edge under both LTR and RTL.
+ */
+export function Toc({
+  items,
+  className,
+}: {
+  items: TocItem[];
+  className?: string;
+}) {
+  const active = useActiveSection(items.map((i) => i.id));
+
+  // One lonely entry isn't a table of contents.
+  if (items.length < 2) return null;
+
+  return (
+    <nav
+      aria-label="On this page"
+      className={cn("flex flex-col gap-3", className)}
+    >
+      <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+        On this page
+      </p>
+      <ul className="flex flex-col">
+        {items.map((item) => {
+          const isActive = item.id === active;
+          return (
+            <li key={item.id}>
+              <a
+                href={`#${item.id}`}
+                aria-current={isActive ? "location" : undefined}
+                className={cn(
+                  "block border-s py-1 ps-3 text-[13px] leading-snug transition-colors",
+                  isActive
+                    ? "border-s-accent-cool font-medium text-foreground"
+                    : "border-s-border/60 text-muted-foreground hover:border-s-foreground/40 hover:text-foreground",
+                )}
+              >
+                {item.label}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}
+
+/**
+ * Tracks which section is in view. An IntersectionObserver marks sections as
+ * they cross the upper band of the viewport; the active one is the first
+ * (top-most in document order) currently inside that band. Falls back to the
+ * first id before any scroll. Runs only in the browser, so it's safe under
+ * `output: "export"` — the static HTML ships without it and it wires up on
+ * hydration.
+ */
+function useActiveSection(ids: string[]): string | null {
+  const [active, setActive] = React.useState<string | null>(ids[0] ?? null);
+  // Re-run the effect when the *set* of ids changes, not its array identity.
+  const key = ids.join("|");
+
+  React.useEffect(() => {
+    const sectionIds = key ? key.split("|") : [];
+    if (sectionIds.length === 0) return;
+
+    const visible = new Set<string>();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) visible.add(entry.target.id);
+          else visible.delete(entry.target.id);
+        }
+        const current = sectionIds.find((id) => visible.has(id));
+        if (current) setActive(current);
+      },
+      // Activate a heading once it passes the topbar and before it leaves the
+      // top third — keeps the highlight one step ahead of the reading line.
+      { rootMargin: "-88px 0px -66% 0px", threshold: 0 },
+    );
+
+    for (const id of sectionIds) {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    }
+
+    return () => observer.disconnect();
+  }, [key]);
+
+  return active;
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,6 +67,8 @@ app/                              # Next.js App Router (output: "export")
   layout.tsx, manifest.ts, sitemap.ts, robots.ts, opengraph-image.tsx, icon.tsx …
 components/showcase/              # site chrome — NOT part of the registry
   site-header.tsx, topbar.tsx, sidebar.tsx, site-footer.tsx
+  component-page.tsx              # shared detail-page layout (content + "On this page" rail)
+  toc.tsx                         # scroll-spy table of contents for the detail pages
   changelog-view.tsx              # /changelog presentation
   code-block.tsx, command-menu.tsx, theme-*.tsx, logo.tsx, install-block.tsx …
 registry/hirael/                  # canonical source for every registry item
@@ -95,12 +97,15 @@ vercel.json                       # GENERATED redirects (old flat URLs → categ
   Agency Landing, Portfolio, USD Halo, Mindloop, Rivr, NexaCore, Velorah). Full
   list in [catalog.md](./catalog.md).
 - **Showcase** — landing with live demos, component/block/template indexes,
-  per-category listing pages, per-item pages (demo + usage source + prop table
-  - install) with a breadcrumb trail, theme playground, command menu, light/dark
-    toggle. Every browsable item sits under its category segment
-    (`/components/<category>/<name>`, `/blocks/<category>/<name>`); build
-    `entryHref(entry)` rather than hand-writing paths, and old flat URLs 301 to
-    the nested ones via generated `vercel.json` redirects.
+  per-category listing pages, and per-item detail pages laid out like the
+  shadcn/ui docs: a breadcrumb + title header, then anchored sections (preview
+  or examples, installation, API/props, source, dependencies) in a content
+  column beside a sticky scroll-spy "On this page" rail (`toc.tsx`, the rail
+  hides below `xl`). Plus a theme playground, command menu, and light/dark
+  toggle. Every browsable item sits under its category segment
+  (`/components/<category>/<name>`, `/blocks/<category>/<name>`); build
+  `entryHref(entry)` rather than hand-writing paths, and old flat URLs 301 to
+  the nested ones via generated `vercel.json` redirects.
 - **RTL** — every component and block works under `dir="rtl"`; previews have
   an RTL toggle.
 - **Fully static export** — `output: "export"`, image optimization off,

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,7 @@ components/showcase/              # site chrome — NOT part of the registry
   site-header.tsx, topbar.tsx, sidebar.tsx, site-footer.tsx
   component-page.tsx              # shared detail-page layout (content + "On this page" rail)
   toc.tsx                         # scroll-spy table of contents for the detail pages
+  pager.tsx                       # prev/next walk across the whole catalog
   changelog-view.tsx              # /changelog presentation
   code-block.tsx, command-menu.tsx, theme-*.tsx, logo.tsx, install-block.tsx …
 registry/hirael/                  # canonical source for every registry item
@@ -100,9 +101,12 @@ vercel.json                       # GENERATED redirects (old flat URLs → categ
   per-category listing pages, and per-item detail pages laid out like the
   shadcn/ui docs: a breadcrumb + title header, then anchored sections (preview
   or examples, installation, API/props, source, dependencies) in a content
-  column beside a sticky scroll-spy "On this page" rail (`toc.tsx`, the rail
-  hides below `xl`). Plus a theme playground, command menu, and light/dark
-  toggle. Every browsable item sits under its category segment
+  column beside a sticky scroll-spy "On this page" rail (`toc.tsx`, hidden
+  below `xl`). Headings are deep-linkable, the live previews sit on a faint
+  dot-grid canvas, and a prev/next pager (`pager.tsx`) walks the whole
+  collection across category boundaries. Plus a theme playground, command
+  menu, and light/dark toggle. Every browsable item sits under its category
+  segment
   (`/components/<category>/<name>`, `/blocks/<category>/<name>`); build
   `entryHref(entry)` rather than hand-writing paths, and old flat URLs 301 to
   the nested ones via generated `vercel.json` redirects.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -169,6 +169,22 @@ into sections.
   text. Prefer "Pick a date" over "Effortlessly select your desired date."
 - **No em dashes in user-facing copy** — a deliberate site-wide decision.
 
+## Detail-page layout (`component-page.tsx`)
+
+The shared per-item page (components, blocks, templates) renders a content
+column beside a sticky "On this page" rail (`toc.tsx`), shadcn-docs style. Two
+things to keep in sync when you touch it:
+
+- **One descriptor list, two consumers.** `ComponentPage` builds a single
+  `sections` array (`{ id, label, content }`) and feeds it to both the rendered
+  `<Section>`s and the `Toc`. Add or reorder a section there, not in two places,
+  or the rail drifts from the page.
+- **Sticky offsets must agree.** The topbar is `sticky h-14`, so every section
+  carries `scroll-mt-24` and the rail sticks at `top-24`; the scroll-spy
+  `rootMargin` clears the same band. Change one, change all three. The rail is
+  client-only (an `IntersectionObserver`), which is fine under `output:
+"export"` — it ships static and wires up on hydration.
+
 ## Gating signal
 
 There is no unit/visual-regression suite yet. Before requesting review:

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -184,6 +184,17 @@ things to keep in sync when you touch it:
   `rootMargin` clears the same band. Change one, change all three. The rail is
   client-only (an `IntersectionObserver`), which is fine under `output:
 "export"` — it ships static and wires up on hydration.
+- **Headings deep-link; the pager walks the collection.** Each `<Section>`
+  heading is an `<a href="#id">` with a hover-revealed hash, and the page ends
+  with a prev/next `Pager`. Siblings come from `entrySiblings(entry)` in
+  `registry-meta.ts`, which walks a flat per-collection order
+  (`COMPONENTS_ORDERED` chains every category end-to-end, `BLOCKS_ORDERED`
+  every kind), so Next crosses category boundaries. The pager chevrons flip
+  with `rtl:rotate-180`.
+- **Previews sit on a dot-grid canvas.** Component examples and the block
+  viewer back their preview surface with `bg-dot-grid` (token-only, so it
+  works in both themes); the toolbar keeps the `bg-card` tint so chrome reads
+  apart from the canvas.
 
 ## Gating signal
 

--- a/registry/hirael/registry-meta.ts
+++ b/registry/hirael/registry-meta.ts
@@ -2506,3 +2506,44 @@ export function entryEmbedHref(entry: RegistryEntryMeta): string {
   if (entry.category === "templates") return `/embed/templates/${entry.name}`;
   return `/embed/blocks/${entryCategorySlug(entry)}/${entry.name}`;
 }
+
+/* -------------------------------------------------------------------------- */
+/* Sibling navigation — a linear walk through each collection                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Every component flattened into display order: category by category (the
+ * sidebar / index order), and within a category the registry order. This is
+ * the path the detail-page pager walks, so Next steps from the last item of
+ * one category straight into the first of the next.
+ */
+export const COMPONENTS_ORDERED: RegistryEntryMeta[] =
+  COMPONENT_CATEGORY_ORDER.flatMap((cat) => REGISTRY_BY_CATEGORY[cat]);
+
+/** Every block flattened into display order: kind by kind, then registry order. */
+export const BLOCKS_ORDERED: RegistryEntryMeta[] = BLOCK_KIND_ORDER.flatMap(
+  (kind) => BLOCKS_BY_KIND[kind],
+);
+
+/**
+ * The previous and next entry within an item's own collection
+ * (components | blocks | templates). Used for the detail-page pager; either
+ * side is `null` at a collection boundary.
+ */
+export function entrySiblings(entry: RegistryEntryMeta): {
+  prev: RegistryEntryMeta | null;
+  next: RegistryEntryMeta | null;
+} {
+  const list =
+    entry.category === "templates"
+      ? TEMPLATES
+      : entry.category === "blocks"
+        ? BLOCKS_ORDERED
+        : COMPONENTS_ORDERED;
+  const i = list.findIndex((e) => e.name === entry.name);
+  if (i === -1) return { prev: null, next: null };
+  return {
+    prev: i > 0 ? list[i - 1] : null,
+    next: i < list.length - 1 ? list[i + 1] : null,
+  };
+}


### PR DESCRIPTION
Refactors component/block/template detail pages to match shadcn/ui's documentation layout: a content column beside a sticky "On this page" navigation rail that scroll-spies the active section.

## Changes

- **New `toc.tsx` component** — Renders a sticky "On this page" rail with scroll-spy behavior via `IntersectionObserver`. Tracks which section is in view and highlights the corresponding nav link. Hides on screens below `xl` breakpoint.

- **Refactored `ComponentPage`** — Consolidates section rendering logic into a single `sections` descriptor array (`{ id, label, content }`) that feeds both the rendered content and the table of contents. This ensures the two never drift. Sections now include `id` attributes and `scroll-mt-24` to account for the sticky topbar.

- **Layout restructure** — Wraps content in an `xl:grid` with two columns: main content on the left, sticky TOC rail on the right. Removed the separate `DependenciesSection` component and inlined its logic into the sections array.

- **Removed `InstallBlock` margin** — The component no longer carries `mt-1` since it's now part of the structured sections flow.

## Implementation details

- The TOC only renders if there are 2+ sections (a single entry isn't a table of contents).
- Scroll-spy uses `rootMargin: "-88px 0px -66% 0px"` to activate a section once it passes the topbar and before it leaves the top third, keeping the highlight ahead of the reading line.
- Logical properties (`border-s`, `ms`, `ps`) throughout the TOC so it works under both LTR and RTL.
- The TOC is client-only (uses `IntersectionObserver`), which is safe under `output: "export"` — static HTML ships without it and wires up on hydration.
- Updated documentation in `docs/README.md` and `docs/conventions.md` to reflect the new layout and sync requirements.

https://claude.ai/code/session_018C72pMuJ95nLfiL1MXkt6H