### PR TITLE
Support pinned items in sortable component

### DIFF
--- a/registry/hirael/ui/sortable.tsx
+++ b/registry/hirael/ui/sortable.tsx
@@ -67,6 +67,22 @@ function arrayMove(arr: string[], from: number, to: number) {
   return next;
 }
 
+function reorderPinned(
+  order: string[],
+  isDisabled: (id: string) => boolean,
+  id: string,
+  toMovablePos: number,
+) {
+  const movable = order.filter((v) => !isDisabled(v));
+  const from = movable.indexOf(id);
+  if (from === -1) return order;
+  const to = Math.max(0, Math.min(toMovablePos, movable.length - 1));
+  if (to === from) return order;
+  const nextMovable = arrayMove(movable, from, to);
+  let m = 0;
+  return order.map((v) => (isDisabled(v) ? v : nextMovable[m++]));
+}
+
 export type SortableProps = Omit<
   React.ComponentProps<"div">,
   "defaultValue" | "onChange"
@@ -117,6 +133,11 @@ function Sortable({
     };
   }, []);
 
+  const isDisabled = React.useCallback(
+    (id: string) => itemsRef.current.get(id)?.disabled ?? false,
+    [],
+  );
+
   const announce = React.useCallback((text: string) => {
     setLiveText(text);
   }, []);
@@ -165,10 +186,10 @@ function Sortable({
       const current = orderRef.current;
       const horizontal = orientation === "horizontal";
       const coord = horizontal ? e.clientX : e.clientY;
-      const others = current.filter((v) => v !== id);
+      const movableOthers = current.filter((v) => v !== id && !isDisabled(v));
 
       let before = 0;
-      for (const other of others) {
+      for (const other of movableOthers) {
         const entry = itemsRef.current.get(other);
         if (!entry) continue;
         const rect = entry.node.getBoundingClientRect();
@@ -179,13 +200,12 @@ function Sortable({
         if (passed) before += 1;
       }
 
-      if (before !== current.indexOf(id)) {
-        const next = others.slice();
-        next.splice(before, 0, id);
-        setPreview(next);
+      const movablePos = current.filter((v) => !isDisabled(v)).indexOf(id);
+      if (before !== movablePos) {
+        setPreview(reorderPinned(current, isDisabled, id, before));
       }
     },
-    [dragId, orientation],
+    [dragId, orientation, isDisabled],
   );
 
   const handlePointerEnd = React.useCallback(
@@ -210,22 +230,18 @@ function Sortable({
   const moveGrabbed = React.useCallback(
     (id: string, dir: -1 | 1) => {
       const current = orderRef.current;
-      const from = current.indexOf(id);
+      const movable = current.filter((v) => !isDisabled(v));
+      const from = movable.indexOf(id);
       if (from === -1) return;
-      let to = from + dir;
-      while (
-        to >= 0 &&
-        to < current.length &&
-        itemsRef.current.get(current[to])?.disabled
-      ) {
-        to += dir;
-      }
-      if (to < 0 || to >= current.length) return;
-      const next = arrayMove(current, from, to);
+      const to = from + dir;
+      if (to < 0 || to >= movable.length) return;
+      const next = reorderPinned(current, isDisabled, id, to);
       setPreview(next);
-      announce(`Moved ${id} to position ${to + 1} of ${next.length}`);
+      announce(
+        `Moved ${id} to position ${next.indexOf(id) + 1} of ${next.length}`,
+      );
     },
-    [announce],
+    [announce, isDisabled],
   );
 
   const handleKeyDown = React.useCallback(


### PR DESCRIPTION
## Summary
Refactored the sortable component to properly handle disabled (pinned) items during reordering operations. Disabled items now remain in their fixed positions while only movable items can be reordered among themselves.

## Key Changes
- Added `reorderPinned()` utility function that reorders items while preserving disabled items in their original positions
- Added `isDisabled()` callback to check if an item is disabled
- Updated drag-to-reorder logic to only consider movable items when calculating drop positions
- Updated keyboard navigation (`moveGrabbed`) to operate on movable items only, skipping over disabled items
- Fixed position announcement in keyboard navigation to reflect the actual final position in the full list

## Implementation Details
The core change separates the concept of "movable" items (those that can be reordered) from the full item list. When reordering:
1. Extract only non-disabled items into a separate array
2. Perform reordering operations on this movable subset
3. Reconstruct the full list by interleaving disabled items back into their original positions

This ensures disabled/pinned items act as immovable anchors while maintaining their relative positions in the overall list.

https://claude.ai/code/session_01GK99FkFtZa9HY6x2xB2xgw