### PR TITLE
Add 40+ new UI components for AI, dev, and commerce

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Hirael — a shadcn-compatible component registry
 
-Hirael ships "the components shadcn/ui doesn't ship": ~70 React components,
-~40 section blocks, and full-page templates, distributed through the
+Hirael ships "the components shadcn/ui doesn't ship": ~110 React components,
+~56 section blocks, and full-page templates, distributed through the
 **shadcn registry schema** so consumers install them with
 `npx shadcn add https://hirael.com/r/<name>.json` and the source lands in
 their repo. There is no runtime package. The

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ at the repo root.
 ## What this is
 
 **Hirael is a shadcn-compatible component registry** — "the components
-shadcn/ui doesn't ship." It distributes ~70 React components, ~40 section
+shadcn/ui doesn't ship." It distributes ~110 React components, ~56 section
 blocks, and full-page templates through the shadcn registry schema, so a
 consumer runs
 `npx shadcn add https://hirael.com/r/<name>.json` and the **source is copied
@@ -93,10 +93,12 @@ vercel.json                       # GENERATED redirects (old flat URLs → categ
 - **Registry pipeline** — `registry-meta.ts` as the single source of truth,
   generation + drift check + prop extraction + comment stripping wired into
   `pnpm build`.
-- **Catalog** — 70 registry UI items (69 components + the distribution-only
-  `accordion`), 40 blocks, and 9 full-page templates (Creative Studio,
-  Agency Landing, Portfolio, USD Halo, Mindloop, Rivr, NexaCore, Velorah,
-  Asme). Full list in [catalog.md](./catalog.md).
+- **Catalog** — 110 registry UI items (108 components + the distribution-only
+  `accordion` and `calendar-utils`), 56 blocks, and 9 full-page templates
+  (Creative Studio, Agency Landing, Portfolio, USD Halo, Mindloop, Rivr,
+  NexaCore, Velorah, Asme). Components span twelve categories, including the
+  new `ai`, `dev` and `commerce` families. Full list in
+  [catalog.md](./catalog.md).
 - **Showcase** — landing with live demos, component/block/template indexes,
   per-category listing pages, and per-item detail pages laid out like the
   shadcn/ui docs: a breadcrumb + title header, then anchored sections (preview

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -7,12 +7,11 @@ human-readable index — when you add or rename an item, update the matching
 table here in the same change.
 
 The catalog spans three tiers: **components** (single UI primitives),
-**blocks** (marketing / app sections), and **templates** (full, multi-section
-pages). As of the last update: **70 registry UI items** (69 standalone
-components + 1 distribution-only primitive), **56 section blocks**, and
-**9 templates**. Counts come from `registry.json`; the landing page derives
-its counts from `registry-meta.ts`, so treat that file as the truth if these
-drift.
+**blocks** (marketing / app sections), and full-page templates. As of the
+last update: **110 registry UI items** (108 standalone components + 2
+distribution-only primitives), **56 section blocks**, and **9 templates**.
+Counts come from `registry.json`; the landing page derives its counts from
+`registry-meta.ts`, so treat that file as the truth if these drift.
 
 Each component installs with:
 
@@ -33,128 +32,183 @@ and a breadcrumb trail. Build links with `entryHref(entry)` from
 
 ## Components
 
-#### Inputs (12)
+#### Inputs (13)
 
-| Component        | Registry deps                            | What it is                                                                                                                                                        |
-| ---------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `combobox`       | `input-group`                            | Searchable select on Base UI: single or multiple selection, chips, grouped options, an input addon slot and a clear button.                                       |
-| `currency-input` | `input-group`                            | Locale-aware grouping with currency-symbol prefix and configurable decimal precision.                                                                             |
-| `inline-edit`    | `button`, `input`, `spinner`, `textarea` | Click-to-edit text with preview, validation, async submit and confirm/cancel controls. Input and textarea modes.                                                  |
-| `lazy-select`    | `command`, `popover`                     | Autocomplete single-select that defers loading until open and pages through results on scroll. Debounced server-side search with a pluggable lazy paginator hook. |
-| `mention-input`  | `spinner`                                | @-mention textarea with caret-anchored autocomplete, highlighted mention chips, async search and multiple trigger characters.                                     |
-| `multi-select`   | `badge`, `command`, `popover`            | Chip-based multi-select with command-palette dropdown, search, select-all and async loader. Compound and single-prop APIs.                                        |
-| `number-range`   | `input`, `slider`                        | Two-thumb slider paired with synced number inputs. Min/max/step, currency or unit formatting, keyboard-first.                                                     |
-| `password-input` | `input-group`                            | Show/hide toggle with an optional pluggable strength meter. Compound and single-prop APIs.                                                                        |
-| `phone-input`    | `command`, `input-group`, `popover`      | Country dial-code dropdown with E.164 output. Compound and single-prop APIs.                                                                                      |
-| `rating`         | —                                        | Star rating with hover preview, half-star precision, read-only mode and sm / md / lg sizes.                                                                       |
-| `signature-pad`  | `button`                                 | Canvas signature capture with velocity-based ink, per-stroke undo, theme-aware re-inking and PNG/JPEG export via ref.                                             |
-| `tag-input`      | `badge`                                  | Chip input with paste-to-split, dedupe, validation hook, max tags. Compound and single-prop APIs.                                                                 |
+| Component             | Registry deps                  | What it is                                                                                |
+| --------------------- | ------------------------------ | ----------------------------------------------------------------------------------------- |
+| `advanced-search-bar` | `badge`, `button`, `input-group` | Power search field with a scope selector, removable filter tokens and a grouped suggestions dropdown with keyboard nav. |
+| `combobox`            | `input-group`                  | Searchable select on Base UI: single or multiple selection, chips, grouped options, clear button. |
+| `currency-input`      | `input-group`                  | Locale-aware grouping with currency-symbol prefix and configurable decimal precision.     |
+| `inline-edit`         | `button`, `input`, `spinner`, `textarea` | Click-to-edit text with preview, validation, async submit and confirm/cancel.   |
+| `lazy-select`         | `command`, `popover`           | Autocomplete single-select that defers loading until open and pages through results on scroll. |
+| `mention-input`       | `spinner`                      | @-mention textarea with caret-anchored autocomplete, highlighted chips and async search.  |
+| `multi-select`        | `badge`, `command`, `popover`  | Chip-based multi-select with command-palette dropdown, search, select-all and async loader. |
+| `number-range`        | `input`, `slider`              | Two-thumb slider paired with synced number inputs.                                        |
+| `password-input`      | `input-group`                  | Show/hide toggle with an optional pluggable strength meter.                                |
+| `phone-input`         | `command`, `input-group`, `popover` | Country dial-code dropdown with E.164 output.                                         |
+| `rating`              | —                              | Star rating with hover preview, half-star precision, read-only mode and sizes.            |
+| `signature-pad`       | `button`                       | Canvas signature capture with per-stroke undo, theme-aware re-inking and PNG/JPEG export. |
+| `tag-input`           | `badge`                        | Chip input with paste-to-split, dedupe, a validation hook and max tags.                   |
 
 #### Pickers (6)
 
-| Component           | Registry deps                    | What it is                                                                                                                       |
-| ------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `color-picker`      | `input`, `popover`, `tabs`       | SV gradient + hue slider with HEX / RGB / HSL tabs, eyedropper (where supported) and recent swatches.                            |
-| `date-picker`       | `button`, `popover`              | Single-date picker with month grid, keyboard nav, min/max bounds and disabled dates. Inline DateCalendar, no date library.       |
-| `date-range-picker` | `button`, `popover`, `separator` | Dual-month range picker with hover preview, presets, min/max bounds and keyboard nav. Inline DateRangeCalendar, no date library. |
-| `month-picker`      | `button`, `popover`              | 4×3 month grid with year stepper, keyboard nav, min/max bounds, single or range mode.                                            |
-| `time-picker`       | `popover`, `tabs`                | Hour, minute and optional second scroll columns with 12/24h modes, step intervals and keyboard nav.                              |
-| `year-picker`       | `button`, `popover`              | Decade-grid year picker with keyboard nav, min/max bounds, single or range mode.                                                 |
+| Component           | Registry deps                    | What it is                                                                       |
+| ------------------- | -------------------------------- | ------------------------------------------------------------------------------- |
+| `color-picker`      | `input`, `popover`, `tabs`       | SV gradient + hue slider with HEX / RGB / HSL tabs, eyedropper and recent swatches. |
+| `date-picker`       | `button`, `popover`              | Single-date picker with month grid, keyboard nav and bounds. No date library.   |
+| `date-range-picker` | `button`, `popover`, `separator` | Dual-month range picker with hover preview, presets and bounds. No date library. |
+| `month-picker`      | `button`, `popover`              | 4×3 month grid with year stepper, keyboard nav, bounds, single or range mode.   |
+| `time-picker`       | `popover`, `tabs`                | Hour, minute and optional second scroll columns with 12/24h modes and steps.    |
+| `year-picker`       | `button`, `popover`              | Decade-grid year picker with keyboard nav, bounds, single or range mode.        |
 
-#### Files (3)
+#### Files (6)
 
-| Component       | Registry deps | What it is                                                                                                                                   |
-| --------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `file-dropzone` | —             | Drag-drop + click upload zone with previews, accept and max-size validation. Compound and single-prop APIs.                                  |
-| `image-cropper` | `slider`      | Pan-and-zoom image cropper with rect or round mask, fixed aspect frame, pinch / wheel / keyboard control and canvas export via ref.          |
-| `media-input`   | `button`      | Local media file picker that previews via an object URL; empty-state prompt, replace and clear, size validation. Nothing leaves the browser. |
+| Component        | Registry deps        | What it is                                                                              |
+| ---------------- | -------------------- | -------------------------------------------------------------------------------------- |
+| `asset-manager`  | `badge`, `button`    | Media library with a thumbnail grid or list, search, multi-select and a detail inspector. |
+| `file-dropzone`  | —                    | Drag-drop + click upload zone with previews, accept and max-size validation.           |
+| `file-explorer`  | `breadcrumb`, `button` | Two-pane file browser with a folder tree, a breadcrumb path and a list or grid view.  |
+| `image-cropper`  | `slider`             | Pan-and-zoom image cropper with rect or round mask and canvas export via ref.          |
+| `media-input`    | `button`             | Local media file picker that previews via an object URL. Nothing leaves the browser.   |
+| `upload-manager` | `button`, `progress` | Upload queue with per-file progress and status, retry / cancel / remove and a summary. |
 
-#### Data display (10)
+#### Data display (18)
 
-| Component          | Registry deps | What it is                                                                                                                                                       |
-| ------------------ | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `activity-feed`    | —             | Avatar-led event feed with a connecting rail, actor and action lines, timestamps, quoted bodies and date dividers. Compound API.                                 |
-| `animated-number`  | —             | Count-up number that tweens to its target with easing, Intl formatting (currency, compact, percent), prefix/suffix and reduced-motion support.                   |
-| `audit-log`        | `collapsible` | Compliance-style event log with expandable rows that reveal actor, action, status and request metadata. Compound disclosure API.                                 |
-| `avatar-stack`     | —             | Overlapping avatar group with size and spacing variants, image or fallback, a numeric overflow chip, and `asChild` items so each avatar can be a link or button. |
-| `calendar-heatmap` | `tooltip`     | GitHub-style contribution heatmap with month and weekday labels, tooltips, configurable intensity scale and a legend.                                            |
-| `countdown-timer`  | —             | Count-down-to-date timer with boxed / inline / minimal variants, a `useCountdown` hook, digit animation and completion content.                                  |
-| `sortable`         | —             | Drag-to-reorder list with pointer and keyboard sorting, handle or whole-item dragging, and live-region announcements. No dnd-kit.                                |
-| `stat-card`        | —             | Compact metric card with label, value, and an up/down/flat trend chip. Compound and single-prop APIs.                                                            |
-| `timeline`         | —             | Vertical event timeline with default or icon dots, tone variants and labelled time / title / description parts.                                                  |
-| `tree-view`        | `collapsible` | Collapsible nested tree for file explorers and hierarchical data, with auto folder/file icons, depth indentation, selection and keyboard focus.                  |
+| Component           | Registry deps                      | What it is                                                                            |
+| ------------------- | ---------------------------------- | ------------------------------------------------------------------------------------ |
+| `activity-feed`     | —                                  | Avatar-led event feed with a connecting rail, timestamps, quoted bodies and dividers. |
+| `animated-number`   | —                                  | Count-up number that tweens to its target with Intl formatting and reduced-motion.   |
+| `approval-workflow` | —                                  | Rail-connected approval chain with approver, timestamp and approve / reject on the current step. |
+| `audit-log`         | `collapsible`                      | Compliance event log with expandable rows revealing actor, action, status and metadata. |
+| `auction-timeline`  | `badge`                            | Live auction panel with the leading bid, a countdown, a live status and a bid-history timeline. |
+| `avatar-stack`      | —                                  | Overlapping avatar group with size and spacing variants and a numeric overflow chip. |
+| `calendar-heatmap`  | `tooltip`                          | GitHub-style contribution heatmap with labels, tooltips and a legend.                |
+| `countdown-timer`   | —                                  | Count-down-to-date timer with boxed / inline / minimal variants and a hook.          |
+| `filter-builder`    | `badge`, `button`, `input`, `select` | Flat field / operator / value filters with an add row, removable chips and clear all. |
+| `kanban-board`      | `badge`, `button`                  | Column board with cards you drag between and within columns (native DnD) and keyboard moves. |
+| `nested-sortable`   | `button`                           | Drag-to-reorder outline with nesting (indent / outdent), pointer and keyboard control. |
+| `permission-matrix` | `checkbox`                         | Roles by permissions checkbox grid with grouped rows, a sticky column and master toggles. |
+| `query-builder`     | `button`, `input`, `select`        | Nested AND / OR query of field, operator and value rules, with add and remove at every level. |
+| `shipment-tracker`  | —                                  | Order delivery stages as a connected stepper with a live current stage and an event history. |
+| `sortable`          | —                                  | Drag-to-reorder list with pointer and keyboard sorting and announcements. No dnd-kit. |
+| `stat-card`         | —                                  | Compact metric card with label, value and an up / down / flat trend chip.            |
+| `timeline`          | —                                  | Vertical event timeline with default or icon dots, tone variants and labelled parts. |
+| `tree-view`         | `collapsible`                      | Collapsible nested tree for file explorers and hierarchical data, with selection.    |
 
-#### Display & feedback (13)
+#### AI (6)
 
-| Component          | Registry deps                    | What it is                                                                                                                                   |
-| ------------------ | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `announcement-bar` | —                                | Top-of-page banner with default / primary / muted tones, optional dismiss button and localStorage persistence.                               |
-| `audio-player`     | `button`, `slider`               | Composable audio player with play/pause, scrub-safe seek with buffered tint, skip, time readouts, volume and playback rate.                  |
-| `callout`          | —                                | MDX-style admonition with info / success / warning / error / neutral variants. Ships `--info` / `--success` / `--warning` theme tokens.      |
-| `code-block`       | `badge`, `button`, `copy-button` | Code display with dependency-free token highlighting, line numbers, line highlights, diff gutters, copy button and collapsible max-height.   |
-| `copy-button`      | —                                | Click-to-copy button with copied feedback, icon-only or labelled, ghost / outline variants and a non-secure-context clipboard fallback.      |
-| `image-compare`    | —                                | Before/after comparison slider with a draggable, keyboard-accessible divider, horizontal or vertical orientation and hover-follow mode.      |
-| `kbd`              | —                                | 3D tactile keycap with hover lift and pressed states. Compound API with `KbdGroup` for chords and `KbdDisplay` for inline keys.              |
-| `lightbox`         | —                                | Fullscreen image lightbox on Radix Dialog with gallery navigation, zoom and pan, swipe gestures, captions and a thumbnail strip.             |
-| `marquee`          | —                                | Infinite scrolling row or column for logos and testimonials, with pause-on-hover, reverse and vertical modes. Keyframes inline, zero config. |
-| `masonry`          | —                                | True masonry layout that balances children into the shortest column by measured height, order-preserving, responsive, dependency-free.       |
-| `qr-code`          | —                                | Dependency-free QR code generator rendering crisp SVG, with L/M/Q/H error correction, quiet-zone control and `currentColor` theming.         |
-| `scroll-progress`  | —                                | Fixed reading progress bar. Tracks document scroll by default or a scoped container ref.                                                     |
-| `spinner`          | —                                | Loading indicator with circle, dots and bars variants, sm / md / lg sizes. Inherits text color and ships an accessible status label.         |
+| Component             | Registry deps  | What it is                                                                              |
+| --------------------- | -------------- | -------------------------------------------------------------------------------------- |
+| `agent-workflow`      | —              | Rail-connected trace of an agent run: thought, tool and output steps with status and detail. |
+| `ai-chat`             | `button`       | Chat thread with role-aligned bubbles, avatars, a typing indicator and an auto-growing composer. |
+| `ai-completion-input` | —              | Text field with an inline ghost completion you accept with Tab. The suggestion is supplied by you. |
+| `ai-tool-call`        | `collapsible`  | Collapsible view of an LLM tool call with status and pretty-printed argument and result JSON. |
+| `prompt-editor`       | —              | Prompt template editor that highlights `{{variable}}` tokens and counts characters and tokens. |
+| `rag-citations`       | —              | Grounded answer with inline citation markers that cross-link to source cards.          |
 
-#### Navigation (10)
+#### Developer (5)
 
-| Component                | Registry deps        | What it is                                                                                                                                                                                               |
-| ------------------------ | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tenant-switcher`        | `popover`, `command` | Workspace / organization / project switcher for multi-tenant apps: logo or initials, plan or role caption, grouped searchable list, create action.                                                       |
-| `toc`                    | —                    | On-this-page navigation that tracks the active heading as you scroll and highlights it with a moving border marker. Flat or nested items, or composes from parts. Smooth scroll respects reduced-motion. |
-| `dock`                   | —                    | macOS-style dock with cursor magnification: icons scale and spring as the pointer passes, with hover and focus labels. Built on framer-motion.                                                           |
-| `floating-action-button` | —                    | Expanding speed-dial FAB: a primary trigger that rotates open to stagger a stack of secondary actions on any side. Compound API.                                                                         |
-| `floating-toolbar`       | —                    | Floating pill toolbar for text selection and canvas actions, with toggle buttons, separators and labels.                                                                                                 |
-| `inspector-panel`        | `collapsible`        | Design-tool inspector with a header, collapsible sections and label/control rows. Compound API for property panels and sidebars.                                                                         |
-| `resizable-panels`       | —                    | Composable resizable panel groups with draggable, keyboard-accessible handles, per-panel minimums and nestable horizontal or vertical groups.                                                            |
-| `split-view`             | —                    | Two-pane master/detail layout with a draggable divider, keyboard resize, min/max bounds and horizontal or vertical orientation.                                                                          |
-| `stepper`                | —                    | Multi-step progress indicator with horizontal and vertical orientation, completed / active / inactive states, clickable steps and a compound API.                                                        |
-| `tour`                   | `button`             | Onboarding spotlight that dims the page around a target element and walks users through steps with a positioned coach-mark card.                                                                         |
+| Component         | Registry deps                    | What it is                                                                              |
+| ----------------- | -------------------------------- | -------------------------------------------------------------------------------------- |
+| `diff-viewer`     | —                                | Line-level text diff with unified or split mode, line numbers and add / remove gutters. |
+| `json-viewer`     | —                                | Collapsible, syntax-highlighted JSON tree with type-colored values. Dependency-free.   |
+| `log-viewer`      | `button`, `input-group`          | Monospace log stream with per-line level, level filter chips, search highlight and a live tail. |
+| `request-builder` | `button`, `input`, `select`, `tabs` | Compose an HTTP request with params, headers and body, and a response panel.         |
+| `terminal`        | —                                | Presentational terminal with window chrome, scrollback, history and a command handler. |
+
+#### Commerce (6)
+
+| Component               | Registry deps                       | What it is                                                                          |
+| ----------------------- | ----------------------------------- | ---------------------------------------------------------------------------------- |
+| `bundle-builder`        | `badge`, `button`, `input`, `select` | Assemble a product bundle with quantity steppers, a bundle discount and live savings. |
+| `discount-builder`      | `badge`, `button`, `input`, `select` | Configure a percentage, fixed or free-shipping discount with conditions and a summary. |
+| `inventory-matrix`      | `input`                             | Editable stock grid of variants by location with totals and low / out-of-stock highlighting. |
+| `pricing-rules-builder` | `badge`, `button`, `input`, `select` | Top-down conditional pricing rules of the form when condition then price action.   |
+| `variant-editor`        | `badge`, `button`, `input`          | Define product option axes and edit the generated variant rows (price, SKU, stock). |
+| `vendor-comparison`     | `badge`                             | Compare vendors across grouped features with boolean / text cells and a recommended column. |
+
+#### Display & feedback (15)
+
+| Component          | Registry deps                    | What it is                                                                            |
+| ------------------ | -------------------------------- | ------------------------------------------------------------------------------------ |
+| `announcement-bar` | —                                | Top-of-page banner with default / primary / muted tones, dismiss and persistence.    |
+| `audio-player`     | `button`, `slider`               | Composable audio player with scrub-safe seek, skip, time readouts, volume and rate.  |
+| `callout`          | —                                | MDX-style admonition with info / success / warning / error / neutral variants.       |
+| `changelog-viewer` | `badge`                          | Vertical timeline of versioned releases with grouped change sections and a latest marker. |
+| `code-block`       | `badge`, `button`, `copy-button` | Code display with dependency-free token highlighting, line numbers and diff gutters.  |
+| `copy-button`      | —                                | Click-to-copy button with copied feedback and a non-secure-context clipboard fallback. |
+| `image-compare`    | —                                | Before/after comparison slider with a draggable, keyboard-accessible divider.        |
+| `kbd`              | —                                | 3D tactile keycap with `KbdGroup` for chords and `KbdDisplay` for inline keys.       |
+| `lightbox`         | —                                | Fullscreen image lightbox with gallery nav, zoom, swipe and a thumbnail strip.       |
+| `marquee`          | —                                | Infinite scrolling row or column with pause-on-hover, reverse and vertical modes.    |
+| `masonry`          | —                                | True masonry layout that balances children into the shortest column. Dependency-free. |
+| `qr-code`          | —                                | Dependency-free QR code generator rendering crisp SVG with `currentColor` theming.   |
+| `release-notes`    | `badge`                          | Single-release what's-new card with a version badge, date, title and highlights.     |
+| `scroll-progress`  | —                                | Fixed reading progress bar. Tracks document scroll or a scoped container ref.        |
+| `spinner`          | —                                | Loading indicator with circle, dots and bars variants and an accessible label.       |
+
+#### Navigation (15)
+
+| Component                | Registry deps              | What it is                                                                            |
+| ------------------------ | -------------------------- | ------------------------------------------------------------------------------------ |
+| `breadcrumb-generator`   | `breadcrumb`, `dropdown-menu` | Generate a breadcrumb trail from a path or items, with middle-collapse into a dropdown. |
+| `command-palette`        | `command`, `kbd`           | Cmd+K command launcher with grouped actions, icons, shortcuts and a global hotkey.    |
+| `dock`                   | —                          | macOS-style dock with cursor magnification: icons scale and spring past the pointer.  |
+| `floating-action-button` | —                          | Expanding speed-dial FAB that rotates open to stagger secondary actions.              |
+| `floating-toolbar`       | —                          | Floating pill toolbar for text selection and canvas actions.                         |
+| `inspector-panel`        | `collapsible`              | Design-tool inspector with a header, collapsible sections and label/control rows.    |
+| `keyboard-shortcuts`     | `dialog`, `kbd`            | Shortcuts cheat-sheet dialog opened with `?`, grouped by area and searchable.         |
+| `onboarding`             | `button`, `progress`       | Multi-step onboarding wizard with a progress header, per-step panels and a finish state. |
+| `resizable-panels`       | —                          | Composable resizable panel groups with keyboard-accessible handles and minimums.     |
+| `spotlight-search`       | `dialog`, `kbd`            | Centered search overlay with a large field, grouped rich results and keyboard nav.    |
+| `split-view`             | —                          | Two-pane master/detail layout with a draggable divider and keyboard resize.          |
+| `stepper`                | —                          | Multi-step progress indicator, horizontal or vertical, with a compound API.          |
+| `tenant-switcher`        | `popover`, `command`       | Workspace / organization / project switcher with a grouped, searchable list.         |
+| `toc`                    | —                          | On-this-page navigation that tracks the active heading with a moving marker.          |
+| `tour`                   | `button`                   | Onboarding spotlight that dims the page and walks users through steps.                |
 
 #### Animation (8)
 
-| Component         | Registry deps | What it is                                                                                                                                  |
-| ----------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `blur-reveal`     | —             | Reveals content with a blur, fade and lift as it scrolls into view. Configurable delay, duration and threshold; respects reduced-motion.    |
-| `cursor-glow`     | —             | Ambient glow layer that follows the pointer across its container and fades when it leaves. Drop it behind heroes, grids or feature panels.  |
-| `magnetic-button` | —             | Button that pulls toward the cursor and springs back on leave. Adjustable strength, `asChild` to wrap a link, respects reduced-motion.      |
-| `morphing-dialog` | —             | A trigger card that morphs into a centered dialog via shared-layout animation, with focus trapping, scroll lock and Esc to close.           |
-| `scroll-reveal`   | —             | Fades and slides content in from any direction as it enters the viewport. Configurable distance, delay and replay; respects reduced-motion. |
-| `spotlight-card`  | —             | Card surface with a soft spotlight that tracks the cursor and fades in on hover. Built on design tokens, no hard-coded colors.              |
-| `text-reveal`     | —             | Staggered text entrance that masks and slides each word, character or line into place on scroll. Respects reduced-motion.                   |
-| `tilt-card`       | —             | 3D pointer tilt with optional cursor-following glare and configurable max angle, scale and perspective. Respects reduced-motion.            |
+| Component         | Registry deps | What it is                                                                                  |
+| ----------------- | ------------- | ------------------------------------------------------------------------------------------- |
+| `blur-reveal`     | —             | Reveals content with a blur, fade and lift as it scrolls into view. Reduced-motion aware.   |
+| `cursor-glow`     | —             | Ambient glow layer that follows the pointer across its container.                           |
+| `magnetic-button` | —             | Button that pulls toward the cursor and springs back on leave.                              |
+| `morphing-dialog` | —             | A trigger card that morphs into a centered dialog via shared-layout animation.              |
+| `scroll-reveal`   | —             | Fades and slides content in from any direction as it enters the viewport.                   |
+| `spotlight-card`  | —             | Card surface with a soft spotlight that tracks the cursor and fades in on hover.            |
+| `text-reveal`     | —             | Staggered text entrance that masks and slides each word, character or line into place.      |
+| `tilt-card`       | —             | 3D pointer tilt with optional cursor-following glare. Reduced-motion aware.                 |
 
 #### Widgets (3)
 
-| Component       | Registry deps | What it is                                                                                                          |
-| --------------- | ------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `kpi-grid`      | —             | Hairline-joined grid of KPI tiles with label, value, an up/down/flat delta chip and a dependency-free sparkline.    |
-| `notifications` | —             | Notification panel with header, list, per-item media, title, description, time and an accent-cool unread marker.    |
-| `quick-actions` | —             | Grid of dashboard shortcut tiles with icon, label and description. Each tile is a button or, via `asChild`, a link. |
+| Component       | Registry deps | What it is                                                                                |
+| --------------- | ------------- | ---------------------------------------------------------------------------------------- |
+| `kpi-grid`      | —             | Hairline-joined grid of KPI tiles with a delta chip and a dependency-free sparkline.     |
+| `notifications` | —             | Notification panel with per-item media, title, description, time and an unread marker.    |
+| `quick-actions` | —             | Grid of dashboard shortcut tiles with icon, label and description. `asChild` for links.  |
 
-#### SaaS (4)
+#### SaaS (7)
 
-| Component            | Registry deps | What it is                                                                                             |
-| -------------------- | ------------- | ------------------------------------------------------------------------------------------------------ |
-| `api-keys`           | —             | API key manager with reveal/hide, copy-to-clipboard, key metadata and a create action.                 |
-| `billing-card`       | —             | Current-plan summary with price, a usage meter, billing detail rows and footer actions.                |
-| `subscription-plans` | —             | In-app plan selector with featured and current states, a badge, feature checklist and per-plan action. |
-| `usage-dashboard`    | —             | Metered usage panel with per-resource progress bars that tint amber near the limit and red over it.    |
+| Component              | Registry deps              | What it is                                                                            |
+| ---------------------- | -------------------------- | ------------------------------------------------------------------------------------ |
+| `api-keys`             | `button`                   | API key manager with reveal/hide, copy-to-clipboard, key metadata and a create action. |
+| `billing-card`         | —                          | Current-plan summary with price, a usage meter, billing detail rows and footer actions. |
+| `feature-flag-manager` | `badge`                    | Searchable feature flags with key, environments, rollout and an accessible on/off toggle. |
+| `review-queue`         | `badge`, `button`, `kbd`   | Work a moderation queue one item at a time with approve / reject / skip and shortcuts. |
+| `role-manager`         | `badge`, `button`, `checkbox` | Two-pane role admin with a grouped permission checklist; system roles are read-only. |
+| `subscription-plans`   | `button`                   | In-app plan selector with featured and current states, a badge and per-plan action.  |
+| `usage-dashboard`      | —                          | Metered usage panel with per-resource progress bars that tint near and over the limit. |
 
 > The SaaS "Audit Logs" view is served by the `audit-log` component (Data
 > display) rather than a near-duplicate entry.
 
-#### Primitives — distribution-only (1)
+#### Primitives — distribution-only (2)
 
-| Component   | Registry deps | What it is                                                                                                                                         |
-| ----------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `accordion` | —             | Radix-powered accordion primitive used by the FAQ blocks. Listed in `DISTRIBUTION_ONLY` so it ships in the registry without its own showcase page. |
+| Component        | Registry deps | What it is                                                                                                                                         |
+| ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `accordion`      | —             | Radix-powered accordion primitive used by the FAQ blocks. Listed in `DISTRIBUTION_ONLY` so it ships in the registry without its own showcase page. |
+| `calendar-utils` | —             | Dependency-free date helpers (month grids, day math, keyboard-grid navigation) shared by `date-picker` and `date-range-picker`.                   |
 
 ## Blocks
 
@@ -167,8 +221,8 @@ kind has a category page at `/blocks/<category>` and its blocks at
 (`feature` → `features`, `login` → `auth`, `faq` → `faqs`) — see
 `BLOCK_KIND_SLUGS`.
 
-| Kind           | Blocks                                                                                         | What it covers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| -------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Kind           | Blocks                                                                                         | What it covers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| -------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Hero           | `hero-01`, `hero-02`, `hero-03`, `hero-04`, `hero-05`, `hero-06`, `hero-07`, `hero-08`         | Landing hero sections — headline, sub-copy, CTAs. `hero-01` light-beam shader card with glass nav + stat footer, `hero-02` animated gradient-bar shader with wordmark strip, `hero-03` editorial faded-grid with a logo cloud, `hero-04` full-bleed image banner with a scrim, `hero-05` aurora shader card with a glass panel + avatar social proof, `hero-06` centered personal hero with a live badge, stat row and geometric accents, `hero-07` centered word-by-word reveal with beam line-art, `hero-08` framed token-lit panel with a window preview. Shader backdrops (`hero-01/02/05`) reuse the `shaders` package and load client-side only. |
 | Feature        | `feature-01`, `feature-02`                                                                     | Feature grids and alternating feature rows.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | Pricing        | `pricing-01`, `pricing-02`                                                                     | Tiered pricing tables with feature lists and highlighted plan.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |

--- a/registry.json
+++ b/registry.json
@@ -3799,6 +3799,149 @@
       ]
     },
     {
+      "name": "discount-builder",
+      "type": "registry:ui",
+      "title": "Discount Builder",
+      "description": "Configure a store discount: percentage, fixed amount or free shipping, with optional conditions and a live summary. Compound API.",
+      "categories": [
+        "commerce"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "badge",
+        "button",
+        "input",
+        "select"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/discount-builder.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/discount-builder.tsx"
+        }
+      ]
+    },
+    {
+      "name": "bundle-builder",
+      "type": "registry:ui",
+      "title": "Bundle Builder",
+      "description": "Assemble a product bundle from a catalog with quantity steppers, a bundle discount and live savings versus buying separately. Compound API.",
+      "categories": [
+        "commerce"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "badge",
+        "button",
+        "input",
+        "select"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/bundle-builder.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/bundle-builder.tsx"
+        }
+      ]
+    },
+    {
+      "name": "vendor-comparison",
+      "type": "registry:ui",
+      "title": "Vendor Comparison",
+      "description": "Compare vendors or plans across grouped features with boolean, text and rating cells, a sticky feature column and a recommended column. Compound API.",
+      "categories": [
+        "commerce"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "badge"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/vendor-comparison.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/vendor-comparison.tsx"
+        }
+      ]
+    },
+    {
+      "name": "inventory-matrix",
+      "type": "registry:ui",
+      "title": "Inventory Matrix",
+      "description": "Editable stock grid of variants by location with row and column totals and low-stock and out-of-stock highlighting. Compound API.",
+      "categories": [
+        "commerce"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "input"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/inventory-matrix.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/inventory-matrix.tsx"
+        }
+      ]
+    },
+    {
+      "name": "variant-editor",
+      "type": "registry:ui",
+      "title": "Variant Editor",
+      "description": "Define product option axes and edit the generated variant rows (price, SKU, stock); editing options regenerates rows and keeps existing data. Compound API.",
+      "categories": [
+        "commerce"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "badge",
+        "button",
+        "input"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/variant-editor.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/variant-editor.tsx"
+        }
+      ]
+    },
+    {
+      "name": "pricing-rules-builder",
+      "type": "registry:ui",
+      "title": "Pricing Rules Builder",
+      "description": "Build top-down conditional pricing rules of the form when condition then price action, each with a live summary. Compound API.",
+      "categories": [
+        "commerce"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "badge",
+        "button",
+        "input",
+        "select"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/pricing-rules-builder.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/pricing-rules-builder.tsx"
+        }
+      ]
+    },
+    {
       "name": "accordion",
       "type": "registry:ui",
       "title": "Accordion",

--- a/registry.json
+++ b/registry.json
@@ -3942,6 +3942,163 @@
       ]
     },
     {
+      "name": "upload-manager",
+      "type": "registry:ui",
+      "title": "Upload Manager",
+      "description": "Upload queue with per-file progress, status and retry, cancel and remove actions, plus an overall progress summary. Compound API.",
+      "categories": [
+        "files"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "button",
+        "progress"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/upload-manager.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/upload-manager.tsx"
+        }
+      ]
+    },
+    {
+      "name": "file-explorer",
+      "type": "registry:ui",
+      "title": "File Explorer",
+      "description": "Two-pane file browser: a collapsible folder tree, a breadcrumb path and a list or grid of the current folder's contents. Compound API.",
+      "categories": [
+        "files"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "breadcrumb",
+        "button"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/file-explorer.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/file-explorer.tsx"
+        }
+      ]
+    },
+    {
+      "name": "asset-manager",
+      "type": "registry:ui",
+      "title": "Asset Manager",
+      "description": "Media library with a thumbnail grid or list, search, multi-select and a detail inspector showing the selected asset's preview and metadata. Compound API.",
+      "categories": [
+        "files"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "badge",
+        "button"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/asset-manager.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/asset-manager.tsx"
+        }
+      ]
+    },
+    {
+      "name": "kanban-board",
+      "type": "registry:ui",
+      "title": "Kanban Board",
+      "description": "Column board with cards you drag between and within columns (native DnD, no library) plus keyboard move actions. Controlled board value. Compound API.",
+      "categories": [
+        "data"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "badge",
+        "button"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/kanban-board.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/kanban-board.tsx"
+        }
+      ]
+    },
+    {
+      "name": "nested-sortable",
+      "type": "registry:ui",
+      "title": "Nested Sortable",
+      "description": "Drag-to-reorder outline with nesting: indent and outdent items into a real tree, with pointer and keyboard control and live-region announcements. Compound API.",
+      "categories": [
+        "data"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "button"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/nested-sortable.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/nested-sortable.tsx"
+        }
+      ]
+    },
+    {
+      "name": "shipment-tracker",
+      "type": "registry:ui",
+      "title": "Shipment Tracker",
+      "description": "Order delivery stages as a connected progress stepper with timestamps and a live current stage, plus an event history list. Compound API.",
+      "categories": [
+        "data"
+      ],
+      "dependencies": [
+        "class-variance-authority",
+        "lucide-react"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/hirael/ui/shipment-tracker.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/shipment-tracker.tsx"
+        }
+      ]
+    },
+    {
+      "name": "auction-timeline",
+      "type": "registry:ui",
+      "title": "Auction Timeline",
+      "description": "Live auction panel with the leading bid, a countdown to close, a live status and a bid-history timeline; shows the winner once closed. Compound API.",
+      "categories": [
+        "data"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "badge"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/auction-timeline.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/auction-timeline.tsx"
+        }
+      ]
+    },
+    {
       "name": "accordion",
       "type": "registry:ui",
       "title": "Accordion",

--- a/registry.json
+++ b/registry.json
@@ -3438,6 +3438,128 @@
       ]
     },
     {
+      "name": "ai-chat",
+      "type": "registry:ui",
+      "title": "AI Chat",
+      "description": "Chat thread for AI products: role-aligned bubbles, avatars, a typing indicator, message actions and an auto-growing composer. Compound API.",
+      "categories": [
+        "ai"
+      ],
+      "dependencies": [
+        "class-variance-authority"
+      ],
+      "registryDependencies": [
+        "button"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/ai-chat.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/ai-chat.tsx"
+        }
+      ]
+    },
+    {
+      "name": "prompt-editor",
+      "type": "registry:ui",
+      "title": "Prompt Editor",
+      "description": "Prompt template editor that highlights {{variable}} tokens live, inserts them from a chip row, and counts characters and approximate tokens. Compound API.",
+      "categories": [
+        "ai"
+      ],
+      "dependencies": [],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/hirael/ui/prompt-editor.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/prompt-editor.tsx"
+        }
+      ]
+    },
+    {
+      "name": "ai-completion-input",
+      "type": "registry:ui",
+      "title": "AI Completion Input",
+      "description": "Text field with an inline ghost completion you accept with Tab. The suggestion is supplied by you, so nothing calls a model. Compound API.",
+      "categories": [
+        "ai"
+      ],
+      "dependencies": [],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/hirael/ui/ai-completion-input.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/ai-completion-input.tsx"
+        }
+      ]
+    },
+    {
+      "name": "ai-tool-call",
+      "type": "registry:ui",
+      "title": "AI Tool Call",
+      "description": "Collapsible view of an LLM tool call: function name, pending / done / error status and pretty-printed argument and result JSON. Compound API.",
+      "categories": [
+        "ai"
+      ],
+      "dependencies": [
+        "class-variance-authority",
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "collapsible"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/ai-tool-call.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/ai-tool-call.tsx"
+        }
+      ]
+    },
+    {
+      "name": "agent-workflow",
+      "type": "registry:ui",
+      "title": "Agent Workflow",
+      "description": "Rail-connected trace of an agent run: thought, tool and output steps with done / running / error status and expandable detail. Compound API.",
+      "categories": [
+        "ai"
+      ],
+      "dependencies": [
+        "class-variance-authority",
+        "lucide-react"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/hirael/ui/agent-workflow.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/agent-workflow.tsx"
+        }
+      ]
+    },
+    {
+      "name": "rag-citations",
+      "type": "registry:ui",
+      "title": "RAG Citations",
+      "description": "Grounded answer with inline citation markers that cross-link to source cards showing title, snippet, url and relevance. Compound API.",
+      "categories": [
+        "ai"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/hirael/ui/rag-citations.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/rag-citations.tsx"
+        }
+      ]
+    },
+    {
       "name": "accordion",
       "type": "registry:ui",
       "title": "Accordion",

--- a/registry.json
+++ b/registry.json
@@ -3560,6 +3560,245 @@
       ]
     },
     {
+      "name": "query-builder",
+      "type": "registry:ui",
+      "title": "Query Builder",
+      "description": "Nested AND/OR query of field, operator and value rules, with add and remove at every level. Controlled tree value. Compound API.",
+      "categories": [
+        "data"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "button",
+        "input",
+        "select"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/query-builder.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/query-builder.tsx"
+        }
+      ]
+    },
+    {
+      "name": "filter-builder",
+      "type": "registry:ui",
+      "title": "Filter Builder",
+      "description": "Flat list of field / operator / value filters with an add row, removable active-filter chips and a clear all. Compound API.",
+      "categories": [
+        "data"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "badge",
+        "button",
+        "input",
+        "select"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/filter-builder.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/filter-builder.tsx"
+        }
+      ]
+    },
+    {
+      "name": "permission-matrix",
+      "type": "registry:ui",
+      "title": "Permission Matrix",
+      "description": "Roles by permissions checkbox grid with grouped rows, a sticky label column and column master toggles with indeterminate state. Compound API.",
+      "categories": [
+        "data"
+      ],
+      "dependencies": [],
+      "registryDependencies": [
+        "checkbox"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/permission-matrix.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/permission-matrix.tsx"
+        }
+      ]
+    },
+    {
+      "name": "approval-workflow",
+      "type": "registry:ui",
+      "title": "Approval Workflow",
+      "description": "Rail-connected approval chain: approved / rejected / pending stages with approver, timestamp, comment and approve / reject actions on the current step. Compound API.",
+      "categories": [
+        "data"
+      ],
+      "dependencies": [
+        "class-variance-authority",
+        "lucide-react"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/hirael/ui/approval-workflow.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/approval-workflow.tsx"
+        }
+      ]
+    },
+    {
+      "name": "json-viewer",
+      "type": "registry:ui",
+      "title": "JSON Viewer",
+      "description": "Collapsible, syntax-highlighted JSON tree with type-colored values, array indices and a configurable expand depth. Dependency-free. Compound API.",
+      "categories": [
+        "dev"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/hirael/ui/json-viewer.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/json-viewer.tsx"
+        }
+      ]
+    },
+    {
+      "name": "diff-viewer",
+      "type": "registry:ui",
+      "title": "Diff Viewer",
+      "description": "Line-level text diff with unified or split mode, line numbers and add / remove gutter signs. Computes its own LCS, dependency-free. Compound API.",
+      "categories": [
+        "dev"
+      ],
+      "dependencies": [],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/hirael/ui/diff-viewer.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/diff-viewer.tsx"
+        }
+      ]
+    },
+    {
+      "name": "log-viewer",
+      "type": "registry:ui",
+      "title": "Log Viewer",
+      "description": "Monospace log stream with per-line level and timestamp, level filter chips, search with highlight, a line count and a live tail indicator. Compound API.",
+      "categories": [
+        "dev"
+      ],
+      "dependencies": [
+        "class-variance-authority",
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "button",
+        "input-group"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/log-viewer.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/log-viewer.tsx"
+        }
+      ]
+    },
+    {
+      "name": "request-builder",
+      "type": "registry:ui",
+      "title": "Request Builder",
+      "description": "Compose an HTTP request: method, URL, editable params and headers, a body editor, and a response panel with status, time and size. Compound API.",
+      "categories": [
+        "dev"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "button",
+        "input",
+        "select",
+        "tabs"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/request-builder.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/request-builder.tsx"
+        }
+      ]
+    },
+    {
+      "name": "terminal",
+      "type": "registry:ui",
+      "title": "Terminal",
+      "description": "Presentational terminal with window chrome, scrollback, command history and a pluggable command handler. Dependency-free. Compound API.",
+      "categories": [
+        "dev"
+      ],
+      "dependencies": [],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/hirael/ui/terminal.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/terminal.tsx"
+        }
+      ]
+    },
+    {
+      "name": "command-palette",
+      "type": "registry:ui",
+      "title": "Command Palette",
+      "description": "Ready-to-use Cmd+K command launcher: grouped actions with icons and shortcuts, a trigger button and a global hotkey. Compound API.",
+      "categories": [
+        "navigation"
+      ],
+      "dependencies": [],
+      "registryDependencies": [
+        "command",
+        "kbd"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/command-palette.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/command-palette.tsx"
+        }
+      ]
+    },
+    {
+      "name": "spotlight-search",
+      "type": "registry:ui",
+      "title": "Spotlight Search",
+      "description": "Centered search overlay with a large field, grouped rich results, full keyboard navigation, an empty state and a hint footer. Compound API.",
+      "categories": [
+        "navigation"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "dialog",
+        "kbd"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/spotlight-search.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/spotlight-search.tsx"
+        }
+      ]
+    },
+    {
       "name": "accordion",
       "type": "registry:ui",
       "title": "Accordion",

--- a/registry.json
+++ b/registry.json
@@ -4099,6 +4099,213 @@
       ]
     },
     {
+      "name": "review-queue",
+      "type": "registry:ui",
+      "title": "Review Queue",
+      "description": "Work a moderation queue one item at a time with approve, reject and skip actions, keyboard shortcuts, progress and a done state. Compound API.",
+      "categories": [
+        "saas"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "badge",
+        "button",
+        "kbd"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/review-queue.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/review-queue.tsx"
+        }
+      ]
+    },
+    {
+      "name": "role-manager",
+      "type": "registry:ui",
+      "title": "Role Manager",
+      "description": "Two-pane role admin: a role list with add, duplicate and delete, and a grouped permission checklist for the selected role; system roles are read-only. Compound API.",
+      "categories": [
+        "saas"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "badge",
+        "button",
+        "checkbox"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/role-manager.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/role-manager.tsx"
+        }
+      ]
+    },
+    {
+      "name": "feature-flag-manager",
+      "type": "registry:ui",
+      "title": "Feature Flag Manager",
+      "description": "Searchable list of feature flags with key, description, environment tags, rollout percentage and an accessible on/off toggle. Compound API.",
+      "categories": [
+        "saas"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "badge"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/feature-flag-manager.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/feature-flag-manager.tsx"
+        }
+      ]
+    },
+    {
+      "name": "keyboard-shortcuts",
+      "type": "registry:ui",
+      "title": "Keyboard Shortcuts",
+      "description": "Shortcuts cheat-sheet dialog opened with the ? key, grouped by area with searchable rows and keys rendered as keycaps. Compound API.",
+      "categories": [
+        "navigation"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "dialog",
+        "kbd"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/keyboard-shortcuts.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/keyboard-shortcuts.tsx"
+        }
+      ]
+    },
+    {
+      "name": "onboarding",
+      "type": "registry:ui",
+      "title": "Onboarding",
+      "description": "Multi-step onboarding wizard with a progress header, per-step panels, back, skip and next, and a completion state. Compound API.",
+      "categories": [
+        "navigation"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "button",
+        "progress"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/onboarding.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/onboarding.tsx"
+        }
+      ]
+    },
+    {
+      "name": "breadcrumb-generator",
+      "type": "registry:ui",
+      "title": "Breadcrumb Generator",
+      "description": "Generate a breadcrumb trail from a path or items, with an optional home icon, a current-page last item and middle-collapse into a dropdown. Compound API.",
+      "categories": [
+        "navigation"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "breadcrumb",
+        "dropdown-menu"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/breadcrumb-generator.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/breadcrumb-generator.tsx"
+        }
+      ]
+    },
+    {
+      "name": "advanced-search-bar",
+      "type": "registry:ui",
+      "title": "Advanced Search Bar",
+      "description": "Power search field with a scope selector, inline removable filter tokens and a grouped suggestions dropdown with keyboard navigation. Compound API.",
+      "categories": [
+        "inputs"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "badge",
+        "button",
+        "input-group"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/advanced-search-bar.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/advanced-search-bar.tsx"
+        }
+      ]
+    },
+    {
+      "name": "changelog-viewer",
+      "type": "registry:ui",
+      "title": "Changelog Viewer",
+      "description": "Vertical timeline of versioned releases with dates, grouped added / fixed / changed / removed sections and a latest marker. Compound API.",
+      "categories": [
+        "display"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "badge"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/changelog-viewer.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/changelog-viewer.tsx"
+        }
+      ]
+    },
+    {
+      "name": "release-notes",
+      "type": "registry:ui",
+      "title": "Release Notes",
+      "description": "Single-release what's-new card with a version badge, date, title, summary and a list of highlights. Compound API.",
+      "categories": [
+        "display"
+      ],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "badge"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/release-notes.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/release-notes.tsx"
+        }
+      ]
+    },
+    {
       "name": "accordion",
       "type": "registry:ui",
       "title": "Accordion",

--- a/registry/hirael/examples/advanced-search-bar-demo.tsx
+++ b/registry/hirael/examples/advanced-search-bar-demo.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import * as React from "react";
+import { Clock, FileText, User, Code, Hash } from "lucide-react";
+
+import {
+  AdvancedSearchBar,
+  SearchScope,
+  SearchField,
+  SearchTokens,
+  SearchSuggestions,
+  SearchSuggestionGroup,
+  SearchSuggestion,
+} from "@/registry/hirael/ui/advanced-search-bar";
+
+const SCOPES = [
+  { value: "all", label: "All" },
+  { value: "people", label: "People" },
+  { value: "files", label: "Files" },
+  { value: "code", label: "Code" },
+];
+
+const RECENT = ["payment retry logic", "onboarding flow", "type:pdf invoices"];
+
+const PEOPLE = ["Mary Major", "Richard Roe"];
+
+const FILES = ["Q3 roadmap.pdf", "brand-guidelines.fig"];
+
+export default function AdvancedSearchBarDemo() {
+  const [tokens, setTokens] = React.useState(["type:pdf", "owner:mary"]);
+
+  return (
+    <div className="grid w-full max-w-xl gap-8">
+      <AdvancedSearchBar
+        scopes={SCOPES}
+        tokens={tokens}
+        onTokensChange={setTokens}
+      >
+        <SearchField placeholder="Search the workspace…">
+          <SearchScope />
+          <SearchTokens />
+        </SearchField>
+        <SearchSuggestions>
+          <SearchSuggestionGroup label="Recent">
+            {RECENT.map((item) => (
+              <SearchSuggestion key={item} value={item} icon={<Clock />}>
+                {item}
+              </SearchSuggestion>
+            ))}
+          </SearchSuggestionGroup>
+          <SearchSuggestionGroup label="People" live>
+            {PEOPLE.map((person) => (
+              <SearchSuggestion key={person} value={person} icon={<User />}>
+                {person}
+              </SearchSuggestion>
+            ))}
+          </SearchSuggestionGroup>
+          <SearchSuggestionGroup label="Files" live>
+            {FILES.map((file) => (
+              <SearchSuggestion key={file} value={file} icon={<FileText />}>
+                {file}
+              </SearchSuggestion>
+            ))}
+          </SearchSuggestionGroup>
+          <SearchSuggestionGroup label="Filter">
+            <SearchSuggestion value="type:pdf" icon={<Hash />}>
+              Only PDF files
+            </SearchSuggestion>
+            <SearchSuggestion value="lang:typescript" icon={<Code />}>
+              Code in TypeScript
+            </SearchSuggestion>
+          </SearchSuggestionGroup>
+        </SearchSuggestions>
+      </AdvancedSearchBar>
+
+      <AdvancedSearchBar
+        scopes={[
+          { value: "issues", label: "Issues" },
+          { value: "prs", label: "Pull requests" },
+        ]}
+        defaultScope="issues"
+        defaultTokens={["is:open"]}
+      >
+        <SearchField placeholder="Filter issues…" filters>
+          <SearchScope />
+          <SearchTokens />
+        </SearchField>
+        <SearchSuggestions>
+          <SearchSuggestionGroup label="Saved">
+            <SearchSuggestion value="assigned to me" icon={<User />}>
+              Assigned to me
+            </SearchSuggestion>
+            <SearchSuggestion value="needs review" icon={<Clock />}>
+              Needs review
+            </SearchSuggestion>
+          </SearchSuggestionGroup>
+          <SearchSuggestionGroup label="Filter">
+            <SearchSuggestion value="is:open" icon={<Hash />}>
+              Open only
+            </SearchSuggestion>
+            <SearchSuggestion value="label:bug" icon={<Hash />}>
+              Labeled bug
+            </SearchSuggestion>
+          </SearchSuggestionGroup>
+        </SearchSuggestions>
+      </AdvancedSearchBar>
+    </div>
+  );
+}

--- a/registry/hirael/examples/agent-workflow-demo.tsx
+++ b/registry/hirael/examples/agent-workflow-demo.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { Database, Globe } from "lucide-react";
+
+import {
+  AgentWorkflow,
+  AgentWorkflowContent,
+  AgentWorkflowDetail,
+  AgentWorkflowMarker,
+  AgentWorkflowMeta,
+  AgentWorkflowStep,
+  AgentWorkflowTitle,
+} from "@/registry/hirael/ui/agent-workflow";
+
+export default function AgentWorkflowDemo() {
+  return (
+    <div className="grid w-full max-w-xl gap-8">
+      <AgentWorkflow>
+        <AgentWorkflowStep status="done" kind="thought">
+          <AgentWorkflowMarker status="done" kind="thought" />
+          <AgentWorkflowContent>
+            <AgentWorkflowTitle>Plan the lookup</AgentWorkflowTitle>
+            <AgentWorkflowMeta>
+              <span>Thought</span>
+              <span>0.4s</span>
+            </AgentWorkflowMeta>
+            <AgentWorkflowDetail>
+              The user wants last quarter&apos;s revenue. Query the orders table,
+              then sum by month.
+            </AgentWorkflowDetail>
+          </AgentWorkflowContent>
+        </AgentWorkflowStep>
+
+        <AgentWorkflowStep status="done" kind="tool">
+          <AgentWorkflowMarker status="done" kind="tool" />
+          <AgentWorkflowContent>
+            <AgentWorkflowTitle>Call search_orders</AgentWorkflowTitle>
+            <AgentWorkflowMeta>
+              <span>Tool</span>
+              <span>1.1s</span>
+            </AgentWorkflowMeta>
+            <AgentWorkflowDetail className="font-mono text-xs">
+              search_orders(range: &quot;2024-Q4&quot;, group_by: &quot;month&quot;)
+            </AgentWorkflowDetail>
+          </AgentWorkflowContent>
+        </AgentWorkflowStep>
+
+        <AgentWorkflowStep status="done" kind="output">
+          <AgentWorkflowMarker status="done" kind="output" />
+          <AgentWorkflowContent>
+            <AgentWorkflowTitle>Read 3 rows</AgentWorkflowTitle>
+            <AgentWorkflowMeta>
+              <span>Result</span>
+              <span>312 tokens</span>
+            </AgentWorkflowMeta>
+            <AgentWorkflowDetail className="font-mono text-xs">
+              Oct 84.2k, Nov 91.0k, Dec 103.7k
+            </AgentWorkflowDetail>
+          </AgentWorkflowContent>
+        </AgentWorkflowStep>
+
+        <AgentWorkflowStep status="running" kind="output">
+          <AgentWorkflowMarker status="running" kind="output" />
+          <AgentWorkflowContent>
+            <AgentWorkflowTitle>Write the summary</AgentWorkflowTitle>
+            <AgentWorkflowMeta>
+              <span>Output</span>
+              <span>claude-opus</span>
+            </AgentWorkflowMeta>
+          </AgentWorkflowContent>
+        </AgentWorkflowStep>
+
+        <AgentWorkflowStep status="pending" kind="tool">
+          <AgentWorkflowMarker status="pending" kind="tool" />
+          <AgentWorkflowContent>
+            <AgentWorkflowTitle>Send to Slack</AgentWorkflowTitle>
+            <AgentWorkflowMeta>
+              <span>Queued</span>
+            </AgentWorkflowMeta>
+          </AgentWorkflowContent>
+        </AgentWorkflowStep>
+      </AgentWorkflow>
+
+      <AgentWorkflow>
+        <AgentWorkflowStep status="done" kind="tool">
+          <AgentWorkflowMarker status="done">
+            <Globe />
+          </AgentWorkflowMarker>
+          <AgentWorkflowContent>
+            <AgentWorkflowTitle>Fetch the changelog</AgentWorkflowTitle>
+            <AgentWorkflowMeta>
+              <span>HTTP</span>
+              <span>200</span>
+              <span>0.8s</span>
+            </AgentWorkflowMeta>
+          </AgentWorkflowContent>
+        </AgentWorkflowStep>
+
+        <AgentWorkflowStep status="error" kind="tool">
+          <AgentWorkflowMarker status="error">
+            <Database />
+          </AgentWorkflowMarker>
+          <AgentWorkflowContent>
+            <AgentWorkflowTitle>Write to cache</AgentWorkflowTitle>
+            <AgentWorkflowMeta>
+              <span>Redis</span>
+              <span>Timeout</span>
+            </AgentWorkflowMeta>
+            <AgentWorkflowDetail className="border-destructive/30 text-destructive">
+              Connection refused after 5s. Retrying with backoff.
+            </AgentWorkflowDetail>
+          </AgentWorkflowContent>
+        </AgentWorkflowStep>
+
+        <AgentWorkflowStep status="running" kind="tool">
+          <AgentWorkflowMarker status="running" kind="tool" />
+          <AgentWorkflowContent>
+            <AgentWorkflowTitle>Retry the write</AgentWorkflowTitle>
+            <AgentWorkflowMeta>
+              <span>Attempt 2 of 3</span>
+            </AgentWorkflowMeta>
+          </AgentWorkflowContent>
+        </AgentWorkflowStep>
+      </AgentWorkflow>
+    </div>
+  );
+}

--- a/registry/hirael/examples/ai-chat-demo.tsx
+++ b/registry/hirael/examples/ai-chat-demo.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import * as React from "react";
+import { Bot, Copy, RefreshCw, ArrowUp } from "lucide-react";
+
+import {
+  AiChat,
+  AiChatActions,
+  AiChatAvatar,
+  AiChatBubble,
+  AiChatComposer,
+  AiChatGroup,
+  AiChatInput,
+  AiChatMessage,
+  AiChatMessages,
+  AiChatSend,
+  AiChatTimestamp,
+  AiChatTyping,
+} from "@/registry/hirael/ui/ai-chat";
+
+export default function AiChatDemo() {
+  const [value, setValue] = React.useState("");
+
+  return (
+    <div className="grid w-full max-w-xl gap-8">
+      <AiChat className="h-[28rem]">
+        <AiChatMessages>
+          <AiChatMessage role="assistant">
+            <AiChatAvatar>
+              <Bot />
+            </AiChatAvatar>
+            <AiChatGroup role="assistant">
+              <AiChatBubble role="assistant">
+                Hi, I can help you draft release notes. Paste a few commits and
+                I will group them.
+              </AiChatBubble>
+              <AiChatTimestamp>09:41</AiChatTimestamp>
+            </AiChatGroup>
+          </AiChatMessage>
+
+          <AiChatMessage role="user">
+            <AiChatGroup role="user">
+              <AiChatBubble role="user">
+                Can you turn these into Highlights and Fixes sections?
+              </AiChatBubble>
+              <AiChatTimestamp>09:42</AiChatTimestamp>
+            </AiChatGroup>
+          </AiChatMessage>
+
+          <AiChatMessage role="assistant">
+            <AiChatAvatar>
+              <Bot />
+            </AiChatAvatar>
+            <AiChatGroup role="assistant">
+              <AiChatBubble role="assistant">
+                Sure. Send the commit list and I will sort each line into the
+                right heading.
+              </AiChatBubble>
+            </AiChatGroup>
+          </AiChatMessage>
+
+          <AiChatMessage role="assistant">
+            <AiChatAvatar>
+              <Bot />
+            </AiChatAvatar>
+            <AiChatTyping />
+          </AiChatMessage>
+        </AiChatMessages>
+
+        <AiChatComposer
+          onSubmit={(event) => {
+            event.preventDefault();
+            setValue("");
+          }}
+        >
+          <AiChatInput
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            placeholder="Send a message"
+          />
+          <AiChatSend disabled={value.trim().length === 0}>
+            <ArrowUp />
+          </AiChatSend>
+        </AiChatComposer>
+      </AiChat>
+
+      <AiChat>
+        <AiChatMessages className="gap-4 p-3">
+          <AiChatMessage role="user">
+            <AiChatGroup role="user">
+              <AiChatBubble role="user" tone="muted" className="text-sm">
+                Summarize this thread in one line.
+              </AiChatBubble>
+            </AiChatGroup>
+          </AiChatMessage>
+
+          <AiChatMessage role="assistant">
+            <AiChatAvatar className="size-7">
+              <Bot />
+            </AiChatAvatar>
+            <AiChatGroup role="assistant">
+              <AiChatBubble role="assistant">
+                You asked for release notes and I offered to sort commits into
+                Highlights and Fixes.
+              </AiChatBubble>
+              <AiChatActions>
+                <button
+                  type="button"
+                  aria-label="Copy reply"
+                  className="inline-flex size-6 items-center justify-center rounded-md transition-colors hover:bg-accent hover:text-foreground"
+                >
+                  <Copy />
+                </button>
+                <button
+                  type="button"
+                  aria-label="Regenerate reply"
+                  className="inline-flex size-6 items-center justify-center rounded-md transition-colors hover:bg-accent hover:text-foreground"
+                >
+                  <RefreshCw />
+                </button>
+              </AiChatActions>
+            </AiChatGroup>
+          </AiChatMessage>
+        </AiChatMessages>
+      </AiChat>
+    </div>
+  );
+}

--- a/registry/hirael/examples/ai-completion-input-demo.tsx
+++ b/registry/hirael/examples/ai-completion-input-demo.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  AiCompletionField,
+  AiCompletionGhost,
+  AiCompletionHint,
+  AiCompletionInput,
+} from "@/registry/hirael/ui/ai-completion-input";
+
+const PHRASES = [
+  "thanks for the quick review",
+  "thanks for catching that",
+  "let me know if anything is unclear",
+  "let me know what you think",
+  "shipping this today",
+  "the build is green now",
+  "happy to pair on this tomorrow",
+  "merging once CI passes",
+];
+
+function predict(value: string): string {
+  if (value.trim() === "") return "";
+  const lower = value.toLowerCase();
+  const match = PHRASES.find(
+    (phrase) => phrase.startsWith(lower) && phrase !== lower,
+  );
+  return match ?? "";
+}
+
+const COMMANDS: Record<string, string> = {
+  g: "git status",
+  gi: "git status",
+  gc: "git commit -m ",
+  gco: "git checkout ",
+  gp: "git push origin main",
+  n: "npm run",
+  nr: "npm run build",
+  d: "docker compose up -d",
+};
+
+function predictCommand(value: string): string {
+  if (value === "") return "";
+  return COMMANDS[value.toLowerCase()] ?? "";
+}
+
+export default function AiCompletionInputDemo() {
+  const [message, setMessage] = React.useState("thanks");
+  const [command, setCommand] = React.useState("");
+
+  return (
+    <div className="grid w-full max-w-xl gap-8">
+      <div className="grid gap-2">
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          Basic · type to see a suggestion
+        </p>
+        <AiCompletionInput
+          value={message}
+          onValueChange={setMessage}
+          suggestion={predict(message)}
+        >
+          <AiCompletionField placeholder="Write a reply" />
+          <AiCompletionHint />
+        </AiCompletionInput>
+        <p className="text-xs text-muted-foreground">
+          Try &quot;let me&quot; or &quot;shipping&quot;. Tab accepts, Escape
+          dismisses.
+        </p>
+      </div>
+
+      <div className="grid gap-2">
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          Custom · command palette
+        </p>
+        <AiCompletionInput
+          value={command}
+          onValueChange={setCommand}
+          suggestion={predictCommand(command)}
+          onAccept={(value) => console.log("ran", value)}
+        >
+          <AiCompletionField
+            placeholder="Type a command, e.g. gc"
+            className="font-mono"
+          />
+          <AiCompletionHint className="font-mono">
+            <AiCompletionGhost className="text-foreground" />
+            <span>· press Tab</span>
+          </AiCompletionHint>
+        </AiCompletionInput>
+        <p className="text-xs text-muted-foreground">
+          Shortcuts: g, gc, gco, gp, nr, d.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/registry/hirael/examples/ai-tool-call-demo.tsx
+++ b/registry/hirael/examples/ai-tool-call-demo.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import {
+  AiToolCall,
+  AiToolCallArguments,
+  AiToolCallContent,
+  AiToolCallResult,
+  AiToolCallSection,
+  AiToolCallTrigger,
+} from "@/registry/hirael/ui/ai-tool-call";
+
+export default function AiToolCallDemo() {
+  return (
+    <div className="grid w-full max-w-xl gap-6">
+      <AiToolCall status="success" defaultOpen>
+        <AiToolCallTrigger name="search_orders" />
+        <AiToolCallContent>
+          <AiToolCallSection label="Arguments">
+            <AiToolCallArguments
+              value={{ customer: "lena.park", status: "shipped", limit: 5 }}
+            />
+          </AiToolCallSection>
+          <AiToolCallSection label="Result">
+            <AiToolCallResult
+              value={{
+                count: 2,
+                orders: [
+                  { id: "ord_4f21", total: 89.0, eta: "2026-06-21" },
+                  { id: "ord_4e07", total: 142.5, eta: "2026-06-23" },
+                ],
+              }}
+            />
+          </AiToolCallSection>
+        </AiToolCallContent>
+      </AiToolCall>
+
+      <AiToolCall status="pending">
+        <AiToolCallTrigger name="generate_invoice" />
+        <AiToolCallContent>
+          <AiToolCallSection label="Arguments">
+            <AiToolCallArguments
+              value={{ order: "ord_4f21", format: "pdf" }}
+            />
+          </AiToolCallSection>
+        </AiToolCallContent>
+      </AiToolCall>
+
+      <AiToolCall status="error">
+        <AiToolCallTrigger name="charge_card" />
+        <AiToolCallContent>
+          <AiToolCallSection label="Arguments">
+            <AiToolCallArguments
+              value={{ customer: "theo.adams", amount: 142.5 }}
+            />
+          </AiToolCallSection>
+          <AiToolCallSection label="Result">
+            <AiToolCallResult
+              value={{ error: "card_declined", reason: "insufficient_funds" }}
+            />
+          </AiToolCallSection>
+        </AiToolCallContent>
+      </AiToolCall>
+    </div>
+  );
+}

--- a/registry/hirael/examples/approval-workflow-demo.tsx
+++ b/registry/hirael/examples/approval-workflow-demo.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import * as React from "react";
+import { Check, X } from "lucide-react";
+
+import {
+  ApprovalStep,
+  ApprovalStepActions,
+  ApprovalStepComment,
+  ApprovalStepContent,
+  ApprovalStepMarker,
+  ApprovalStepMeta,
+  ApprovalStepTitle,
+  ApprovalWorkflow,
+} from "@/registry/hirael/ui/approval-workflow";
+import { Button } from "@/registry/hirael/ui/button";
+
+type Decision = "current" | "approved" | "rejected";
+
+export default function ApprovalWorkflowDemo() {
+  const [decision, setDecision] = React.useState<Decision>("current");
+
+  return (
+    <div className="grid w-full max-w-xl gap-8">
+      <ApprovalWorkflow>
+        <ApprovalStep status="approved">
+          <ApprovalStepMarker status="approved" />
+          <ApprovalStepContent>
+            <ApprovalStepTitle>Submitted by Dana Okafor</ApprovalStepTitle>
+            <ApprovalStepMeta>
+              <span>Reporter</span>
+              <span>Jun 12, 9:14 AM</span>
+            </ApprovalStepMeta>
+            <ApprovalStepComment>
+              Q2 conference travel. Receipts attached.
+            </ApprovalStepComment>
+          </ApprovalStepContent>
+        </ApprovalStep>
+
+        <ApprovalStep status="approved">
+          <ApprovalStepMarker status="approved" />
+          <ApprovalStepContent>
+            <ApprovalStepTitle>Maya Lindqvist</ApprovalStepTitle>
+            <ApprovalStepMeta>
+              <span>Team lead</span>
+              <span>Jun 12, 2:30 PM</span>
+            </ApprovalStepMeta>
+            <ApprovalStepComment>
+              Looks reasonable, within the team budget.
+            </ApprovalStepComment>
+          </ApprovalStepContent>
+        </ApprovalStep>
+
+        <ApprovalStep status={decision}>
+          <ApprovalStepMarker status={decision} />
+          <ApprovalStepContent>
+            <ApprovalStepTitle>You</ApprovalStepTitle>
+            <ApprovalStepMeta>
+              <span>Finance</span>
+              <span>
+                {decision === "current" ? "Awaiting your review" : "Just now"}
+              </span>
+            </ApprovalStepMeta>
+            {decision === "current" ? (
+              <ApprovalStepActions>
+                <Button size="sm" onClick={() => setDecision("approved")}>
+                  <Check />
+                  Approve
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setDecision("rejected")}
+                >
+                  <X />
+                  Reject
+                </Button>
+              </ApprovalStepActions>
+            ) : (
+              <ApprovalStepComment>
+                {decision === "approved"
+                  ? "Approved. Reimbursement is on the way."
+                  : "Rejected. Please split this across two cost centers."}
+              </ApprovalStepComment>
+            )}
+          </ApprovalStepContent>
+        </ApprovalStep>
+
+        <ApprovalStep status="pending">
+          <ApprovalStepMarker status="pending" />
+          <ApprovalStepContent>
+            <ApprovalStepTitle>Payroll</ApprovalStepTitle>
+            <ApprovalStepMeta>
+              <span>Final payout</span>
+              <span>Pending</span>
+            </ApprovalStepMeta>
+          </ApprovalStepContent>
+        </ApprovalStep>
+      </ApprovalWorkflow>
+
+      <ApprovalWorkflow>
+        <ApprovalStep status="approved">
+          <ApprovalStepMarker status="approved" />
+          <ApprovalStepContent>
+            <ApprovalStepTitle>Priya Raman</ApprovalStepTitle>
+            <ApprovalStepMeta>
+              <span>Author</span>
+              <span>Mar 4, 10:02 AM</span>
+            </ApprovalStepMeta>
+            <ApprovalStepComment>
+              Opened the pull request for the new auth flow.
+            </ApprovalStepComment>
+          </ApprovalStepContent>
+        </ApprovalStep>
+
+        <ApprovalStep status="rejected">
+          <ApprovalStepMarker status="rejected" />
+          <ApprovalStepContent>
+            <ApprovalStepTitle>Theo Marchetti</ApprovalStepTitle>
+            <ApprovalStepMeta>
+              <span>Reviewer</span>
+              <span>Mar 4, 4:48 PM</span>
+            </ApprovalStepMeta>
+            <ApprovalStepComment>
+              Changes requested. The token refresh has a race condition under
+              concurrent requests.
+            </ApprovalStepComment>
+          </ApprovalStepContent>
+        </ApprovalStep>
+
+        <ApprovalStep status="pending">
+          <ApprovalStepMarker status="pending" />
+          <ApprovalStepContent>
+            <ApprovalStepTitle>Security</ApprovalStepTitle>
+            <ApprovalStepMeta>
+              <span>Sign-off</span>
+              <span>Blocked</span>
+            </ApprovalStepMeta>
+          </ApprovalStepContent>
+        </ApprovalStep>
+      </ApprovalWorkflow>
+    </div>
+  );
+}

--- a/registry/hirael/examples/asset-manager-demo.tsx
+++ b/registry/hirael/examples/asset-manager-demo.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import {
+  AssetManager,
+  AssetLibrary,
+  AssetToolbar,
+  AssetGrid,
+  AssetDetail,
+  type Asset,
+} from "@/registry/hirael/ui/asset-manager";
+
+const ASSETS: Asset[] = [
+  {
+    id: "hero-banner",
+    name: "hero-banner.jpg",
+    type: "image",
+    size: 2_412_544,
+    modified: "Jun 14, 2026",
+    dimensions: "2400 × 1350",
+    tags: ["marketing", "hero"],
+  },
+  {
+    id: "brand-guide",
+    name: "brand-guidelines.pdf",
+    type: "document",
+    size: 884_736,
+    modified: "Jun 9, 2026",
+    tags: ["brand"],
+  },
+  {
+    id: "product-tour",
+    name: "product-tour.mp4",
+    type: "video",
+    size: 48_234_496,
+    modified: "Jun 2, 2026",
+    dimensions: "1920 × 1080",
+    tags: ["demo"],
+  },
+  {
+    id: "avatar-grid",
+    name: "avatar-grid.png",
+    type: "image",
+    size: 312_320,
+    modified: "May 28, 2026",
+    dimensions: "800 × 800",
+  },
+  {
+    id: "launch-deck",
+    name: "launch-deck.pdf",
+    type: "document",
+    size: 1_572_864,
+    modified: "May 21, 2026",
+    tags: ["launch", "internal"],
+  },
+  {
+    id: "intro-jingle",
+    name: "intro-jingle.mp3",
+    type: "audio",
+    size: 4_194_304,
+    modified: "May 12, 2026",
+    tags: ["sound"],
+  },
+];
+
+export default function AssetManagerDemo() {
+  return (
+    <div className="grid w-full max-w-3xl gap-8">
+      <AssetManager assets={ASSETS} defaultSelectedId="hero-banner">
+        <AssetLibrary>
+          <AssetToolbar />
+          <AssetGrid />
+        </AssetLibrary>
+        <AssetDetail />
+      </AssetManager>
+
+      <AssetManager assets={ASSETS} defaultView="list">
+        <AssetLibrary>
+          <AssetToolbar searchPlaceholder="Filter by name or tag" />
+          <AssetGrid />
+        </AssetLibrary>
+        <AssetDetail />
+      </AssetManager>
+    </div>
+  );
+}

--- a/registry/hirael/examples/auction-timeline-demo.tsx
+++ b/registry/hirael/examples/auction-timeline-demo.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  AuctionBid,
+  AuctionBidRow,
+  AuctionCountdown,
+  AuctionHeader,
+  AuctionHistory,
+  AuctionStatus,
+  AuctionTimeline,
+  AuctionWinner,
+} from "@/registry/hirael/ui/auction-timeline";
+
+export default function AuctionTimelineDemo() {
+  const [endsAt] = React.useState(() => Date.now() + (7 * 60 + 42) * 1000);
+
+  return (
+    <div className="grid w-full max-w-md gap-8">
+      <AuctionTimeline endsAt={endsAt}>
+        <AuctionHeader>
+          <AuctionBid amount="$2,450" bids={14} />
+          <AuctionStatus state="closing" />
+        </AuctionHeader>
+        <AuctionCountdown />
+        <AuctionHistory>
+          <AuctionBidRow
+            bidder="Mara Okafor"
+            amount="$2,450"
+            time="just now"
+            leading
+          />
+          <AuctionBidRow bidder="Leo Tanaka" amount="$2,300" time="2 min ago" />
+          <AuctionBidRow bidder="Priya Nair" amount="$2,100" time="9 min ago" />
+          <AuctionBidRow
+            bidder="Sam Reyes"
+            amount="$1,900"
+            time="21 min ago"
+          />
+        </AuctionHistory>
+      </AuctionTimeline>
+
+      <AuctionTimeline>
+        <AuctionHeader>
+          <AuctionBid amount="$5,800" bids={31} label="Sold for" />
+          <AuctionStatus state="closed" />
+        </AuctionHeader>
+        <AuctionWinner winner="Devon Hale" amount="$5,800" />
+        <AuctionHistory>
+          <AuctionBidRow
+            bidder="Devon Hale"
+            amount="$5,800"
+            time="Mar 4, 6:01 PM"
+            leading
+          />
+          <AuctionBidRow
+            bidder="Ana Costa"
+            amount="$5,650"
+            time="Mar 4, 5:58 PM"
+          />
+          <AuctionBidRow
+            bidder="Yuki Sato"
+            amount="$5,400"
+            time="Mar 4, 5:44 PM"
+          />
+        </AuctionHistory>
+      </AuctionTimeline>
+    </div>
+  );
+}

--- a/registry/hirael/examples/breadcrumb-generator-demo.tsx
+++ b/registry/hirael/examples/breadcrumb-generator-demo.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { BreadcrumbGenerator } from "@/registry/hirael/ui/breadcrumb-generator";
+
+export default function BreadcrumbGeneratorDemo() {
+  return (
+    <div className="grid w-full max-w-2xl gap-8">
+      <BreadcrumbGenerator
+        showHome
+        items={[
+          { label: "Settings", href: "/settings" },
+          { label: "Billing", href: "/settings/billing" },
+          { label: "Invoices" },
+        ]}
+      />
+
+      <BreadcrumbGenerator
+        path="/docs/components/navigation/breadcrumb/examples/collapsed"
+        basePath="/app"
+        maxItems={3}
+      />
+    </div>
+  );
+}

--- a/registry/hirael/examples/bundle-builder-demo.tsx
+++ b/registry/hirael/examples/bundle-builder-demo.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  BundleBuilder,
+  BundleItems,
+  BundlePicker,
+  BundleSummary,
+  type BundleLine,
+} from "@/registry/hirael/ui/bundle-builder";
+
+const PRODUCTS = [
+  { id: "keyboard", name: "Mechanical Keyboard", price: 129 },
+  { id: "mouse", name: "Wireless Mouse", price: 59 },
+  { id: "mat", name: "Desk Mat", price: 35 },
+  { id: "wrist-rest", name: "Wrist Rest", price: 24 },
+  { id: "hub", name: "USB-C Hub", price: 49 },
+];
+
+const WORKSHOP = [
+  { id: "fundamentals", name: "Fundamentals Course", price: 80 },
+  { id: "advanced", name: "Advanced Course", price: 120 },
+  { id: "templates", name: "Template Pack", price: 40 },
+];
+
+export default function BundleBuilderDemo() {
+  const [lines, setLines] = React.useState<BundleLine[]>([
+    { id: "line-keyboard", productId: "keyboard", quantity: 1 },
+    { id: "line-mouse", productId: "mouse", quantity: 1 },
+    { id: "line-mat", productId: "mat", quantity: 2 },
+  ]);
+
+  return (
+    <div className="grid w-full max-w-xl gap-8">
+      <BundleBuilder
+        products={PRODUCTS}
+        value={lines}
+        onValueChange={setLines}
+        defaultDiscount={10}
+      >
+        <BundlePicker />
+        <BundleItems />
+        <BundleSummary />
+      </BundleBuilder>
+
+      <BundleBuilder products={WORKSHOP} defaultDiscount={15}>
+        <BundlePicker variant="list" />
+        <BundleItems emptyHint="Pick a course to start your bundle." />
+        <BundleSummary />
+      </BundleBuilder>
+    </div>
+  );
+}

--- a/registry/hirael/examples/changelog-viewer-demo.tsx
+++ b/registry/hirael/examples/changelog-viewer-demo.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import {
+  ChangelogEntry,
+  ChangelogItem,
+  ChangelogList,
+  ChangelogSection,
+  ChangelogViewer,
+} from "@/registry/hirael/ui/changelog-viewer";
+
+export default function ChangelogViewerDemo() {
+  return (
+    <div className="grid w-full max-w-2xl gap-8">
+      <ChangelogViewer>
+        <ChangelogEntry
+          version="v1.4.0"
+          date="Jun 12, 2026"
+          title="Saved views and faster search"
+          latest
+        >
+          <ChangelogSection type="added">
+            <ChangelogList>
+              <ChangelogItem>Save any filter set as a named view.</ChangelogItem>
+              <ChangelogItem>Keyboard shortcut to jump to search.</ChangelogItem>
+            </ChangelogList>
+          </ChangelogSection>
+          <ChangelogSection type="changed">
+            <ChangelogList>
+              <ChangelogItem>Search now ranks recent results first.</ChangelogItem>
+            </ChangelogList>
+          </ChangelogSection>
+        </ChangelogEntry>
+
+        <ChangelogEntry version="v1.3.2" date="May 28, 2026">
+          <ChangelogSection type="fixed">
+            <ChangelogList>
+              <ChangelogItem>Date picker no longer skips a day in some time zones.</ChangelogItem>
+              <ChangelogItem>Export keeps the column order you set.</ChangelogItem>
+            </ChangelogList>
+          </ChangelogSection>
+        </ChangelogEntry>
+
+        <ChangelogEntry
+          version="v1.3.0"
+          date="May 9, 2026"
+          title="Team roles"
+        >
+          <ChangelogSection type="added">
+            <ChangelogList>
+              <ChangelogItem>Invite teammates and set per-project roles.</ChangelogItem>
+            </ChangelogList>
+          </ChangelogSection>
+          <ChangelogSection type="fixed">
+            <ChangelogList>
+              <ChangelogItem>Avatars load on slow connections.</ChangelogItem>
+            </ChangelogList>
+          </ChangelogSection>
+        </ChangelogEntry>
+      </ChangelogViewer>
+
+      <ChangelogViewer>
+        <ChangelogEntry
+          version="v2.0.0"
+          date="Jun 18, 2026"
+          title="A new editor"
+          latest
+        >
+          <ChangelogSection type="added">
+            <ChangelogList>
+              <ChangelogItem>Block-based editor with drag to reorder.</ChangelogItem>
+              <ChangelogItem>Slash menu for quick formatting.</ChangelogItem>
+              <ChangelogItem>Inline comments on any block.</ChangelogItem>
+            </ChangelogList>
+          </ChangelogSection>
+          <ChangelogSection type="changed">
+            <ChangelogList>
+              <ChangelogItem>Autosave runs every few seconds instead of on blur.</ChangelogItem>
+              <ChangelogItem>Toolbar moves with your selection.</ChangelogItem>
+            </ChangelogList>
+          </ChangelogSection>
+          <ChangelogSection type="fixed">
+            <ChangelogList>
+              <ChangelogItem>Pasting from Word keeps lists intact.</ChangelogItem>
+            </ChangelogList>
+          </ChangelogSection>
+          <ChangelogSection type="removed">
+            <ChangelogList>
+              <ChangelogItem>The old rich text field is gone. Existing drafts migrate on open.</ChangelogItem>
+            </ChangelogList>
+          </ChangelogSection>
+        </ChangelogEntry>
+      </ChangelogViewer>
+    </div>
+  );
+}

--- a/registry/hirael/examples/command-palette-demo.tsx
+++ b/registry/hirael/examples/command-palette-demo.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import * as React from "react";
+import {
+  HomeIcon,
+  SearchIcon,
+  SettingsIcon,
+  FilePlusIcon,
+  UserPlusIcon,
+  MoonIcon,
+} from "lucide-react";
+
+import { Button } from "@/registry/hirael/ui/button";
+import {
+  CommandPalette,
+  CommandPaletteTrigger,
+  CommandPaletteInput,
+  CommandPaletteList,
+  CommandPaletteEmpty,
+  CommandPaletteGroup,
+  CommandPaletteItem,
+  CommandPaletteSeparator,
+} from "@/registry/hirael/ui/command-palette";
+
+export default function CommandPaletteDemo() {
+  const [open, setOpen] = React.useState(false);
+  const [controlledOpen, setControlledOpen] = React.useState(false);
+  const [ran, setRan] = React.useState<string | null>(null);
+
+  function run(label: string, close: (next: boolean) => void) {
+    setRan(label);
+    close(false);
+  }
+
+  return (
+    <div className="grid w-full max-w-xl gap-8">
+      <div className="grid gap-3">
+        <CommandPaletteTrigger onClick={() => setOpen(true)} />
+        <CommandPalette open={open} onOpenChange={setOpen}>
+          <CommandPaletteInput placeholder="Type a command or search…" />
+          <CommandPaletteList>
+            <CommandPaletteEmpty>No results.</CommandPaletteEmpty>
+            <CommandPaletteGroup heading="Navigation">
+              <CommandPaletteItem
+                icon={<HomeIcon />}
+                onSelect={() => run("Home", setOpen)}
+              >
+                Home
+              </CommandPaletteItem>
+              <CommandPaletteItem
+                icon={<SearchIcon />}
+                shortcut="/"
+                onSelect={() => run("Search", setOpen)}
+              >
+                Search
+              </CommandPaletteItem>
+              <CommandPaletteItem
+                icon={<SettingsIcon />}
+                shortcut="⌘,"
+                onSelect={() => run("Settings", setOpen)}
+              >
+                Settings
+              </CommandPaletteItem>
+            </CommandPaletteGroup>
+            <CommandPaletteSeparator />
+            <CommandPaletteGroup heading="Actions">
+              <CommandPaletteItem
+                icon={<FilePlusIcon />}
+                shortcut="⌘N"
+                onSelect={() => run("New file", setOpen)}
+              >
+                New file
+              </CommandPaletteItem>
+              <CommandPaletteItem
+                icon={<UserPlusIcon />}
+                onSelect={() => run("Invite", setOpen)}
+              >
+                Invite people
+              </CommandPaletteItem>
+              <CommandPaletteItem
+                icon={<MoonIcon />}
+                shortcut="⌘T"
+                onSelect={() => run("Toggle theme", setOpen)}
+              >
+                Toggle theme
+              </CommandPaletteItem>
+            </CommandPaletteGroup>
+          </CommandPaletteList>
+        </CommandPalette>
+        {ran && (
+          <p className="text-sm text-muted-foreground">Ran: {ran}</p>
+        )}
+      </div>
+
+      <div className="grid gap-3">
+        <Button
+          variant="outline"
+          className="w-fit"
+          onClick={() => setControlledOpen(true)}
+        >
+          Open from a button
+        </Button>
+        <CommandPalette open={controlledOpen} onOpenChange={setControlledOpen}>
+          <CommandPaletteInput placeholder="Search files…" />
+          <CommandPaletteList>
+            <CommandPaletteEmpty>No files.</CommandPaletteEmpty>
+            <CommandPaletteGroup heading="Recent">
+              <CommandPaletteItem
+                onSelect={() => run("README.md", setControlledOpen)}
+              >
+                README.md
+              </CommandPaletteItem>
+              <CommandPaletteItem
+                onSelect={() => run("package.json", setControlledOpen)}
+              >
+                package.json
+              </CommandPaletteItem>
+            </CommandPaletteGroup>
+          </CommandPaletteList>
+        </CommandPalette>
+      </div>
+    </div>
+  );
+}

--- a/registry/hirael/examples/diff-viewer-demo.tsx
+++ b/registry/hirael/examples/diff-viewer-demo.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import {
+  DiffViewer,
+  DiffViewerHeader,
+} from "@/registry/hirael/ui/diff-viewer";
+
+const oldConfig = `{
+  "name": "site",
+  "version": "0.6.0",
+  "scripts": {
+    "build": "next build"
+  }
+}`;
+
+const newConfig = `{
+  "name": "site",
+  "version": "0.7.0",
+  "scripts": {
+    "build": "next build",
+    "check": "next lint"
+  }
+}`;
+
+const oldFn = `export function total(items) {
+  let sum = 0;
+  for (const item of items) {
+    sum += item.price;
+  }
+  return sum;
+}`;
+
+const newFn = `export function total(items) {
+  return items.reduce((sum, item) => sum + item.price, 0);
+}`;
+
+export default function DiffViewerDemo() {
+  return (
+    <div className="grid w-full max-w-2xl gap-8">
+      <div className="grid gap-3">
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          Unified
+        </p>
+        <DiffViewer oldText={oldConfig} newText={newConfig} />
+      </div>
+
+      <div className="grid gap-3">
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          Split, with a header
+        </p>
+        <DiffViewer oldText={oldFn} newText={newFn} mode="split">
+          <DiffViewerHeader
+            fileName="lib/total.ts"
+            oldLabel="for loop"
+            newLabel="reduce"
+          />
+        </DiffViewer>
+      </div>
+    </div>
+  );
+}

--- a/registry/hirael/examples/discount-builder-demo.tsx
+++ b/registry/hirael/examples/discount-builder-demo.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  DiscountAddCondition,
+  DiscountBuilder,
+  DiscountConditions,
+  DiscountSummary,
+  DiscountType,
+  DiscountValue,
+  type Discount,
+} from "@/registry/hirael/ui/discount-builder";
+
+export default function DiscountBuilderDemo() {
+  const [basic, setBasic] = React.useState<Discount>({
+    type: "percentage",
+    value: 20,
+    conditions: [
+      {
+        id: "min-order",
+        kind: "min_order",
+        amount: 50,
+        collection: "",
+        start: "",
+        end: "",
+      },
+      {
+        id: "first-order",
+        kind: "first_order",
+        amount: 0,
+        collection: "",
+        start: "",
+        end: "",
+      },
+    ],
+  });
+
+  const [shipping, setShipping] = React.useState<Discount>({
+    type: "free_shipping",
+    value: 0,
+    conditions: [
+      {
+        id: "ship-min",
+        kind: "min_order",
+        amount: 75,
+        collection: "",
+        start: "",
+        end: "",
+      },
+    ],
+  });
+
+  return (
+    <div className="grid w-full max-w-xl gap-8">
+      <DiscountBuilder value={basic} onValueChange={setBasic}>
+        <DiscountType />
+        <DiscountValue />
+        <DiscountConditions />
+        <DiscountAddCondition />
+        <DiscountSummary />
+      </DiscountBuilder>
+
+      <div className="rounded-lg border border-border bg-card p-4">
+        <p className="mb-3 text-sm font-medium text-foreground">Shipping offer</p>
+        <DiscountBuilder
+          value={shipping}
+          onValueChange={setShipping}
+          className="gap-3"
+        >
+          <DiscountType />
+          <DiscountValue />
+          <DiscountConditions emptyHint="Add a spend threshold to qualify." />
+          <DiscountAddCondition variant="ghost">
+            Add a condition
+          </DiscountAddCondition>
+          <DiscountSummary />
+        </DiscountBuilder>
+      </div>
+    </div>
+  );
+}

--- a/registry/hirael/examples/feature-flag-manager-demo.tsx
+++ b/registry/hirael/examples/feature-flag-manager-demo.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import {
+  FeatureFlagItem,
+  FeatureFlagList,
+  FeatureFlagManager,
+  FeatureFlagManagerToolbar,
+  FeatureFlagSwitch,
+  type FeatureFlag,
+} from "@/registry/hirael/ui/feature-flag-manager";
+
+const FLAGS: FeatureFlag[] = [
+  {
+    id: "new-checkout",
+    name: "New checkout",
+    key: "NEW_CHECKOUT",
+    description: "One-page checkout with saved cards.",
+    enabled: true,
+    environments: ["dev", "staging", "prod"],
+    rollout: 25,
+  },
+  {
+    id: "dark-mode",
+    name: "Dark mode",
+    key: "DARK_MODE",
+    description: "System-aware theme switching.",
+    enabled: true,
+    environments: ["dev", "staging", "prod"],
+  },
+  {
+    id: "ai-search",
+    name: "AI search",
+    key: "AI_SEARCH",
+    description: "Semantic search across the catalog.",
+    enabled: false,
+    environments: ["dev", "staging"],
+    rollout: 10,
+  },
+  {
+    id: "bulk-export",
+    name: "Bulk export",
+    key: "BULK_EXPORT",
+    description: "Export reports as CSV in the background.",
+    enabled: false,
+    environments: ["dev"],
+  },
+  {
+    id: "live-collab",
+    name: "Live collaboration",
+    key: "LIVE_COLLAB",
+    description: "Edit documents together in real time.",
+    enabled: true,
+    environments: ["dev", "staging"],
+    rollout: 50,
+  },
+];
+
+const ROW: FeatureFlag = {
+  id: "beta-banner",
+  name: "Beta banner",
+  key: "BETA_BANNER",
+  enabled: true,
+  environments: ["prod"],
+};
+
+export default function FeatureFlagManagerDemo() {
+  return (
+    <div className="grid w-full max-w-2xl gap-8">
+      <FeatureFlagManager defaultValue={FLAGS}>
+        <FeatureFlagManagerToolbar />
+        <FeatureFlagList />
+      </FeatureFlagManager>
+
+      <FeatureFlagManager defaultValue={[ROW]}>
+        <FeatureFlagList>
+          <FeatureFlagItem flag={ROW}>
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <span className="text-sm font-medium text-foreground">
+                {ROW.name}
+              </span>
+              <code className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+                {ROW.key}
+              </code>
+            </div>
+            <FeatureFlagSwitch flag={ROW} className="ms-auto" />
+          </FeatureFlagItem>
+        </FeatureFlagList>
+      </FeatureFlagManager>
+    </div>
+  );
+}

--- a/registry/hirael/examples/file-explorer-demo.tsx
+++ b/registry/hirael/examples/file-explorer-demo.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import {
+  FileExplorer,
+  FileExplorerBreadcrumb,
+  FileExplorerList,
+  FileExplorerSidebar,
+  FileExplorerToolbar,
+  FileExplorerTree,
+  type FileNode,
+} from "@/registry/hirael/ui/file-explorer";
+
+const PROJECT: FileNode = {
+  name: "my-app",
+  type: "folder",
+  children: [
+    {
+      name: "src",
+      type: "folder",
+      children: [
+        {
+          name: "components",
+          type: "folder",
+          children: [
+            {
+              name: "button.tsx",
+              type: "file",
+              size: 2480,
+              modified: "Jun 12",
+            },
+            { name: "card.tsx", type: "file", size: 1920, modified: "Jun 10" },
+            {
+              name: "nav.tsx",
+              type: "file",
+              size: 3640,
+              modified: "Jun 14",
+            },
+          ],
+        },
+        {
+          name: "lib",
+          type: "folder",
+          children: [
+            { name: "utils.ts", type: "file", size: 860, modified: "May 30" },
+            { name: "api.ts", type: "file", size: 4210, modified: "Jun 8" },
+          ],
+        },
+        { name: "app.tsx", type: "file", size: 1240, modified: "Jun 15" },
+        { name: "main.tsx", type: "file", size: 520, modified: "Apr 22" },
+      ],
+    },
+    {
+      name: "public",
+      type: "folder",
+      children: [
+        { name: "favicon.ico", type: "file", size: 15400, modified: "Apr 1" },
+        { name: "logo.svg", type: "file", size: 3120, modified: "May 18" },
+      ],
+    },
+    { name: "package.json", type: "file", size: 1840, modified: "Jun 16" },
+    { name: "README.md", type: "file", size: 2200, modified: "Jun 2" },
+  ],
+};
+
+export default function FileExplorerDemo() {
+  return (
+    <div className="grid w-full max-w-3xl gap-8">
+      <FileExplorer tree={PROJECT} defaultPath={["src"]} className="h-80">
+        <FileExplorerSidebar>
+          <FileExplorerTree />
+        </FileExplorerSidebar>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <FileExplorerToolbar />
+          <FileExplorerList />
+        </div>
+      </FileExplorer>
+
+      <FileExplorer
+        tree={PROJECT}
+        defaultPath={["public"]}
+        defaultView="grid"
+        className="h-80"
+      >
+        <FileExplorerSidebar>
+          <FileExplorerTree />
+        </FileExplorerSidebar>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <FileExplorerToolbar>
+            <FileExplorerBreadcrumb rootLabel="Files" />
+          </FileExplorerToolbar>
+          <FileExplorerList emptyState="Nothing here" />
+        </div>
+      </FileExplorer>
+    </div>
+  );
+}

--- a/registry/hirael/examples/filter-builder-demo.tsx
+++ b/registry/hirael/examples/filter-builder-demo.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  FilterAdd,
+  FilterBuilder,
+  FilterChips,
+  FilterRow,
+  type FilterCondition,
+} from "@/registry/hirael/ui/filter-builder";
+
+const FIELDS = [
+  { name: "status", label: "Status" },
+  { name: "owner", label: "Owner" },
+  { name: "created", label: "Created" },
+];
+
+const PLAN_FIELDS = [
+  { name: "plan", label: "Plan", operators: ["is", "is not"] },
+  { name: "seats", label: "Seats", operators: ["greater than", "less than"] },
+  { name: "email", label: "Email", operators: ["contains", "starts with"] },
+];
+
+export default function FilterBuilderDemo() {
+  const [basic, setBasic] = React.useState<FilterCondition[]>([
+    { id: "row-status", field: "status", operator: "is", value: "Open" },
+  ]);
+
+  const [advanced, setAdvanced] = React.useState<FilterCondition[]>([
+    { id: "row-plan", field: "plan", operator: "is", value: "Pro" },
+    { id: "row-seats", field: "seats", operator: "greater than", value: "10" },
+  ]);
+
+  return (
+    <div className="grid w-full max-w-2xl gap-8">
+      <FilterBuilder fields={FIELDS} value={basic} onValueChange={setBasic}>
+        <FilterChips />
+        {basic.map((condition) => (
+          <FilterRow key={condition.id} condition={condition} />
+        ))}
+        <FilterAdd />
+      </FilterBuilder>
+
+      <div className="rounded-lg border border-border bg-card p-4">
+        <p className="mb-3 text-sm font-medium text-foreground">Audience</p>
+        <FilterBuilder
+          fields={PLAN_FIELDS}
+          value={advanced}
+          onValueChange={setAdvanced}
+          className="gap-4"
+        >
+          {advanced.map((condition) => (
+            <FilterRow key={condition.id} condition={condition} />
+          ))}
+          <FilterAdd variant="ghost">Add condition</FilterAdd>
+          <FilterChips emptyHint="Everyone matches until you add a filter." />
+        </FilterBuilder>
+      </div>
+    </div>
+  );
+}

--- a/registry/hirael/examples/inventory-matrix-demo.tsx
+++ b/registry/hirael/examples/inventory-matrix-demo.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { InventoryMatrix } from "@/registry/hirael/ui/inventory-matrix";
+
+export default function InventoryMatrixDemo() {
+  return (
+    <div className="grid w-full max-w-2xl gap-8">
+      <InventoryMatrix
+        variants={[
+          { id: "s", label: "S" },
+          { id: "m", label: "M" },
+          { id: "l", label: "L" },
+          { id: "xl", label: "XL" },
+        ]}
+        locations={[
+          { id: "berlin", label: "Berlin" },
+          { id: "austin", label: "Austin" },
+          { id: "tokyo", label: "Tokyo" },
+        ]}
+        defaultValue={{
+          s: { berlin: 24, austin: 12, tokyo: 4 },
+          m: { berlin: 40, austin: 31, tokyo: 18 },
+          l: { berlin: 3, austin: 0, tokyo: 9 },
+          xl: { berlin: 0, austin: 2, tokyo: 5 },
+        }}
+      />
+
+      <InventoryMatrix
+        variants={[
+          { id: "sku-101", label: "SKU 101" },
+          { id: "sku-102", label: "SKU 102" },
+        ]}
+        locations={[
+          { id: "shelf", label: "Shelf" },
+          { id: "backroom", label: "Backroom" },
+        ]}
+        lowStockThreshold={10}
+        defaultValue={{
+          "sku-101": { shelf: 6, backroom: 22 },
+          "sku-102": { shelf: 0, backroom: 8 },
+        }}
+      />
+    </div>
+  );
+}

--- a/registry/hirael/examples/json-viewer-demo.tsx
+++ b/registry/hirael/examples/json-viewer-demo.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { JsonViewer } from "@/registry/hirael/ui/json-viewer";
+
+const response = {
+  id: "usr_8f2a",
+  name: "Ada Lovelace",
+  active: true,
+  plan: "pro",
+  seats: 12,
+  trialEndsAt: null,
+  roles: ["owner", "admin"],
+  projects: [
+    { id: "prj_01", name: "Analytics", archived: false },
+    { id: "prj_02", name: "Billing", archived: true },
+  ],
+  settings: {
+    theme: "dark",
+    notifications: { email: true, push: false },
+  },
+};
+
+export default function JsonViewerDemo() {
+  return (
+    <div className="grid w-full max-w-xl gap-8">
+      <JsonViewer data={response} />
+
+      <JsonViewer data={response} rootName="user" defaultExpandedDepth={3} />
+    </div>
+  );
+}

--- a/registry/hirael/examples/kanban-board-demo.tsx
+++ b/registry/hirael/examples/kanban-board-demo.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  KanbanAddCard,
+  KanbanBoard,
+  KanbanCard,
+  KanbanCards,
+  KanbanColumn,
+  KanbanColumnHeader,
+  type KanbanColumnData,
+} from "@/registry/hirael/ui/kanban-board";
+
+const initialBoard: KanbanColumnData[] = [
+  {
+    id: "backlog",
+    title: "Backlog",
+    cards: [
+      { id: "b1", title: "Audit empty states" },
+      { id: "b2", title: "Sketch onboarding flow" },
+      { id: "b3", title: "Collect billing feedback" },
+    ],
+  },
+  {
+    id: "in-progress",
+    title: "In progress",
+    cards: [
+      { id: "p1", title: "Build the registry pipeline" },
+      { id: "p2", title: "Wire up the changelog page" },
+    ],
+  },
+  {
+    id: "review",
+    title: "Review",
+    cards: [{ id: "r1", title: "RTL pass on the date picker" }],
+  },
+  {
+    id: "done",
+    title: "Done",
+    cards: [
+      { id: "d1", title: "Ship the color picker" },
+      { id: "d2", title: "Add the command palette" },
+    ],
+  },
+];
+
+const initialCompact: KanbanColumnData[] = [
+  {
+    id: "todo",
+    title: "To do",
+    cards: [
+      { id: "t1", title: "Reply to support" },
+      { id: "t2", title: "Update the pricing copy" },
+    ],
+  },
+  {
+    id: "shipped",
+    title: "Shipped",
+    cards: [{ id: "s1", title: "Tag the release" }],
+  },
+];
+
+export default function KanbanBoardDemo() {
+  const [board, setBoard] = React.useState(initialBoard);
+  const [compact, setCompact] = React.useState(initialCompact);
+
+  return (
+    <div className="grid w-full max-w-3xl gap-8">
+      <div className="grid gap-4">
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          Sprint board · drag cards or use Prev / Next
+        </p>
+        <KanbanBoard value={board} onValueChange={setBoard}>
+          {board.map((column) => (
+            <KanbanColumn key={column.id} value={column.id}>
+              <KanbanColumnHeader />
+              <KanbanCards>
+                {column.cards.map((card, index) => (
+                  <KanbanCard key={card.id} value={card.id} index={index} />
+                ))}
+              </KanbanCards>
+              <KanbanAddCard />
+            </KanbanColumn>
+          ))}
+        </KanbanBoard>
+      </div>
+
+      <div className="grid gap-4">
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          Compact · two columns, custom card body
+        </p>
+        <KanbanBoard value={compact} onValueChange={setCompact}>
+          {compact.map((column) => (
+            <KanbanColumn key={column.id} value={column.id} className="w-60">
+              <KanbanColumnHeader />
+              <KanbanCards>
+                {column.cards.map((card, index) => (
+                  <KanbanCard key={card.id} value={card.id} index={index}>
+                    <span className="block font-medium">{card.title}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {card.id.toUpperCase()}
+                    </span>
+                  </KanbanCard>
+                ))}
+              </KanbanCards>
+              <KanbanAddCard>New task</KanbanAddCard>
+            </KanbanColumn>
+          ))}
+        </KanbanBoard>
+      </div>
+    </div>
+  );
+}

--- a/registry/hirael/examples/keyboard-shortcuts-demo.tsx
+++ b/registry/hirael/examples/keyboard-shortcuts-demo.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import * as React from "react";
+
+import { Button } from "@/registry/hirael/ui/button";
+import {
+  KeyboardShortcuts,
+  KeyboardShortcutsTrigger,
+  KeyboardShortcutsContent,
+  KeyboardShortcutsSearch,
+  KeyboardShortcutsGroup,
+  KeyboardShortcut,
+} from "@/registry/hirael/ui/keyboard-shortcuts";
+
+export default function KeyboardShortcutsDemo() {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <div className="grid w-full max-w-xl gap-8">
+      <div className="grid gap-3">
+        <KeyboardShortcuts>
+          <KeyboardShortcutsTrigger asChild>
+            <Button variant="outline" className="w-fit">
+              Shortcuts
+            </Button>
+          </KeyboardShortcutsTrigger>
+          <KeyboardShortcutsContent description="Press ? anytime to open this.">
+            <KeyboardShortcutsSearch />
+            <div className="flex max-h-80 flex-col gap-5 overflow-y-auto p-6">
+              <KeyboardShortcutsGroup heading="General">
+                <KeyboardShortcut keys={["?"]}>
+                  Show shortcuts
+                </KeyboardShortcut>
+                <KeyboardShortcut keys={["⌘", "K"]}>
+                  Open command menu
+                </KeyboardShortcut>
+                <KeyboardShortcut keys={["⌘", ","]}>
+                  Open settings
+                </KeyboardShortcut>
+              </KeyboardShortcutsGroup>
+
+              <KeyboardShortcutsGroup heading="Navigation">
+                <KeyboardShortcut keys={["G", "H"]}>Go home</KeyboardShortcut>
+                <KeyboardShortcut keys={["G", "I"]}>
+                  Go to inbox
+                </KeyboardShortcut>
+                <KeyboardShortcut keys={["J"]}>Next item</KeyboardShortcut>
+                <KeyboardShortcut keys={["K"]}>
+                  Previous item
+                </KeyboardShortcut>
+              </KeyboardShortcutsGroup>
+
+              <KeyboardShortcutsGroup heading="Editing">
+                <KeyboardShortcut keys={["⌘", "B"]}>Bold</KeyboardShortcut>
+                <KeyboardShortcut keys={["⌘", "I"]}>Italic</KeyboardShortcut>
+                <KeyboardShortcut keys={["⌘", "Z"]}>Undo</KeyboardShortcut>
+                <KeyboardShortcut keys={["⌘", "⇧", "Z"]}>
+                  Redo
+                </KeyboardShortcut>
+              </KeyboardShortcutsGroup>
+            </div>
+          </KeyboardShortcutsContent>
+        </KeyboardShortcuts>
+      </div>
+
+      <div className="grid gap-3">
+        <Button
+          variant="outline"
+          className="w-fit"
+          onClick={() => setOpen(true)}
+        >
+          Open from a button
+        </Button>
+        <KeyboardShortcuts open={open} onOpenChange={setOpen} hotkey={null}>
+          <KeyboardShortcutsContent title="Quick keys">
+            <div className="flex flex-col gap-5 p-6">
+              <KeyboardShortcutsGroup heading="Files">
+                <KeyboardShortcut keys={["⌘", "N"]}>
+                  New file
+                </KeyboardShortcut>
+                <KeyboardShortcut keys={["⌘", "S"]}>Save</KeyboardShortcut>
+                <KeyboardShortcut keys={["⌘", "P"]}>
+                  Go to file
+                </KeyboardShortcut>
+              </KeyboardShortcutsGroup>
+            </div>
+          </KeyboardShortcutsContent>
+        </KeyboardShortcuts>
+      </div>
+    </div>
+  );
+}

--- a/registry/hirael/examples/log-viewer-demo.tsx
+++ b/registry/hirael/examples/log-viewer-demo.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import {
+  LogLine,
+  LogViewer,
+  LogViewerBody,
+  LogViewerCount,
+  LogViewerLevelFilter,
+  LogViewerLive,
+  LogViewerSearch,
+  LogViewerToolbar,
+} from "@/registry/hirael/ui/log-viewer";
+
+export default function LogViewerDemo() {
+  return (
+    <div className="grid w-full max-w-2xl gap-8">
+      <LogViewer>
+        <LogViewerToolbar>
+          <LogViewerSearch />
+          <LogViewerLevelFilter />
+          <LogViewerCount />
+        </LogViewerToolbar>
+        <LogViewerBody>
+          <LogLine level="info" time="12:04:28">
+            Starting deploy of web@4f9a1c2 to production
+          </LogLine>
+          <LogLine level="debug" time="12:04:28">
+            Resolved 312 packages from lockfile
+          </LogLine>
+          <LogLine level="info" time="12:04:31">
+            Building Next.js app, 14 routes
+          </LogLine>
+          <LogLine level="debug" time="12:04:46">
+            Compiled successfully in 14.2s
+          </LogLine>
+          <LogLine level="warn" time="12:04:47">
+            Large bundle on /dashboard, 248 kB over budget
+          </LogLine>
+          <LogLine level="info" time="12:04:52">
+            Uploading static assets to edge cache
+          </LogLine>
+          <LogLine level="debug" time="12:04:55">
+            Cache hit for 188 of 204 assets
+          </LogLine>
+          <LogLine level="info" time="12:05:01">
+            Running database migrations
+          </LogLine>
+          <LogLine level="warn" time="12:05:02">
+            Migration 0042 took 3.1s, consider a backfill job
+          </LogLine>
+          <LogLine level="error" time="12:05:09">
+            Health check failed on app-2, connection refused
+          </LogLine>
+          <LogLine level="info" time="12:05:14">
+            Retrying health check on app-2
+          </LogLine>
+          <LogLine level="info" time="12:05:18">
+            Deploy complete, all 3 instances healthy
+          </LogLine>
+        </LogViewerBody>
+      </LogViewer>
+
+      <LogViewer live>
+        <LogViewerToolbar>
+          <LogViewerLive />
+          <LogViewerSearch />
+          <LogViewerCount />
+        </LogViewerToolbar>
+        <LogViewerBody wrap>
+          <LogLine level="info" time="12:06:00">
+            Tailing api logs from 3 instances
+          </LogLine>
+          <LogLine level="debug" time="12:06:01">
+            GET /v1/orders 200 in 41ms
+          </LogLine>
+          <LogLine level="debug" time="12:06:01">
+            GET /v1/orders/8821 200 in 12ms
+          </LogLine>
+          <LogLine level="warn" time="12:06:03">
+            Slow query on orders, 820ms, missing index on customer_id
+          </LogLine>
+          <LogLine level="error" time="12:06:04">
+            POST /v1/checkout 500, payment provider timeout after 5s
+          </LogLine>
+          <LogLine level="info" time="12:06:05">
+            Falling back to secondary payment provider
+          </LogLine>
+        </LogViewerBody>
+      </LogViewer>
+    </div>
+  );
+}

--- a/registry/hirael/examples/nested-sortable-demo.tsx
+++ b/registry/hirael/examples/nested-sortable-demo.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  NestedSortable,
+  NestedSortableHandle,
+  NestedSortableItem,
+  NestedSortableLabel,
+  type NestedItem,
+} from "@/registry/hirael/ui/nested-sortable";
+
+const nav: NestedItem[] = [
+  { id: "home", label: "Home" },
+  {
+    id: "products",
+    label: "Products",
+    children: [
+      { id: "components", label: "Components" },
+      { id: "blocks", label: "Blocks" },
+      { id: "templates", label: "Templates" },
+    ],
+  },
+  {
+    id: "docs",
+    label: "Docs",
+    children: [{ id: "getting-started", label: "Getting started" }],
+  },
+  { id: "pricing", label: "Pricing" },
+];
+
+const checklist: NestedItem[] = [
+  {
+    id: "launch",
+    label: "Launch",
+    children: [
+      { id: "copy", label: "Write the copy" },
+      { id: "qa", label: "Run QA" },
+    ],
+  },
+  { id: "announce", label: "Announce" },
+];
+
+function renderRows(items: NestedItem[]): React.ReactNode {
+  return items.map((item) => (
+    <React.Fragment key={item.id}>
+      <NestedSortableItem value={item.id}>
+        <NestedSortableHandle />
+        <NestedSortableLabel>{item.label}</NestedSortableLabel>
+      </NestedSortableItem>
+      {item.children ? renderRows(item.children) : null}
+    </React.Fragment>
+  ));
+}
+
+export default function NestedSortableDemo() {
+  const [menu, setMenu] = React.useState(nav);
+  const [tasks, setTasks] = React.useState(checklist);
+
+  return (
+    <div className="grid w-full max-w-md gap-8">
+      <div className="grid gap-3">
+        <div className="flex flex-col gap-1">
+          <p className="text-sm font-medium">Navigation</p>
+          <p className="text-sm text-muted-foreground">
+            Drag to reorder. Drag sideways, or use the arrow keys, to nest an
+            item under the one above.
+          </p>
+        </div>
+        <NestedSortable value={menu} onValueChange={setMenu}>
+          {renderRows(menu)}
+        </NestedSortable>
+      </div>
+
+      <div className="grid gap-3">
+        <div className="flex flex-col gap-1">
+          <p className="text-sm font-medium">Checklist</p>
+          <p className="text-sm text-muted-foreground">
+            Capped at one level of nesting.
+          </p>
+        </div>
+        <NestedSortable value={tasks} onValueChange={setTasks} maxDepth={1}>
+          {renderRows(tasks)}
+        </NestedSortable>
+      </div>
+    </div>
+  );
+}

--- a/registry/hirael/examples/onboarding-demo.tsx
+++ b/registry/hirael/examples/onboarding-demo.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  Onboarding,
+  OnboardingActions,
+  OnboardingComplete,
+  OnboardingProgress,
+  OnboardingStep,
+  OnboardingStepBody,
+  OnboardingStepDescription,
+  OnboardingStepTitle,
+} from "@/registry/hirael/ui/onboarding";
+
+export default function OnboardingDemo() {
+  return (
+    <div className="grid w-full max-w-md gap-8">
+      <Onboarding>
+        <OnboardingProgress />
+
+        <OnboardingStep value={0}>
+          <OnboardingStepTitle>Welcome to Hirael</OnboardingStepTitle>
+          <OnboardingStepDescription>
+            A few quick steps and your workspace is ready.
+          </OnboardingStepDescription>
+        </OnboardingStep>
+
+        <OnboardingStep value={1}>
+          <OnboardingStepTitle>Set up your profile</OnboardingStepTitle>
+          <OnboardingStepDescription>
+            Add a name and a photo so teammates know who you are.
+          </OnboardingStepDescription>
+          <OnboardingStepBody>
+            <input
+              type="text"
+              placeholder="Full name"
+              className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            />
+          </OnboardingStepBody>
+        </OnboardingStep>
+
+        <OnboardingStep value={2}>
+          <OnboardingStepTitle>Invite your team</OnboardingStepTitle>
+          <OnboardingStepDescription>
+            Work is better together. Add a few people now or later.
+          </OnboardingStepDescription>
+          <OnboardingStepBody>
+            <input
+              type="email"
+              placeholder="name@company.com"
+              className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            />
+          </OnboardingStepBody>
+        </OnboardingStep>
+
+        <OnboardingStep value={3}>
+          <OnboardingStepTitle>You are all set</OnboardingStepTitle>
+          <OnboardingStepDescription>
+            Press Finish to open your new workspace.
+          </OnboardingStepDescription>
+        </OnboardingStep>
+
+        <OnboardingComplete>
+          <OnboardingStepTitle>Workspace ready</OnboardingStepTitle>
+          <OnboardingStepDescription>
+            Everything is set up. Welcome aboard.
+          </OnboardingStepDescription>
+        </OnboardingComplete>
+
+        <OnboardingActions />
+      </Onboarding>
+
+      <Onboarding>
+        <OnboardingProgress variant="bar" />
+
+        <OnboardingStep value={0}>
+          <OnboardingStepTitle>Pick a plan</OnboardingStepTitle>
+          <OnboardingStepDescription>
+            Start free. Upgrade whenever you need more.
+          </OnboardingStepDescription>
+        </OnboardingStep>
+
+        <OnboardingStep value={1}>
+          <OnboardingStepTitle>Confirm details</OnboardingStepTitle>
+          <OnboardingStepDescription>
+            Review your choice, then finish to continue.
+          </OnboardingStepDescription>
+        </OnboardingStep>
+
+        <OnboardingComplete>
+          <OnboardingStepTitle>All done</OnboardingStepTitle>
+          <OnboardingStepDescription>
+            Your plan is active.
+          </OnboardingStepDescription>
+        </OnboardingComplete>
+
+        <OnboardingActions showSkip={false} finishLabel="Done" />
+      </Onboarding>
+    </div>
+  );
+}

--- a/registry/hirael/examples/permission-matrix-demo.tsx
+++ b/registry/hirael/examples/permission-matrix-demo.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import * as React from "react";
+
+import { PermissionMatrix } from "@/registry/hirael/ui/permission-matrix";
+
+const roles = [
+  { id: "viewer", label: "Viewer" },
+  { id: "editor", label: "Editor" },
+  { id: "admin", label: "Admin" },
+];
+
+const permissions = [
+  { id: "members.view", label: "View members", group: "Members" },
+  { id: "members.invite", label: "Invite members", group: "Members" },
+  { id: "members.remove", label: "Remove members", group: "Members" },
+  { id: "billing.view", label: "View invoices", group: "Billing" },
+  { id: "billing.manage", label: "Manage plan", group: "Billing" },
+  { id: "content.publish", label: "Publish content", group: "Content" },
+  { id: "content.delete", label: "Delete content", group: "Content" },
+];
+
+const smallRoles = [
+  { id: "member", label: "Member" },
+  { id: "owner", label: "Owner" },
+];
+
+const smallPermissions = [
+  { id: "read", label: "Read" },
+  { id: "write", label: "Write" },
+  { id: "delete", label: "Delete" },
+];
+
+export default function PermissionMatrixDemo() {
+  const [value, setValue] = React.useState<Record<string, string[]>>({
+    "members.view": ["viewer", "editor", "admin"],
+    "members.invite": ["editor", "admin"],
+    "members.remove": ["admin"],
+    "billing.view": ["admin"],
+    "billing.manage": ["admin"],
+    "content.publish": ["editor", "admin"],
+    "content.delete": ["admin"],
+  });
+
+  return (
+    <div className="grid w-full max-w-2xl gap-8">
+      <PermissionMatrix
+        roles={roles}
+        permissions={permissions}
+        value={value}
+        onValueChange={setValue}
+      />
+
+      <PermissionMatrix
+        roles={smallRoles}
+        permissions={smallPermissions}
+        defaultValue={{ read: ["member", "owner"], write: ["owner"] }}
+        rowToggles
+      />
+    </div>
+  );
+}

--- a/registry/hirael/examples/pricing-rules-builder-demo.tsx
+++ b/registry/hirael/examples/pricing-rules-builder-demo.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  PricingRule,
+  PricingRuleAction,
+  PricingRuleCondition,
+  PricingRuleSummary,
+  PricingRules,
+  PricingRulesAdd,
+  type PricingAction,
+  type PricingField,
+  type PricingRule as PricingRuleValue,
+} from "@/registry/hirael/ui/pricing-rules-builder";
+
+const shippingFields: PricingField[] = [
+  { name: "weight", label: "Weight (kg)", operators: [">=", ">", "<", "<="] },
+  { name: "zone", label: "Zone", operators: ["is", "is not"] },
+];
+
+const shippingActions: PricingAction[] = [
+  { name: "flat-rate", label: "Flat rate", unit: "$" },
+  { name: "percent-off", label: "Percentage off", unit: "%" },
+  { name: "free", label: "Free shipping" },
+];
+
+export default function PricingRulesBuilderDemo() {
+  const [rules, setRules] = React.useState<PricingRuleValue[]>([
+    {
+      id: "rule-volume",
+      field: "quantity",
+      operator: ">=",
+      value: "10",
+      action: "percent-off",
+      actionValue: "15",
+    },
+    {
+      id: "rule-bulk",
+      field: "quantity",
+      operator: ">=",
+      value: "50",
+      action: "price-per-unit",
+      actionValue: "8.50",
+    },
+    {
+      id: "rule-wholesale",
+      field: "customer-group",
+      operator: "is",
+      value: "Wholesale",
+      action: "amount-off",
+      actionValue: "25",
+    },
+  ]);
+
+  const [shipping, setShipping] = React.useState<PricingRuleValue[]>([
+    {
+      id: "ship-heavy",
+      field: "weight",
+      operator: ">=",
+      value: "20",
+      action: "flat-rate",
+      actionValue: "12",
+    },
+  ]);
+
+  return (
+    <div className="grid w-full max-w-2xl gap-8">
+      <div className="grid gap-3">
+        <div className="grid gap-1">
+          <p className="text-sm font-medium text-foreground">Volume pricing</p>
+          <p className="text-xs text-muted-foreground">
+            Rules run top to bottom. The first match wins.
+          </p>
+        </div>
+        <PricingRules value={rules} onValueChange={setRules}>
+          {rules.map((rule, index) => (
+            <PricingRule key={rule.id} rule={rule} index={index} />
+          ))}
+          <PricingRulesAdd />
+        </PricingRules>
+      </div>
+
+      <div className="rounded-lg border border-border bg-card p-4">
+        <p className="mb-3 text-sm font-medium text-foreground">
+          Shipping discounts
+        </p>
+        <PricingRules
+          fields={shippingFields}
+          actions={shippingActions}
+          value={shipping}
+          onValueChange={setShipping}
+          className="gap-4"
+        >
+          {shipping.map((rule) => (
+            <PricingRule key={rule.id} rule={rule}>
+              <div className="mt-3 grid gap-2 rounded-md bg-muted/40 p-2">
+                <PricingRuleSummary className="w-fit" />
+                <PricingRuleCondition label="If" />
+                <PricingRuleAction label="charge" />
+              </div>
+            </PricingRule>
+          ))}
+          <PricingRulesAdd variant="ghost">Add a discount</PricingRulesAdd>
+        </PricingRules>
+      </div>
+    </div>
+  );
+}

--- a/registry/hirael/examples/prompt-editor-demo.tsx
+++ b/registry/hirael/examples/prompt-editor-demo.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import * as React from "react";
+import { Eraser, Sparkles, Wand2 } from "lucide-react";
+
+import {
+  PromptEditor,
+  PromptEditorField,
+  PromptEditorFooter,
+  PromptEditorToolbar,
+  PromptEditorVariable,
+  PromptEditorVariables,
+} from "@/registry/hirael/ui/prompt-editor";
+
+export default function PromptEditorDemo() {
+  const [system, setSystem] = React.useState(
+    "You are a friendly assistant for {{name}}.\nAnswer questions about {{topic}} in two short sentences.",
+  );
+  const [reply, setReply] = React.useState(
+    "Reply to {{customer}} about their {{order_id}} order.",
+  );
+
+  return (
+    <div className="grid w-full max-w-xl gap-8">
+      <div className="grid gap-2">
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          System prompt · controlled
+        </p>
+        <PromptEditor value={system} onValueChange={setSystem}>
+          <PromptEditorField rows={5} placeholder="Write your prompt…" />
+          <PromptEditorVariables label="Insert">
+            <PromptEditorVariable name="name" />
+            <PromptEditorVariable name="topic" />
+            <PromptEditorVariable name="tone" />
+          </PromptEditorVariables>
+          <PromptEditorFooter />
+        </PromptEditor>
+      </div>
+
+      <div className="grid gap-2">
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          With a toolbar and custom footer
+        </p>
+        <PromptEditor value={reply} onValueChange={setReply}>
+          <PromptEditorToolbar>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 rounded-sm px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            >
+              <Sparkles className="size-3.5" />
+              Improve
+            </button>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 rounded-sm px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            >
+              <Wand2 className="size-3.5" />
+              Rephrase
+            </button>
+            <button
+              type="button"
+              onClick={() => setReply("")}
+              className="ms-auto inline-flex items-center gap-1.5 rounded-sm px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            >
+              <Eraser className="size-3.5" />
+              Clear
+            </button>
+          </PromptEditorToolbar>
+          <PromptEditorField rows={4} placeholder="Draft a reply…" />
+          <PromptEditorVariables label="Variables">
+            <PromptEditorVariable name="customer" />
+            <PromptEditorVariable name="order_id" />
+            <PromptEditorVariable name="agent_name" />
+          </PromptEditorVariables>
+          <PromptEditorFooter>
+            <span>Tokens are an estimate.</span>
+            <span className="font-mono">~{Math.ceil(reply.length / 4)}</span>
+          </PromptEditorFooter>
+        </PromptEditor>
+      </div>
+    </div>
+  );
+}

--- a/registry/hirael/examples/query-builder-demo.tsx
+++ b/registry/hirael/examples/query-builder-demo.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  QueryBuilder,
+  type QueryField,
+  type QueryGroupNode,
+} from "@/registry/hirael/ui/query-builder";
+
+const accountFields: QueryField[] = [
+  { name: "status", label: "Status", operators: ["is", "is not"] },
+  { name: "plan", label: "Plan", operators: ["is", "is not"] },
+  {
+    name: "seats",
+    label: "Seats",
+    operators: ["is", "greater than", "less than"],
+  },
+  { name: "country", label: "Country", operators: ["is", "is not"] },
+];
+
+const initialQuery: QueryGroupNode = {
+  id: "root",
+  combinator: "and",
+  rules: [
+    { id: "r1", field: "status", operator: "is", value: "active" },
+    {
+      id: "g1",
+      combinator: "or",
+      rules: [
+        { id: "r2", field: "plan", operator: "is", value: "pro" },
+        { id: "r3", field: "seats", operator: "greater than", value: "10" },
+      ],
+    },
+    { id: "r4", field: "country", operator: "is not", value: "US" },
+  ],
+};
+
+const eventFields: QueryField[] = [
+  { name: "type", label: "Event", operators: ["is", "is not"] },
+  { name: "source", label: "Source", operators: ["is", "contains"] },
+  { name: "date", label: "Date", operators: ["before", "after"] },
+];
+
+export default function QueryBuilderDemo() {
+  const [query, setQuery] = React.useState<QueryGroupNode>(initialQuery);
+
+  return (
+    <div className="grid w-full max-w-2xl gap-8">
+      <div className="grid gap-3">
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          Audience filter
+        </p>
+        <QueryBuilder
+          fields={accountFields}
+          value={query}
+          onValueChange={setQuery}
+        />
+      </div>
+
+      <div className="grid gap-3">
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          Event rules
+        </p>
+        <QueryBuilder fields={eventFields} />
+      </div>
+    </div>
+  );
+}

--- a/registry/hirael/examples/rag-citations-demo.tsx
+++ b/registry/hirael/examples/rag-citations-demo.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import {
+  RagCitations,
+  RagCitationsAnswer,
+  RagCitationMark,
+  RagCitationsSources,
+  RagCitationSource,
+  RagCitationSourceTitle,
+  RagCitationSourceSnippet,
+  RagCitationSourceUrl,
+  RagCitationScore,
+} from "@/registry/hirael/ui/rag-citations";
+
+export default function RagCitationsDemo() {
+  return (
+    <div className="grid w-full max-w-xl gap-8">
+      <RagCitations>
+        <RagCitationsAnswer>
+          <p>
+            The library ships about 70 components and 40 section blocks
+            <RagCitationMark index={1} />. Everything installs through the
+            shadcn registry, so the source lands in your repo instead of a
+            package
+            <RagCitationMark index={2} />. The whole site is a static export
+            with no server at runtime
+            <RagCitationMark index={3} />.
+          </p>
+        </RagCitationsAnswer>
+
+        <RagCitationsSources>
+          <RagCitationSource index={1}>
+            <RagCitationSourceTitle>Catalog overview</RagCitationSourceTitle>
+            <RagCitationSourceSnippet>
+              Around 70 React components, 40 blocks, and full-page templates,
+              grouped by category.
+            </RagCitationSourceSnippet>
+            <RagCitationSourceUrl href="#">
+              hirael.com/docs/catalog
+            </RagCitationSourceUrl>
+          </RagCitationSource>
+
+          <RagCitationSource index={2}>
+            <RagCitationSourceTitle>Install with shadcn</RagCitationSourceTitle>
+            <RagCitationSourceSnippet>
+              Run npx shadcn add to copy a component into your codebase. There
+              is no runtime dependency.
+            </RagCitationSourceSnippet>
+            <RagCitationSourceUrl href="#">
+              hirael.com/docs/install
+            </RagCitationSourceUrl>
+          </RagCitationSource>
+
+          <RagCitationSource index={3}>
+            <RagCitationSourceTitle>Static export</RagCitationSourceTitle>
+            <RagCitationSourceSnippet>
+              The showcase builds to plain HTML. Data is fetched once at build
+              time and frozen into the output.
+            </RagCitationSourceSnippet>
+            <RagCitationSourceUrl href="#">
+              hirael.com/docs/architecture
+            </RagCitationSourceUrl>
+          </RagCitationSource>
+        </RagCitationsSources>
+      </RagCitations>
+
+      <RagCitations>
+        <RagCitationsAnswer className="text-base">
+          <p>
+            Components are built compound-first
+            <RagCitationMark index={1} /> and styled with design tokens, so
+            light and dark both work without extra setup
+            <RagCitationMark index={2} />.
+          </p>
+        </RagCitationsAnswer>
+
+        <RagCitationsSources className="gap-3">
+          <RagCitationSource index={1} className="bg-muted/30">
+            <RagCitationSourceTitle className="flex items-center justify-between gap-2">
+              Compound API
+              <RagCitationScore score="0.94" />
+            </RagCitationSourceTitle>
+            <RagCitationSourceSnippet className="line-clamp-none">
+              A flat set of composable parts. The root holds state, the parts
+              render the slots.
+            </RagCitationSourceSnippet>
+            <RagCitationSourceUrl href="#">
+              hirael.com/docs/conventions
+            </RagCitationSourceUrl>
+          </RagCitationSource>
+
+          <RagCitationSource index={2} className="bg-muted/30">
+            <RagCitationSourceTitle className="flex items-center justify-between gap-2">
+              Design tokens
+              <RagCitationScore score="0.88" />
+            </RagCitationSourceTitle>
+            <RagCitationSourceSnippet className="line-clamp-none">
+              Color comes from CSS variables, never hard-coded values, so themes
+              stay consistent.
+            </RagCitationSourceSnippet>
+            <RagCitationSourceUrl href="#">
+              hirael.com/docs/design
+            </RagCitationSourceUrl>
+          </RagCitationSource>
+        </RagCitationsSources>
+      </RagCitations>
+    </div>
+  );
+}

--- a/registry/hirael/examples/release-notes-demo.tsx
+++ b/registry/hirael/examples/release-notes-demo.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { ArrowRight, Check, Sparkles, Zap } from "lucide-react";
+
+import { Button } from "@/registry/hirael/ui/button";
+import {
+  ReleaseNotes,
+  ReleaseNotesFooter,
+  ReleaseNotesHeader,
+  ReleaseNotesHighlight,
+  ReleaseNotesHighlights,
+  ReleaseNotesSection,
+  ReleaseNotesSummary,
+} from "@/registry/hirael/ui/release-notes";
+
+export default function ReleaseNotesDemo() {
+  return (
+    <div className="grid w-full max-w-xl gap-8">
+      <ReleaseNotes version="v2.0" date="June 18, 2026" title="What's new">
+        <ReleaseNotesSummary>
+          A faster editor, real-time collaboration, and a fresh look across the
+          app.
+        </ReleaseNotesSummary>
+
+        <ReleaseNotesHighlights>
+          <ReleaseNotesHighlight icon={Zap} title="Twice as fast">
+            Pages load in under a second, even on large projects.
+          </ReleaseNotesHighlight>
+          <ReleaseNotesHighlight icon={Sparkles} title="Live collaboration">
+            See teammates' cursors and edits as they happen.
+          </ReleaseNotesHighlight>
+          <ReleaseNotesHighlight icon={Check} title="Redesigned settings">
+            Everything is now one click away from the sidebar.
+          </ReleaseNotesHighlight>
+        </ReleaseNotesHighlights>
+
+        <ReleaseNotesFooter>
+          <Button variant="link" size="sm" className="px-0" asChild>
+            <a href="#">
+              Read the full changelog
+              <ArrowRight className="rtl:rotate-180" />
+            </a>
+          </Button>
+        </ReleaseNotesFooter>
+      </ReleaseNotes>
+
+      <ReleaseNotes className="gap-4 p-5">
+        <ReleaseNotesHeader version="v1.4.2" date="June 11, 2026" />
+        <ReleaseNotesSection label="Fixes">
+          <ReleaseNotesHighlights className="gap-2">
+            <ReleaseNotesHighlight icon={false} title="Export no longer stalls on empty rows." />
+            <ReleaseNotesHighlight icon={false} title="Dark mode now applies to printed pages." />
+          </ReleaseNotesHighlights>
+        </ReleaseNotesSection>
+      </ReleaseNotes>
+    </div>
+  );
+}

--- a/registry/hirael/examples/release-notes-demo.tsx
+++ b/registry/hirael/examples/release-notes-demo.tsx
@@ -27,7 +27,7 @@ export default function ReleaseNotesDemo() {
             Pages load in under a second, even on large projects.
           </ReleaseNotesHighlight>
           <ReleaseNotesHighlight icon={Sparkles} title="Live collaboration">
-            See teammates' cursors and edits as they happen.
+            See cursors and edits from teammates as they happen.
           </ReleaseNotesHighlight>
           <ReleaseNotesHighlight icon={Check} title="Redesigned settings">
             Everything is now one click away from the sidebar.

--- a/registry/hirael/examples/request-builder-demo.tsx
+++ b/registry/hirael/examples/request-builder-demo.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  RequestBar,
+  RequestBody,
+  RequestBodyPre,
+  RequestBuilder,
+  RequestKeyValues,
+  RequestMethod,
+  RequestResponse,
+  RequestSection,
+  RequestSend,
+  RequestStatus,
+  RequestUrl,
+  type RequestKeyValue,
+} from "@/registry/hirael/ui/request-builder";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from "@/registry/hirael/ui/tabs";
+
+type MockResponse = {
+  status: number;
+  time: string;
+  size: string;
+  body: string;
+};
+
+export default function RequestBuilderDemo() {
+  return (
+    <div className="grid w-full max-w-2xl gap-8">
+      <BasicRequest />
+      <BodyRequest />
+    </div>
+  );
+}
+
+function BasicRequest() {
+  const [params, setParams] = React.useState<RequestKeyValue[]>([
+    { id: "param-page", name: "page", value: "1", enabled: true },
+    { id: "param-limit", name: "limit", value: "20", enabled: true },
+  ]);
+  const [headers, setHeaders] = React.useState<RequestKeyValue[]>([
+    { id: "header-accept", name: "Accept", value: "application/json", enabled: true },
+  ]);
+  const [pending, setPending] = React.useState(false);
+  const [response, setResponse] = React.useState<MockResponse | null>(null);
+  const timer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  React.useEffect(() => {
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, []);
+
+  const send = React.useCallback(() => {
+    setPending(true);
+    timer.current = setTimeout(() => {
+      setResponse({
+        status: 200,
+        time: "142 ms",
+        size: "1.1 KB",
+        body: `{
+  "page": 1,
+  "limit": 20,
+  "total": 2,
+  "users": [
+    { "id": "u_01", "name": "Lena Ortiz" },
+    { "id": "u_02", "name": "Sam Bell" }
+  ]
+}`,
+      });
+      setPending(false);
+    }, 600);
+  }, []);
+
+  return (
+    <RequestBuilder defaultMethod="GET" defaultUrl="https://api.example.com/v1/users">
+      <RequestBar>
+        <RequestMethod />
+        <RequestUrl />
+        <RequestSend pending={pending} onClick={send} />
+      </RequestBar>
+
+      <Tabs defaultValue="params" className="px-3">
+        <TabsList className="w-full">
+          <TabsTrigger value="params">Params</TabsTrigger>
+          <TabsTrigger value="headers">Headers</TabsTrigger>
+          <TabsTrigger value="body">Body</TabsTrigger>
+        </TabsList>
+
+        <RequestSection value="params">
+          <RequestKeyValues
+            rows={params}
+            onChange={setParams}
+            addLabel="Add param"
+            namePlaceholder="Key"
+            valuePlaceholder="Value"
+          />
+        </RequestSection>
+
+        <RequestSection value="headers">
+          <RequestKeyValues
+            rows={headers}
+            onChange={setHeaders}
+            addLabel="Add header"
+            namePlaceholder="Header"
+            valuePlaceholder="Value"
+          />
+        </RequestSection>
+
+        <RequestSection value="body">
+          <RequestBody />
+        </RequestSection>
+      </Tabs>
+
+      {response ? (
+        <RequestResponse time={response.time} size={response.size}>
+          <RequestStatus status={response.status} />
+        </RequestResponse>
+      ) : null}
+      {response ? (
+        <div className="px-3 pb-3">
+          <RequestBodyPre>{response.body}</RequestBodyPre>
+        </div>
+      ) : null}
+    </RequestBuilder>
+  );
+}
+
+function BodyRequest() {
+  const [headers, setHeaders] = React.useState<RequestKeyValue[]>([
+    {
+      id: "post-content-type",
+      name: "Content-Type",
+      value: "application/json",
+      enabled: true,
+    },
+  ]);
+  const [pending, setPending] = React.useState(false);
+  const [response, setResponse] = React.useState<MockResponse | null>(null);
+  const timer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  React.useEffect(() => {
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, []);
+
+  const send = React.useCallback(() => {
+    setPending(true);
+    timer.current = setTimeout(() => {
+      setResponse({
+        status: 201,
+        time: "208 ms",
+        size: "312 B",
+        body: `{
+  "id": "u_03",
+  "name": "Ada Reyes",
+  "email": "ada@example.com",
+  "createdAt": "2026-06-18T09:24:00Z"
+}`,
+      });
+      setPending(false);
+    }, 600);
+  }, []);
+
+  return (
+    <RequestBuilder defaultMethod="POST" defaultUrl="https://api.example.com/v1/users">
+      <RequestBar>
+        <RequestMethod />
+        <RequestUrl />
+        <RequestSend pending={pending} onClick={send} />
+      </RequestBar>
+
+      <Tabs defaultValue="body" className="px-3">
+        <TabsList className="w-full">
+          <TabsTrigger value="headers">Headers</TabsTrigger>
+          <TabsTrigger value="body">Body</TabsTrigger>
+        </TabsList>
+
+        <RequestSection value="headers">
+          <RequestKeyValues
+            rows={headers}
+            onChange={setHeaders}
+            addLabel="Add header"
+            namePlaceholder="Header"
+            valuePlaceholder="Value"
+          />
+        </RequestSection>
+
+        <RequestSection value="body">
+          <RequestBody />
+        </RequestSection>
+      </Tabs>
+
+      {response ? (
+        <RequestResponse time={response.time} size={response.size}>
+          <RequestStatus status={response.status} />
+        </RequestResponse>
+      ) : null}
+      {response ? (
+        <div className="px-3 pb-3">
+          <RequestBodyPre>{response.body}</RequestBodyPre>
+        </div>
+      ) : null}
+    </RequestBuilder>
+  );
+}

--- a/registry/hirael/examples/review-queue-demo.tsx
+++ b/registry/hirael/examples/review-queue-demo.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import * as React from "react";
+import { RotateCcw } from "lucide-react";
+
+import { Badge } from "@/registry/hirael/ui/badge";
+import { Button } from "@/registry/hirael/ui/button";
+import {
+  ReviewQueue,
+  ReviewQueueActions,
+  ReviewQueueEmpty,
+  ReviewQueueItem,
+  ReviewQueueProgress,
+  ReviewQueueRemaining,
+} from "@/registry/hirael/ui/review-queue";
+
+type FlaggedComment = {
+  id: string;
+  author: string;
+  handle: string;
+  body: string;
+  reason: string;
+};
+
+const FLAGGED: FlaggedComment[] = [
+  {
+    id: "c1",
+    author: "Mara Quinn",
+    handle: "@maraq",
+    body: "This guide saved me hours. Dropping my referral link below for anyone who wants the same setup.",
+    reason: "Possible spam",
+  },
+  {
+    id: "c2",
+    author: "Dev Okafor",
+    handle: "@devo",
+    body: "Pretty sure half of this is wrong, but whatever, do your own research I guess.",
+    reason: "Low quality",
+  },
+  {
+    id: "c3",
+    author: "Priya Raman",
+    handle: "@priya.r",
+    body: "Following up here since support never replied. Has anyone actually gotten a refund?",
+    reason: "Reported by user",
+  },
+  {
+    id: "c4",
+    author: "Anon",
+    handle: "@throwaway91",
+    body: "Contact me on telegram for cheap keys, link in bio, fast delivery guaranteed.",
+    reason: "Possible spam",
+  },
+  {
+    id: "c5",
+    author: "Lena Hart",
+    handle: "@lenah",
+    body: "Small typo in step 4, the flag should be --prod not --production. Otherwise great.",
+    reason: "Needs a look",
+  },
+];
+
+type AccessRequest = {
+  id: string;
+  requester: string;
+  resource: string;
+  role: string;
+};
+
+const REQUESTS: AccessRequest[] = [
+  {
+    id: "r1",
+    requester: "tomas.vance",
+    resource: "Billing dashboard",
+    role: "Editor",
+  },
+  {
+    id: "r2",
+    requester: "sasha.lin",
+    resource: "Production database",
+    role: "Read only",
+  },
+  {
+    id: "r3",
+    requester: "noah.kerr",
+    resource: "Deploy keys",
+    role: "Admin",
+  },
+];
+
+export default function ReviewQueueDemo() {
+  const [commentRound, setCommentRound] = React.useState(0);
+  const [requestRound, setRequestRound] = React.useState(0);
+
+  return (
+    <div className="grid w-full max-w-xl gap-8">
+      <div className="grid gap-3">
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          Flagged comments · A approve, R reject, S skip
+        </p>
+        <ReviewQueue
+          key={`comments-${commentRound}`}
+          items={FLAGGED}
+          onDecision={(id, decision) => {
+            console.log(decision, id);
+          }}
+        >
+          <ReviewQueueProgress />
+          <ReviewQueueItem>
+            {(comment: FlaggedComment) => (
+              <>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex flex-col">
+                    <span className="text-sm font-medium text-foreground">
+                      {comment.author}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {comment.handle}
+                    </span>
+                  </div>
+                  <Badge variant="outline">{comment.reason}</Badge>
+                </div>
+                <p className="text-sm text-foreground">{comment.body}</p>
+              </>
+            )}
+          </ReviewQueueItem>
+          <ReviewQueueActions />
+          <ReviewQueueEmpty>
+            <p className="text-sm font-medium text-foreground">All clear</p>
+            <p className="text-sm text-muted-foreground">
+              No more comments in the queue.
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setCommentRound((n) => n + 1)}
+            >
+              <RotateCcw aria-hidden className="rtl:rotate-180" />
+              Start over
+            </Button>
+          </ReviewQueueEmpty>
+        </ReviewQueue>
+      </div>
+
+      <div className="grid gap-3">
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          Access requests · grant, deny, or come back later
+        </p>
+        <ReviewQueue
+          key={`requests-${requestRound}`}
+          items={REQUESTS}
+          onDecision={(id, decision) => {
+            console.log(decision, id);
+          }}
+        >
+          <div className="flex items-center justify-between gap-2">
+            <ReviewQueueProgress className="flex-1">
+              {(position, total) => (
+                <>
+                  Request {position} / {total}
+                </>
+              )}
+            </ReviewQueueProgress>
+            <ReviewQueueRemaining />
+          </div>
+          <ReviewQueueItem className="gap-2">
+            {(request: AccessRequest) => (
+              <>
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="font-mono text-sm text-foreground">
+                    {request.requester}
+                  </span>
+                  <Badge variant="secondary">{request.role}</Badge>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  Wants access to{" "}
+                  <span className="text-foreground">{request.resource}</span>
+                </p>
+              </>
+            )}
+          </ReviewQueueItem>
+          <ReviewQueueActions
+            approveLabel="Grant"
+            rejectLabel="Deny"
+            skipLabel="Later"
+          />
+          <ReviewQueueEmpty>
+            <p className="text-sm font-medium text-foreground">
+              Nothing pending
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Every request has an answer.
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setRequestRound((n) => n + 1)}
+            >
+              <RotateCcw aria-hidden className="rtl:rotate-180" />
+              Replay
+            </Button>
+          </ReviewQueueEmpty>
+        </ReviewQueue>
+      </div>
+    </div>
+  );
+}

--- a/registry/hirael/examples/role-manager-demo.tsx
+++ b/registry/hirael/examples/role-manager-demo.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import * as React from "react";
+
+import { RoleManager, type Role } from "@/registry/hirael/ui/role-manager";
+
+const permissions = [
+  { id: "members.view", label: "View members", group: "Members" },
+  { id: "members.invite", label: "Invite members", group: "Members" },
+  { id: "members.remove", label: "Remove members", group: "Members" },
+  { id: "content.publish", label: "Publish content", group: "Content" },
+  { id: "content.delete", label: "Delete content", group: "Content" },
+  { id: "billing.view", label: "View invoices", group: "Billing" },
+  { id: "billing.manage", label: "Manage plan", group: "Billing" },
+];
+
+const roles: Role[] = [
+  {
+    id: "owner",
+    name: "Owner",
+    description: "Full access to everything, including billing.",
+    members: 1,
+    system: true,
+    permissions: permissions.map((permission) => permission.id),
+  },
+  {
+    id: "admin",
+    name: "Admin",
+    description: "Manages members and content.",
+    members: 3,
+    permissions: [
+      "members.view",
+      "members.invite",
+      "members.remove",
+      "content.publish",
+      "content.delete",
+    ],
+  },
+  {
+    id: "editor",
+    name: "Editor",
+    description: "Creates and publishes content.",
+    members: 8,
+    permissions: ["members.view", "content.publish"],
+  },
+  {
+    id: "viewer",
+    name: "Viewer",
+    description: "Read-only access.",
+    members: 24,
+    permissions: ["members.view", "billing.view"],
+  },
+];
+
+const smallPermissions = [
+  { id: "read", label: "Read" },
+  { id: "write", label: "Write" },
+  { id: "delete", label: "Delete" },
+];
+
+const smallRoles: Role[] = [
+  {
+    id: "member",
+    name: "Member",
+    members: 5,
+    permissions: ["read", "write"],
+  },
+  {
+    id: "guest",
+    name: "Guest",
+    members: 2,
+    permissions: ["read"],
+  },
+];
+
+export default function RoleManagerDemo() {
+  return (
+    <div className="grid w-full max-w-3xl gap-8">
+      <RoleManager
+        roles={roles}
+        permissions={permissions}
+        defaultSelectedId="admin"
+      />
+
+      <RoleManager roles={smallRoles} permissions={smallPermissions} />
+    </div>
+  );
+}

--- a/registry/hirael/examples/shipment-tracker-demo.tsx
+++ b/registry/hirael/examples/shipment-tracker-demo.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { Home, Package } from "lucide-react";
+
+import {
+  ShipmentEvent,
+  ShipmentEvents,
+  ShipmentStage,
+  ShipmentStages,
+  ShipmentTracker,
+} from "@/registry/hirael/ui/shipment-tracker";
+
+export default function ShipmentTrackerDemo() {
+  return (
+    <div className="grid w-full max-w-2xl gap-8">
+      <ShipmentTracker orientation="horizontal">
+        <ShipmentStages>
+          <ShipmentStage
+            status="complete"
+            label="Ordered"
+            time="Jun 14"
+            icon={<Package />}
+          />
+          <ShipmentStage status="complete" label="Packed" time="Jun 15" />
+          <ShipmentStage status="complete" label="Shipped" time="Jun 16" />
+          <ShipmentStage
+            status="current"
+            label="Out for delivery"
+            time="Today, 8:02 AM"
+          />
+          <ShipmentStage status="upcoming" label="Delivered" />
+        </ShipmentStages>
+
+        <ShipmentEvents>
+          <ShipmentEvent
+            time="8:02 AM"
+            location="Local depot, Brooklyn"
+            description="Out for delivery on route 12."
+          />
+          <ShipmentEvent
+            time="Jun 16, 6:41 PM"
+            location="Sort facility, Newark"
+            description="Departed the regional hub."
+          />
+          <ShipmentEvent
+            time="Jun 16, 9:10 AM"
+            location="Sort facility, Newark"
+            description="Arrived and scanned."
+          />
+          <ShipmentEvent
+            time="Jun 15, 4:30 PM"
+            location="Warehouse, Edison"
+            description="Package handed to the carrier."
+          />
+        </ShipmentEvents>
+      </ShipmentTracker>
+
+      <ShipmentTracker orientation="vertical">
+        <ShipmentStages>
+          <ShipmentStage
+            status="complete"
+            label="Ordered"
+            time="Jun 9, 11:20 AM"
+            icon={<Package />}
+          />
+          <ShipmentStage
+            status="complete"
+            label="Shipped"
+            time="Jun 10, 2:15 PM"
+          />
+          <ShipmentStage
+            status="complete"
+            label="Out for delivery"
+            time="Jun 12, 7:48 AM"
+          />
+          <ShipmentStage
+            status="complete"
+            label="Delivered"
+            time="Jun 12, 1:06 PM"
+            icon={<Home />}
+          />
+        </ShipmentStages>
+
+        <ShipmentEvents>
+          <ShipmentEvent
+            time="Jun 12, 1:06 PM"
+            location="Front door, Queens"
+            description="Left in a safe spot. Signed by R. Haddad."
+          />
+          <ShipmentEvent
+            time="Jun 12, 7:48 AM"
+            location="Local depot, Queens"
+            description="Out for delivery."
+          />
+          <ShipmentEvent
+            time="Jun 10, 2:15 PM"
+            location="Warehouse, Columbus"
+            description="Shipped from the fulfillment center."
+          />
+        </ShipmentEvents>
+      </ShipmentTracker>
+    </div>
+  );
+}

--- a/registry/hirael/examples/spotlight-search-demo.tsx
+++ b/registry/hirael/examples/spotlight-search-demo.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import * as React from "react";
+import { FileText, Folder, ImageIcon, User } from "lucide-react";
+
+import { Button } from "@/registry/hirael/ui/button";
+import {
+  SpotlightSearch,
+  SpotlightSearchContent,
+  SpotlightSearchEmpty,
+  SpotlightSearchFooter,
+  SpotlightSearchGroup,
+  SpotlightSearchInput,
+  SpotlightSearchItem,
+  SpotlightSearchResults,
+  SpotlightSearchTrigger,
+} from "@/registry/hirael/ui/spotlight-search";
+
+export default function SpotlightSearchDemo() {
+  const [opened, setOpened] = React.useState<string | null>(null);
+  const [controlledOpen, setControlledOpen] = React.useState(false);
+
+  return (
+    <div className="grid w-full max-w-xl gap-8">
+      <div className="grid gap-2">
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          Grouped results · icons · meta tags
+        </p>
+        <SpotlightSearch shortcut={null}>
+          <SpotlightSearchTrigger asChild>
+            <Button variant="outline" className="w-fit">
+              Open search
+            </Button>
+          </SpotlightSearchTrigger>
+          <SpotlightSearchContent>
+            <SpotlightSearchInput placeholder="Search people, projects, files" />
+            <SpotlightSearchResults>
+              <SpotlightSearchGroup heading="People">
+                <SpotlightSearchItem
+                  value="Mona Ali"
+                  icon={<User />}
+                  description="Product design"
+                  meta="Person"
+                  onSelect={() => setOpened("Mona Ali")}
+                >
+                  Mona Ali
+                </SpotlightSearchItem>
+                <SpotlightSearchItem
+                  value="Karim Haddad"
+                  icon={<User />}
+                  description="Engineering"
+                  meta="Person"
+                  onSelect={() => setOpened("Karim Haddad")}
+                >
+                  Karim Haddad
+                </SpotlightSearchItem>
+              </SpotlightSearchGroup>
+
+              <SpotlightSearchGroup heading="Projects">
+                <SpotlightSearchItem
+                  value="Atlas redesign"
+                  icon={<Folder />}
+                  description="Updated 2 hours ago"
+                  meta="Project"
+                  onSelect={() => setOpened("Atlas redesign")}
+                >
+                  Atlas redesign
+                </SpotlightSearchItem>
+                <SpotlightSearchItem
+                  value="Mobile onboarding"
+                  icon={<Folder />}
+                  description="Updated yesterday"
+                  meta="Project"
+                  onSelect={() => setOpened("Mobile onboarding")}
+                >
+                  Mobile onboarding
+                </SpotlightSearchItem>
+              </SpotlightSearchGroup>
+
+              <SpotlightSearchGroup heading="Files">
+                <SpotlightSearchItem
+                  value="Q3 roadmap.pdf"
+                  icon={<FileText />}
+                  description="1.2 MB · PDF"
+                  meta="File"
+                  onSelect={() => setOpened("Q3 roadmap.pdf")}
+                >
+                  Q3 roadmap.pdf
+                </SpotlightSearchItem>
+                <SpotlightSearchItem
+                  value="Brand kit.png"
+                  icon={<ImageIcon />}
+                  description="4.8 MB · Image"
+                  meta="File"
+                  onSelect={() => setOpened("Brand kit.png")}
+                >
+                  Brand kit.png
+                </SpotlightSearchItem>
+              </SpotlightSearchGroup>
+
+              <SpotlightSearchEmpty>No matches</SpotlightSearchEmpty>
+            </SpotlightSearchResults>
+            <SpotlightSearchFooter />
+          </SpotlightSearchContent>
+        </SpotlightSearch>
+        {opened ? (
+          <p
+            data-slot="spotlight-search-demo-result"
+            className="text-sm text-muted-foreground"
+          >
+            Opened: {opened}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="grid gap-2">
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          Controlled open
+        </p>
+        <Button
+          variant="outline"
+          className="w-fit"
+          onClick={() => setControlledOpen(true)}
+        >
+          Search settings
+        </Button>
+        <SpotlightSearch
+          open={controlledOpen}
+          onOpenChange={setControlledOpen}
+          shortcut={null}
+        >
+          <SpotlightSearchContent>
+            <SpotlightSearchInput placeholder="Search settings" />
+            <SpotlightSearchResults>
+              <SpotlightSearchGroup heading="Settings">
+                <SpotlightSearchItem
+                  value="Appearance theme dark light"
+                  description="Theme, accent, density"
+                  meta="General"
+                  onSelect={() => setOpened("Appearance")}
+                >
+                  Appearance
+                </SpotlightSearchItem>
+                <SpotlightSearchItem
+                  value="Notifications email push"
+                  description="Email and push alerts"
+                  meta="General"
+                  onSelect={() => setOpened("Notifications")}
+                >
+                  Notifications
+                </SpotlightSearchItem>
+                <SpotlightSearchItem
+                  value="Members roles access"
+                  description="Roles and access"
+                  meta="Workspace"
+                  onSelect={() => setOpened("Members")}
+                >
+                  Members
+                </SpotlightSearchItem>
+              </SpotlightSearchGroup>
+              <SpotlightSearchEmpty />
+            </SpotlightSearchResults>
+            <SpotlightSearchFooter />
+          </SpotlightSearchContent>
+        </SpotlightSearch>
+      </div>
+    </div>
+  );
+}

--- a/registry/hirael/examples/terminal-demo.tsx
+++ b/registry/hirael/examples/terminal-demo.tsx
@@ -1,0 +1,119 @@
+"use client"
+
+import * as React from "react"
+
+import {
+  Terminal,
+  TerminalBody,
+  TerminalHeader,
+  TerminalInput,
+  TerminalLine,
+  TerminalOutput,
+  TerminalPrompt,
+  useTerminal,
+} from "@/registry/hirael/ui/terminal"
+
+const HELP = `Available commands:
+  help     show this list
+  echo     print the text you pass
+  whoami   print the current user
+  date     print the current time
+  clear    clear the screen`
+
+function WindowShell() {
+  const { clear } = useTerminal()
+
+  function run(input: string): React.ReactNode {
+    const [command, ...rest] = input.trim().split(/\s+/)
+    const args = rest.join(" ")
+
+    switch (command) {
+      case "":
+        return null
+      case "help":
+        return HELP
+      case "echo":
+        return args
+      case "whoami":
+        return "mona"
+      case "date":
+        return new Date().toString()
+      case "clear":
+        clear()
+        return null
+      default:
+        return (
+          <TerminalOutput tone="error">
+            command not found: {command}
+          </TerminalOutput>
+        )
+    }
+  }
+
+  return (
+    <>
+      <TerminalLine>
+        <TerminalPrompt />
+        <span>whoami</span>
+      </TerminalLine>
+      <TerminalOutput>mona</TerminalOutput>
+      <TerminalLine>
+        <TerminalPrompt />
+        <span>echo hello world</span>
+      </TerminalLine>
+      <TerminalOutput>hello world</TerminalOutput>
+      <TerminalOutput tone="muted">Type help to see what works.</TerminalOutput>
+      <TerminalInput onCommand={run} />
+    </>
+  )
+}
+
+function HeadlessShell() {
+  function run(input: string): React.ReactNode {
+    const trimmed = input.trim()
+    if (!trimmed) return null
+    if (trimmed === "ping") return "pong"
+    if (trimmed === "version") return "hirael 1.0.0"
+    return <TerminalOutput tone="muted">No output.</TerminalOutput>
+  }
+
+  return (
+    <>
+      <TerminalLine>
+        <TerminalPrompt symbol="~/app ❯" className="text-accent-foreground" />
+        <span>version</span>
+      </TerminalLine>
+      <TerminalOutput>hirael 1.0.0</TerminalOutput>
+      <TerminalInput prompt="~/app ❯" onCommand={run} />
+    </>
+  )
+}
+
+export default function TerminalDemo() {
+  return (
+    <div className="grid w-full max-w-2xl gap-8">
+      <div className="grid gap-3">
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          Window with a live prompt
+        </p>
+        <Terminal>
+          <TerminalHeader title="zsh — ~/projects/hirael" />
+          <TerminalBody>
+            <WindowShell />
+          </TerminalBody>
+        </Terminal>
+      </div>
+
+      <div className="grid gap-3">
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          Headless, custom prompt
+        </p>
+        <Terminal>
+          <TerminalBody>
+            <HeadlessShell />
+          </TerminalBody>
+        </Terminal>
+      </div>
+    </div>
+  )
+}

--- a/registry/hirael/examples/upload-manager-demo.tsx
+++ b/registry/hirael/examples/upload-manager-demo.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  UploadDropzone,
+  UploadItem,
+  UploadList,
+  UploadManager,
+  UploadSummary,
+  type UploadItem as UploadItemType,
+} from "@/registry/hirael/ui/upload-manager";
+
+const INITIAL: UploadItemType[] = [
+  {
+    id: "demo-photo",
+    name: "team-photo.jpg",
+    size: 2_412_544,
+    progress: 0,
+    status: "uploading",
+  },
+  {
+    id: "demo-deck",
+    name: "q3-roadmap.pdf",
+    size: 8_847_360,
+    progress: 0,
+    status: "uploading",
+  },
+  {
+    id: "demo-export",
+    name: "customers-export.csv",
+    size: 524_288,
+    progress: 100,
+    status: "error",
+  },
+];
+
+export default function UploadManagerDemo() {
+  const [items, setItems] = React.useState<UploadItemType[]>(INITIAL);
+  const seedRef = React.useRef(0);
+
+  React.useEffect(() => {
+    const id = window.setInterval(() => {
+      setItems((current) => {
+        let changed = false;
+        const next = current.map((item) => {
+          if (item.status !== "uploading") return item;
+          changed = true;
+          const progress = Math.min(100, item.progress + 7 + Math.random() * 6);
+          if (progress >= 100) {
+            return { ...item, progress: 100, status: "done" as const };
+          }
+          return { ...item, progress };
+        });
+        return changed ? next : current;
+      });
+    }, 350);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const handleAdd = React.useCallback((files: File[]) => {
+    setItems((current) => [
+      ...current,
+      ...files.map((file) => ({
+        id: `demo-added-${seedRef.current++}`,
+        name: file.name,
+        size: file.size,
+        progress: 0,
+        status: "uploading" as const,
+      })),
+    ]);
+  }, []);
+
+  const cancel = (id: string) =>
+    setItems((current) => current.filter((item) => item.id !== id));
+
+  const remove = (id: string) =>
+    setItems((current) => current.filter((item) => item.id !== id));
+
+  const retry = (id: string) =>
+    setItems((current) =>
+      current.map((item) =>
+        item.id === id
+          ? { ...item, progress: 0, status: "uploading" as const }
+          : item,
+      ),
+    );
+
+  return (
+    <div className="grid w-full max-w-xl gap-8">
+      <div className="grid gap-4">
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          Queue · simulated
+        </p>
+        <UploadManager value={items} onValueChange={setItems}>
+          <UploadSummary />
+          <UploadDropzone
+            onAdd={handleAdd}
+            subline="Up to 25 MB each"
+          />
+          <UploadList empty="Nothing queued yet.">
+            {items.map((item) => (
+              <UploadItem
+                key={item.id}
+                item={item}
+                onCancel={cancel}
+                onRetry={retry}
+                onRemove={remove}
+              />
+            ))}
+          </UploadList>
+        </UploadManager>
+      </div>
+
+      <div className="grid gap-4">
+        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+          Compact · custom summary
+        </p>
+        <UploadManager value={items} onValueChange={setItems}>
+          <UploadSummary>
+            {({ done, total, uploading }) => (
+              <p className="text-sm text-muted-foreground">
+                {uploading > 0
+                  ? `Uploading ${uploading} of ${total}`
+                  : `${done} of ${total} uploaded`}
+              </p>
+            )}
+          </UploadSummary>
+          <UploadDropzone onAdd={handleAdd} headline="Add more files" />
+          <UploadList>
+            {items.map((item) => (
+              <UploadItem
+                key={item.id}
+                item={item}
+                onCancel={cancel}
+                onRetry={retry}
+                onRemove={remove}
+              />
+            ))}
+          </UploadList>
+        </UploadManager>
+      </div>
+    </div>
+  );
+}

--- a/registry/hirael/examples/variant-editor-demo.tsx
+++ b/registry/hirael/examples/variant-editor-demo.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  VariantCount,
+  VariantEditor,
+  VariantOptions,
+  VariantTable,
+  type VariantOption,
+  type VariantRow,
+} from "@/registry/hirael/ui/variant-editor";
+
+type ProductState = { options: VariantOption[]; rows: VariantRow[] };
+
+const PRODUCT: ProductState = {
+  options: [
+    { id: "size", name: "Size", values: ["S", "M", "L"] },
+    { id: "color", name: "Color", values: ["Black", "White"] },
+  ],
+  rows: [
+    {
+      id: "s-black",
+      options: { Size: "S", Color: "Black" },
+      price: "24.00",
+      sku: "TEE-S-BLK",
+      stock: "40",
+    },
+    {
+      id: "s-white",
+      options: { Size: "S", Color: "White" },
+      price: "24.00",
+      sku: "TEE-S-WHT",
+      stock: "32",
+    },
+    {
+      id: "m-black",
+      options: { Size: "M", Color: "Black" },
+      price: "26.00",
+      sku: "TEE-M-BLK",
+      stock: "55",
+    },
+    {
+      id: "m-white",
+      options: { Size: "M", Color: "White" },
+      price: "26.00",
+      sku: "TEE-M-WHT",
+      stock: "48",
+    },
+    {
+      id: "l-black",
+      options: { Size: "L", Color: "Black" },
+      price: "28.00",
+      sku: "TEE-L-BLK",
+      stock: "20",
+    },
+    {
+      id: "l-white",
+      options: { Size: "L", Color: "White" },
+      price: "28.00",
+      sku: "TEE-L-WHT",
+      stock: "18",
+    },
+  ],
+};
+
+const PLAN: ProductState = {
+  options: [{ id: "tier", name: "Tier", values: ["Monthly", "Yearly"] }],
+  rows: [
+    {
+      id: "tier-monthly",
+      options: { Tier: "Monthly" },
+      price: "12.00",
+      sku: "PLAN-M",
+      stock: "",
+    },
+    {
+      id: "tier-yearly",
+      options: { Tier: "Yearly" },
+      price: "120.00",
+      sku: "PLAN-Y",
+      stock: "",
+    },
+  ],
+};
+
+export default function VariantEditorDemo() {
+  const [product, setProduct] = React.useState(PRODUCT);
+  const [plan, setPlan] = React.useState(PLAN);
+
+  return (
+    <div className="grid w-full max-w-2xl gap-8">
+      <VariantEditor value={product} onValueChange={setProduct}>
+        <VariantOptions />
+        <VariantCount />
+        <VariantTable />
+      </VariantEditor>
+
+      <div className="rounded-lg border border-border bg-card p-4">
+        <p className="mb-3 text-sm font-medium text-foreground">Billing plan</p>
+        <VariantEditor value={plan} onValueChange={setPlan}>
+          <VariantOptions addLabel="Add axis" />
+          <VariantCount>
+            {(count) => `${count} price ${count === 1 ? "point" : "points"}`}
+          </VariantCount>
+          <VariantTable emptyHint="Add a tier to set prices." />
+        </VariantEditor>
+      </div>
+    </div>
+  );
+}

--- a/registry/hirael/examples/vendor-comparison-demo.tsx
+++ b/registry/hirael/examples/vendor-comparison-demo.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { VendorComparison } from "@/registry/hirael/ui/vendor-comparison";
+
+const vendors = [
+  { id: "starter", name: "Starter" },
+  { id: "team", name: "Team", recommended: true },
+  { id: "scale", name: "Scale" },
+];
+
+const features = [
+  {
+    id: "seats",
+    label: "Seats",
+    group: "Plan",
+    values: { starter: "3", team: "25", scale: "Unlimited" },
+  },
+  {
+    id: "history",
+    label: "History",
+    group: "Plan",
+    values: { starter: "30 days", team: "1 year", scale: "Forever" },
+  },
+  {
+    id: "sso",
+    label: "Single sign-on",
+    group: "Security",
+    values: { starter: false, team: true, scale: true },
+  },
+  {
+    id: "audit",
+    label: "Audit log",
+    group: "Security",
+    values: { starter: false, team: true, scale: true },
+  },
+  {
+    id: "roles",
+    label: "Custom roles",
+    group: "Security",
+    values: { starter: false, team: false, scale: true },
+  },
+  {
+    id: "support",
+    label: "Priority support",
+    group: "Support",
+    values: { starter: false, team: true, scale: true },
+  },
+];
+
+const smallVendors = [
+  { id: "free", name: "Free" },
+  { id: "pro", name: "Pro", recommended: true },
+];
+
+const smallFeatures = [
+  {
+    id: "projects",
+    label: "Projects",
+    values: { free: "1", pro: "10" },
+  },
+  {
+    id: "analytics",
+    label: "Analytics",
+    values: { free: false, pro: true },
+  },
+  {
+    id: "export",
+    label: "Data export",
+    values: { free: false, pro: true },
+  },
+];
+
+export default function VendorComparisonDemo() {
+  return (
+    <div className="grid w-full max-w-2xl gap-8">
+      <VendorComparison vendors={vendors} features={features} />
+
+      <VendorComparison vendors={smallVendors} features={smallFeatures} />
+    </div>
+  );
+}

--- a/registry/hirael/registry-demos.tsx
+++ b/registry/hirael/registry-demos.tsx
@@ -243,6 +243,27 @@ const EXAMPLE_LOADERS: Record<
     import("@/registry/hirael/examples/agent-workflow-demo"),
   "rag-citations-demo": () =>
     import("@/registry/hirael/examples/rag-citations-demo"),
+  "query-builder-demo": () =>
+    import("@/registry/hirael/examples/query-builder-demo"),
+  "filter-builder-demo": () =>
+    import("@/registry/hirael/examples/filter-builder-demo"),
+  "permission-matrix-demo": () =>
+    import("@/registry/hirael/examples/permission-matrix-demo"),
+  "approval-workflow-demo": () =>
+    import("@/registry/hirael/examples/approval-workflow-demo"),
+  "json-viewer-demo": () =>
+    import("@/registry/hirael/examples/json-viewer-demo"),
+  "diff-viewer-demo": () =>
+    import("@/registry/hirael/examples/diff-viewer-demo"),
+  "log-viewer-demo": () =>
+    import("@/registry/hirael/examples/log-viewer-demo"),
+  "request-builder-demo": () =>
+    import("@/registry/hirael/examples/request-builder-demo"),
+  "terminal-demo": () => import("@/registry/hirael/examples/terminal-demo"),
+  "command-palette-demo": () =>
+    import("@/registry/hirael/examples/command-palette-demo"),
+  "spotlight-search-demo": () =>
+    import("@/registry/hirael/examples/spotlight-search-demo"),
 };
 
 // React.lazy defers the import until first render, so building every preview

--- a/registry/hirael/registry-demos.tsx
+++ b/registry/hirael/registry-demos.tsx
@@ -264,6 +264,18 @@ const EXAMPLE_LOADERS: Record<
     import("@/registry/hirael/examples/command-palette-demo"),
   "spotlight-search-demo": () =>
     import("@/registry/hirael/examples/spotlight-search-demo"),
+  "discount-builder-demo": () =>
+    import("@/registry/hirael/examples/discount-builder-demo"),
+  "bundle-builder-demo": () =>
+    import("@/registry/hirael/examples/bundle-builder-demo"),
+  "vendor-comparison-demo": () =>
+    import("@/registry/hirael/examples/vendor-comparison-demo"),
+  "inventory-matrix-demo": () =>
+    import("@/registry/hirael/examples/inventory-matrix-demo"),
+  "variant-editor-demo": () =>
+    import("@/registry/hirael/examples/variant-editor-demo"),
+  "pricing-rules-builder-demo": () =>
+    import("@/registry/hirael/examples/pricing-rules-builder-demo"),
 };
 
 // React.lazy defers the import until first render, so building every preview

--- a/registry/hirael/registry-demos.tsx
+++ b/registry/hirael/registry-demos.tsx
@@ -276,6 +276,20 @@ const EXAMPLE_LOADERS: Record<
     import("@/registry/hirael/examples/variant-editor-demo"),
   "pricing-rules-builder-demo": () =>
     import("@/registry/hirael/examples/pricing-rules-builder-demo"),
+  "upload-manager-demo": () =>
+    import("@/registry/hirael/examples/upload-manager-demo"),
+  "file-explorer-demo": () =>
+    import("@/registry/hirael/examples/file-explorer-demo"),
+  "asset-manager-demo": () =>
+    import("@/registry/hirael/examples/asset-manager-demo"),
+  "kanban-board-demo": () =>
+    import("@/registry/hirael/examples/kanban-board-demo"),
+  "nested-sortable-demo": () =>
+    import("@/registry/hirael/examples/nested-sortable-demo"),
+  "shipment-tracker-demo": () =>
+    import("@/registry/hirael/examples/shipment-tracker-demo"),
+  "auction-timeline-demo": () =>
+    import("@/registry/hirael/examples/auction-timeline-demo"),
 };
 
 // React.lazy defers the import until first render, so building every preview

--- a/registry/hirael/registry-demos.tsx
+++ b/registry/hirael/registry-demos.tsx
@@ -290,6 +290,23 @@ const EXAMPLE_LOADERS: Record<
     import("@/registry/hirael/examples/shipment-tracker-demo"),
   "auction-timeline-demo": () =>
     import("@/registry/hirael/examples/auction-timeline-demo"),
+  "review-queue-demo": () =>
+    import("@/registry/hirael/examples/review-queue-demo"),
+  "role-manager-demo": () =>
+    import("@/registry/hirael/examples/role-manager-demo"),
+  "feature-flag-manager-demo": () =>
+    import("@/registry/hirael/examples/feature-flag-manager-demo"),
+  "keyboard-shortcuts-demo": () =>
+    import("@/registry/hirael/examples/keyboard-shortcuts-demo"),
+  "onboarding-demo": () => import("@/registry/hirael/examples/onboarding-demo"),
+  "breadcrumb-generator-demo": () =>
+    import("@/registry/hirael/examples/breadcrumb-generator-demo"),
+  "advanced-search-bar-demo": () =>
+    import("@/registry/hirael/examples/advanced-search-bar-demo"),
+  "changelog-viewer-demo": () =>
+    import("@/registry/hirael/examples/changelog-viewer-demo"),
+  "release-notes-demo": () =>
+    import("@/registry/hirael/examples/release-notes-demo"),
 };
 
 // React.lazy defers the import until first render, so building every preview

--- a/registry/hirael/registry-demos.tsx
+++ b/registry/hirael/registry-demos.tsx
@@ -232,6 +232,17 @@ const EXAMPLE_LOADERS: Record<
   "usage-dashboard-demo": () =>
     import("@/registry/hirael/examples/usage-dashboard-demo"),
   "toc-demo": () => import("@/registry/hirael/examples/toc-demo"),
+  "ai-chat-demo": () => import("@/registry/hirael/examples/ai-chat-demo"),
+  "prompt-editor-demo": () =>
+    import("@/registry/hirael/examples/prompt-editor-demo"),
+  "ai-completion-input-demo": () =>
+    import("@/registry/hirael/examples/ai-completion-input-demo"),
+  "ai-tool-call-demo": () =>
+    import("@/registry/hirael/examples/ai-tool-call-demo"),
+  "agent-workflow-demo": () =>
+    import("@/registry/hirael/examples/agent-workflow-demo"),
+  "rag-citations-demo": () =>
+    import("@/registry/hirael/examples/rag-citations-demo"),
 };
 
 // React.lazy defers the import until first render, so building every preview

--- a/registry/hirael/registry-meta.ts
+++ b/registry/hirael/registry-meta.ts
@@ -3,6 +3,7 @@ export type ComponentCategory =
   | "pickers"
   | "files"
   | "data"
+  | "ai"
   | "display"
   | "animation"
   | "navigation"
@@ -2285,6 +2286,66 @@ export const REGISTRY: RegistryEntryMeta[] = [
     registryDependencies: ["card", "chart", "empty", "tooltip", "button"],
     dependencies: ["recharts", "lucide-react"],
   },
+  {
+    name: "ai-chat",
+    title: "AI Chat",
+    description:
+      "Chat thread for AI products: role-aligned bubbles, avatars, a typing indicator, message actions and an auto-growing composer. Compound API.",
+    category: "ai",
+    files: [{ path: "registry/hirael/ui/ai-chat.tsx" }],
+    registryDependencies: ["button"],
+    dependencies: ["class-variance-authority"],
+  },
+  {
+    name: "prompt-editor",
+    title: "Prompt Editor",
+    description:
+      "Prompt template editor that highlights {{variable}} tokens live, inserts them from a chip row, and counts characters and approximate tokens. Compound API.",
+    category: "ai",
+    files: [{ path: "registry/hirael/ui/prompt-editor.tsx" }],
+    registryDependencies: [],
+    dependencies: [],
+  },
+  {
+    name: "ai-completion-input",
+    title: "AI Completion Input",
+    description:
+      "Text field with an inline ghost completion you accept with Tab. The suggestion is supplied by you, so nothing calls a model. Compound API.",
+    category: "ai",
+    files: [{ path: "registry/hirael/ui/ai-completion-input.tsx" }],
+    registryDependencies: [],
+    dependencies: [],
+  },
+  {
+    name: "ai-tool-call",
+    title: "AI Tool Call",
+    description:
+      "Collapsible view of an LLM tool call: function name, pending / done / error status and pretty-printed argument and result JSON. Compound API.",
+    category: "ai",
+    files: [{ path: "registry/hirael/ui/ai-tool-call.tsx" }],
+    registryDependencies: ["collapsible"],
+    dependencies: ["class-variance-authority", "lucide-react"],
+  },
+  {
+    name: "agent-workflow",
+    title: "Agent Workflow",
+    description:
+      "Rail-connected trace of an agent run: thought, tool and output steps with done / running / error status and expandable detail. Compound API.",
+    category: "ai",
+    files: [{ path: "registry/hirael/ui/agent-workflow.tsx" }],
+    registryDependencies: [],
+    dependencies: ["class-variance-authority", "lucide-react"],
+  },
+  {
+    name: "rag-citations",
+    title: "RAG Citations",
+    description:
+      "Grounded answer with inline citation markers that cross-link to source cards showing title, snippet, url and relevance. Compound API.",
+    category: "ai",
+    files: [{ path: "registry/hirael/ui/rag-citations.tsx" }],
+    registryDependencies: [],
+    dependencies: ["lucide-react"],
+  },
 ];
 
 /**
@@ -2338,6 +2399,7 @@ export const CATEGORY_LABELS: Record<ComponentCategory, string> = {
   pickers: "Pickers",
   files: "Files",
   data: "Data display",
+  ai: "AI",
   display: "Display",
   animation: "Animation",
   navigation: "Navigation",
@@ -2353,6 +2415,7 @@ export const REGISTRY_BY_CATEGORY = (() => {
     pickers: [],
     files: [],
     data: [],
+    ai: [],
     display: [],
     animation: [],
     navigation: [],
@@ -2483,6 +2546,7 @@ export const COMPONENT_CATEGORY_ORDER: Exclude<
   "pickers",
   "files",
   "data",
+  "ai",
   "display",
   "animation",
   "navigation",
@@ -2501,6 +2565,7 @@ export const COMPONENT_CATEGORY_DESCRIPTIONS: Record<
     "Date, time, month, year and color pickers with keyboard navigation and no date library.",
   files: "Upload zones, image croppers and local media pickers.",
   data: "Feeds, timelines, trees, heatmaps and other ways to show structured data.",
+  ai: "Chat threads, prompt editors, tool-call and agent-run views, and citation UIs for AI products.",
   display:
     "Callouts, code blocks, marquees, lightboxes and other visual helpers.",
   animation:

--- a/registry/hirael/registry-meta.ts
+++ b/registry/hirael/registry-meta.ts
@@ -5,6 +5,7 @@ export type ComponentCategory =
   | "data"
   | "ai"
   | "dev"
+  | "commerce"
   | "display"
   | "animation"
   | "navigation"
@@ -2457,6 +2458,66 @@ export const REGISTRY: RegistryEntryMeta[] = [
     registryDependencies: ["dialog", "kbd"],
     dependencies: ["lucide-react"],
   },
+  {
+    name: "discount-builder",
+    title: "Discount Builder",
+    description:
+      "Configure a store discount: percentage, fixed amount or free shipping, with optional conditions and a live summary. Compound API.",
+    category: "commerce",
+    files: [{ path: "registry/hirael/ui/discount-builder.tsx" }],
+    registryDependencies: ["badge", "button", "input", "select"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "bundle-builder",
+    title: "Bundle Builder",
+    description:
+      "Assemble a product bundle from a catalog with quantity steppers, a bundle discount and live savings versus buying separately. Compound API.",
+    category: "commerce",
+    files: [{ path: "registry/hirael/ui/bundle-builder.tsx" }],
+    registryDependencies: ["badge", "button", "input", "select"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "vendor-comparison",
+    title: "Vendor Comparison",
+    description:
+      "Compare vendors or plans across grouped features with boolean, text and rating cells, a sticky feature column and a recommended column. Compound API.",
+    category: "commerce",
+    files: [{ path: "registry/hirael/ui/vendor-comparison.tsx" }],
+    registryDependencies: ["badge"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "inventory-matrix",
+    title: "Inventory Matrix",
+    description:
+      "Editable stock grid of variants by location with row and column totals and low-stock and out-of-stock highlighting. Compound API.",
+    category: "commerce",
+    files: [{ path: "registry/hirael/ui/inventory-matrix.tsx" }],
+    registryDependencies: ["input"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "variant-editor",
+    title: "Variant Editor",
+    description:
+      "Define product option axes and edit the generated variant rows (price, SKU, stock); editing options regenerates rows and keeps existing data. Compound API.",
+    category: "commerce",
+    files: [{ path: "registry/hirael/ui/variant-editor.tsx" }],
+    registryDependencies: ["badge", "button", "input"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "pricing-rules-builder",
+    title: "Pricing Rules Builder",
+    description:
+      "Build top-down conditional pricing rules of the form when condition then price action, each with a live summary. Compound API.",
+    category: "commerce",
+    files: [{ path: "registry/hirael/ui/pricing-rules-builder.tsx" }],
+    registryDependencies: ["badge", "button", "input", "select"],
+    dependencies: ["lucide-react"],
+  },
 ];
 
 /**
@@ -2512,6 +2573,7 @@ export const CATEGORY_LABELS: Record<ComponentCategory, string> = {
   data: "Data display",
   ai: "AI",
   dev: "Developer",
+  commerce: "Commerce",
   display: "Display",
   animation: "Animation",
   navigation: "Navigation",
@@ -2529,6 +2591,7 @@ export const REGISTRY_BY_CATEGORY = (() => {
     data: [],
     ai: [],
     dev: [],
+    commerce: [],
     display: [],
     animation: [],
     navigation: [],
@@ -2661,6 +2724,7 @@ export const COMPONENT_CATEGORY_ORDER: Exclude<
   "data",
   "ai",
   "dev",
+  "commerce",
   "display",
   "animation",
   "navigation",
@@ -2681,6 +2745,8 @@ export const COMPONENT_CATEGORY_DESCRIPTIONS: Record<
   data: "Feeds, timelines, trees, heatmaps and other ways to show structured data.",
   ai: "Chat threads, prompt editors, tool-call and agent-run views, and citation UIs for AI products.",
   dev: "Developer tools: JSON and diff viewers, a log stream, a terminal and an HTTP request builder.",
+  commerce:
+    "Storefront and catalog tooling: variant and pricing editors, inventory, bundles, discounts and vendor comparison.",
   display:
     "Callouts, code blocks, marquees, lightboxes and other visual helpers.",
   animation:

--- a/registry/hirael/registry-meta.ts
+++ b/registry/hirael/registry-meta.ts
@@ -2518,6 +2518,76 @@ export const REGISTRY: RegistryEntryMeta[] = [
     registryDependencies: ["badge", "button", "input", "select"],
     dependencies: ["lucide-react"],
   },
+  {
+    name: "upload-manager",
+    title: "Upload Manager",
+    description:
+      "Upload queue with per-file progress, status and retry, cancel and remove actions, plus an overall progress summary. Compound API.",
+    category: "files",
+    files: [{ path: "registry/hirael/ui/upload-manager.tsx" }],
+    registryDependencies: ["button", "progress"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "file-explorer",
+    title: "File Explorer",
+    description:
+      "Two-pane file browser: a collapsible folder tree, a breadcrumb path and a list or grid of the current folder's contents. Compound API.",
+    category: "files",
+    files: [{ path: "registry/hirael/ui/file-explorer.tsx" }],
+    registryDependencies: ["breadcrumb", "button"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "asset-manager",
+    title: "Asset Manager",
+    description:
+      "Media library with a thumbnail grid or list, search, multi-select and a detail inspector showing the selected asset's preview and metadata. Compound API.",
+    category: "files",
+    files: [{ path: "registry/hirael/ui/asset-manager.tsx" }],
+    registryDependencies: ["badge", "button"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "kanban-board",
+    title: "Kanban Board",
+    description:
+      "Column board with cards you drag between and within columns (native DnD, no library) plus keyboard move actions. Controlled board value. Compound API.",
+    category: "data",
+    files: [{ path: "registry/hirael/ui/kanban-board.tsx" }],
+    registryDependencies: ["badge", "button"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "nested-sortable",
+    title: "Nested Sortable",
+    description:
+      "Drag-to-reorder outline with nesting: indent and outdent items into a real tree, with pointer and keyboard control and live-region announcements. Compound API.",
+    category: "data",
+    files: [{ path: "registry/hirael/ui/nested-sortable.tsx" }],
+    registryDependencies: ["button"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "shipment-tracker",
+    title: "Shipment Tracker",
+    description:
+      "Order delivery stages as a connected progress stepper with timestamps and a live current stage, plus an event history list. Compound API.",
+    category: "data",
+    files: [{ path: "registry/hirael/ui/shipment-tracker.tsx" }],
+    registryDependencies: [],
+    dependencies: ["class-variance-authority", "lucide-react"],
+  },
+  {
+    name: "auction-timeline",
+    title: "Auction Timeline",
+    description:
+      "Live auction panel with the leading bid, a countdown to close, a live status and a bid-history timeline; shows the winner once closed. Compound API.",
+    category: "data",
+    files: [{ path: "registry/hirael/ui/auction-timeline.tsx" }],
+    registryDependencies: ["badge"],
+    dependencies: ["lucide-react"],
+  },
 ];
 
 /**

--- a/registry/hirael/registry-meta.ts
+++ b/registry/hirael/registry-meta.ts
@@ -2588,6 +2588,96 @@ export const REGISTRY: RegistryEntryMeta[] = [
     registryDependencies: ["badge"],
     dependencies: ["lucide-react"],
   },
+  {
+    name: "review-queue",
+    title: "Review Queue",
+    description:
+      "Work a moderation queue one item at a time with approve, reject and skip actions, keyboard shortcuts, progress and a done state. Compound API.",
+    category: "saas",
+    files: [{ path: "registry/hirael/ui/review-queue.tsx" }],
+    registryDependencies: ["badge", "button", "kbd"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "role-manager",
+    title: "Role Manager",
+    description:
+      "Two-pane role admin: a role list with add, duplicate and delete, and a grouped permission checklist for the selected role; system roles are read-only. Compound API.",
+    category: "saas",
+    files: [{ path: "registry/hirael/ui/role-manager.tsx" }],
+    registryDependencies: ["badge", "button", "checkbox"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "feature-flag-manager",
+    title: "Feature Flag Manager",
+    description:
+      "Searchable list of feature flags with key, description, environment tags, rollout percentage and an accessible on/off toggle. Compound API.",
+    category: "saas",
+    files: [{ path: "registry/hirael/ui/feature-flag-manager.tsx" }],
+    registryDependencies: ["badge"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "keyboard-shortcuts",
+    title: "Keyboard Shortcuts",
+    description:
+      "Shortcuts cheat-sheet dialog opened with the ? key, grouped by area with searchable rows and keys rendered as keycaps. Compound API.",
+    category: "navigation",
+    files: [{ path: "registry/hirael/ui/keyboard-shortcuts.tsx" }],
+    registryDependencies: ["dialog", "kbd"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "onboarding",
+    title: "Onboarding",
+    description:
+      "Multi-step onboarding wizard with a progress header, per-step panels, back, skip and next, and a completion state. Compound API.",
+    category: "navigation",
+    files: [{ path: "registry/hirael/ui/onboarding.tsx" }],
+    registryDependencies: ["button", "progress"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "breadcrumb-generator",
+    title: "Breadcrumb Generator",
+    description:
+      "Generate a breadcrumb trail from a path or items, with an optional home icon, a current-page last item and middle-collapse into a dropdown. Compound API.",
+    category: "navigation",
+    files: [{ path: "registry/hirael/ui/breadcrumb-generator.tsx" }],
+    registryDependencies: ["breadcrumb", "dropdown-menu"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "advanced-search-bar",
+    title: "Advanced Search Bar",
+    description:
+      "Power search field with a scope selector, inline removable filter tokens and a grouped suggestions dropdown with keyboard navigation. Compound API.",
+    category: "inputs",
+    files: [{ path: "registry/hirael/ui/advanced-search-bar.tsx" }],
+    registryDependencies: ["badge", "button", "input-group"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "changelog-viewer",
+    title: "Changelog Viewer",
+    description:
+      "Vertical timeline of versioned releases with dates, grouped added / fixed / changed / removed sections and a latest marker. Compound API.",
+    category: "display",
+    files: [{ path: "registry/hirael/ui/changelog-viewer.tsx" }],
+    registryDependencies: ["badge"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "release-notes",
+    title: "Release Notes",
+    description:
+      "Single-release what's-new card with a version badge, date, title, summary and a list of highlights. Compound API.",
+    category: "display",
+    files: [{ path: "registry/hirael/ui/release-notes.tsx" }],
+    registryDependencies: ["badge"],
+    dependencies: ["lucide-react"],
+  },
 ];
 
 /**

--- a/registry/hirael/registry-meta.ts
+++ b/registry/hirael/registry-meta.ts
@@ -4,6 +4,7 @@ export type ComponentCategory =
   | "files"
   | "data"
   | "ai"
+  | "dev"
   | "display"
   | "animation"
   | "navigation"
@@ -2346,6 +2347,116 @@ export const REGISTRY: RegistryEntryMeta[] = [
     registryDependencies: [],
     dependencies: ["lucide-react"],
   },
+  {
+    name: "query-builder",
+    title: "Query Builder",
+    description:
+      "Nested AND/OR query of field, operator and value rules, with add and remove at every level. Controlled tree value. Compound API.",
+    category: "data",
+    files: [{ path: "registry/hirael/ui/query-builder.tsx" }],
+    registryDependencies: ["button", "input", "select"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "filter-builder",
+    title: "Filter Builder",
+    description:
+      "Flat list of field / operator / value filters with an add row, removable active-filter chips and a clear all. Compound API.",
+    category: "data",
+    files: [{ path: "registry/hirael/ui/filter-builder.tsx" }],
+    registryDependencies: ["badge", "button", "input", "select"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "permission-matrix",
+    title: "Permission Matrix",
+    description:
+      "Roles by permissions checkbox grid with grouped rows, a sticky label column and column master toggles with indeterminate state. Compound API.",
+    category: "data",
+    files: [{ path: "registry/hirael/ui/permission-matrix.tsx" }],
+    registryDependencies: ["checkbox"],
+    dependencies: [],
+  },
+  {
+    name: "approval-workflow",
+    title: "Approval Workflow",
+    description:
+      "Rail-connected approval chain: approved / rejected / pending stages with approver, timestamp, comment and approve / reject actions on the current step. Compound API.",
+    category: "data",
+    files: [{ path: "registry/hirael/ui/approval-workflow.tsx" }],
+    registryDependencies: [],
+    dependencies: ["class-variance-authority", "lucide-react"],
+  },
+  {
+    name: "json-viewer",
+    title: "JSON Viewer",
+    description:
+      "Collapsible, syntax-highlighted JSON tree with type-colored values, array indices and a configurable expand depth. Dependency-free. Compound API.",
+    category: "dev",
+    files: [{ path: "registry/hirael/ui/json-viewer.tsx" }],
+    registryDependencies: [],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "diff-viewer",
+    title: "Diff Viewer",
+    description:
+      "Line-level text diff with unified or split mode, line numbers and add / remove gutter signs. Computes its own LCS, dependency-free. Compound API.",
+    category: "dev",
+    files: [{ path: "registry/hirael/ui/diff-viewer.tsx" }],
+    registryDependencies: [],
+    dependencies: [],
+  },
+  {
+    name: "log-viewer",
+    title: "Log Viewer",
+    description:
+      "Monospace log stream with per-line level and timestamp, level filter chips, search with highlight, a line count and a live tail indicator. Compound API.",
+    category: "dev",
+    files: [{ path: "registry/hirael/ui/log-viewer.tsx" }],
+    registryDependencies: ["button", "input-group"],
+    dependencies: ["class-variance-authority", "lucide-react"],
+  },
+  {
+    name: "request-builder",
+    title: "Request Builder",
+    description:
+      "Compose an HTTP request: method, URL, editable params and headers, a body editor, and a response panel with status, time and size. Compound API.",
+    category: "dev",
+    files: [{ path: "registry/hirael/ui/request-builder.tsx" }],
+    registryDependencies: ["button", "input", "select", "tabs"],
+    dependencies: ["lucide-react"],
+  },
+  {
+    name: "terminal",
+    title: "Terminal",
+    description:
+      "Presentational terminal with window chrome, scrollback, command history and a pluggable command handler. Dependency-free. Compound API.",
+    category: "dev",
+    files: [{ path: "registry/hirael/ui/terminal.tsx" }],
+    registryDependencies: [],
+    dependencies: [],
+  },
+  {
+    name: "command-palette",
+    title: "Command Palette",
+    description:
+      "Ready-to-use Cmd+K command launcher: grouped actions with icons and shortcuts, a trigger button and a global hotkey. Compound API.",
+    category: "navigation",
+    files: [{ path: "registry/hirael/ui/command-palette.tsx" }],
+    registryDependencies: ["command", "kbd"],
+    dependencies: [],
+  },
+  {
+    name: "spotlight-search",
+    title: "Spotlight Search",
+    description:
+      "Centered search overlay with a large field, grouped rich results, full keyboard navigation, an empty state and a hint footer. Compound API.",
+    category: "navigation",
+    files: [{ path: "registry/hirael/ui/spotlight-search.tsx" }],
+    registryDependencies: ["dialog", "kbd"],
+    dependencies: ["lucide-react"],
+  },
 ];
 
 /**
@@ -2400,6 +2511,7 @@ export const CATEGORY_LABELS: Record<ComponentCategory, string> = {
   files: "Files",
   data: "Data display",
   ai: "AI",
+  dev: "Developer",
   display: "Display",
   animation: "Animation",
   navigation: "Navigation",
@@ -2416,6 +2528,7 @@ export const REGISTRY_BY_CATEGORY = (() => {
     files: [],
     data: [],
     ai: [],
+    dev: [],
     display: [],
     animation: [],
     navigation: [],
@@ -2547,6 +2660,7 @@ export const COMPONENT_CATEGORY_ORDER: Exclude<
   "files",
   "data",
   "ai",
+  "dev",
   "display",
   "animation",
   "navigation",
@@ -2566,6 +2680,7 @@ export const COMPONENT_CATEGORY_DESCRIPTIONS: Record<
   files: "Upload zones, image croppers and local media pickers.",
   data: "Feeds, timelines, trees, heatmaps and other ways to show structured data.",
   ai: "Chat threads, prompt editors, tool-call and agent-run views, and citation UIs for AI products.",
+  dev: "Developer tools: JSON and diff viewers, a log stream, a terminal and an HTTP request builder.",
   display:
     "Callouts, code blocks, marquees, lightboxes and other visual helpers.",
   animation:

--- a/registry/hirael/registry-props.json
+++ b/registry/hirael/registry-props.json
@@ -7620,5 +7620,1230 @@
       ],
       "extendsNative": true
     }
+  ],
+  "query-builder": [
+    {
+      "name": "QueryBuilder",
+      "props": [
+        {
+          "name": "fields",
+          "type": "QueryField[]",
+          "required": true,
+          "default": null,
+          "description": "Selectable fields. Each field can carry its own operator list."
+        },
+        {
+          "name": "value",
+          "type": "QueryGroupNode",
+          "required": false,
+          "default": null,
+          "description": "Controlled root group."
+        },
+        {
+          "name": "defaultValue",
+          "type": "QueryGroupNode",
+          "required": false,
+          "default": null,
+          "description": "Initial root group for uncontrolled use."
+        },
+        {
+          "name": "onValueChange",
+          "type": "((value: QueryGroupNode) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called with the next root group whenever the tree changes."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "QueryGroup",
+      "props": [
+        {
+          "name": "node",
+          "type": "QueryGroupNode",
+          "required": true,
+          "default": null,
+          "description": "The group node this part renders recursively."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "QueryRule",
+      "props": [
+        {
+          "name": "rule",
+          "type": "QueryRule",
+          "required": true,
+          "default": null,
+          "description": "The rule node this part renders."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "QueryCombinator",
+      "props": [
+        {
+          "name": "value",
+          "type": "QueryCombinatorValue",
+          "required": true,
+          "default": null,
+          "description": "The active combinator."
+        },
+        {
+          "name": "onValueChange",
+          "type": "(value: QueryCombinatorValue) => void",
+          "required": true,
+          "default": null,
+          "description": "Called when a combinator is selected."
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "filter-builder": [
+    {
+      "name": "FilterBuilder",
+      "props": [
+        {
+          "name": "fields",
+          "type": "FilterField[]",
+          "required": true,
+          "default": null,
+          "description": "Fields a condition can target. `operators` overrides the default operator list per field."
+        },
+        {
+          "name": "value",
+          "type": "FilterCondition[]",
+          "required": false,
+          "default": null,
+          "description": "Controlled list of conditions."
+        },
+        {
+          "name": "defaultValue",
+          "type": "FilterCondition[]",
+          "required": false,
+          "default": null,
+          "description": "Initial conditions for an uncontrolled builder."
+        },
+        {
+          "name": "onValueChange",
+          "type": "((value: FilterCondition[]) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called whenever the condition list changes."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "FilterRow",
+      "props": [
+        {
+          "name": "condition",
+          "type": "FilterCondition",
+          "required": true,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "FilterAdd",
+      "props": [
+        {
+          "name": "size",
+          "type": "\"sm\" | \"lg\" | \"default\" | \"xs\" | \"icon\" | \"icon-xs\" | \"icon-sm\" | \"icon-lg\" | null",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "variant",
+          "type": "\"link\" | \"default\" | \"ghost\" | \"outline\" | \"destructive\" | \"secondary\" | null",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "asChild",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "FilterChips",
+      "props": [
+        {
+          "name": "emptyHint",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "\"No filters yet.\"",
+          "description": "Shown when no conditions exist."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "FilterChip",
+      "props": [
+        {
+          "name": "asChild",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "variant",
+          "type": "\"link\" | \"default\" | \"ghost\" | \"outline\" | \"destructive\" | \"secondary\" | null",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "condition",
+          "type": "FilterCondition",
+          "required": true,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "permission-matrix": [
+    {
+      "name": "PermissionMatrix",
+      "props": [
+        {
+          "name": "roles",
+          "type": "Role[]",
+          "required": true,
+          "default": null,
+          "description": "Columns of the grid. Each role renders one checkbox column."
+        },
+        {
+          "name": "permissions",
+          "type": "Permission[]",
+          "required": true,
+          "default": null,
+          "description": "Rows of the grid. Group adjacent permissions under a section header with `group`."
+        },
+        {
+          "name": "value",
+          "type": "GrantState",
+          "required": false,
+          "default": null,
+          "description": "Controlled grant map of permission id to the role ids that hold it."
+        },
+        {
+          "name": "defaultValue",
+          "type": "GrantState",
+          "required": false,
+          "default": null,
+          "description": "Initial grant map for uncontrolled use."
+        },
+        {
+          "name": "onValueChange",
+          "type": "((value: GrantState) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called with the next grant map whenever a grant changes."
+        },
+        {
+          "name": "columnToggles",
+          "type": "boolean",
+          "required": false,
+          "default": "true",
+          "description": "Show a master checkbox in each column header that toggles the whole column."
+        },
+        {
+          "name": "rowToggles",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Show a leading toggle-all checkbox on each permission row."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "PermissionMatrixHeader",
+      "props": [
+        {
+          "name": "columnToggles",
+          "type": "boolean",
+          "required": false,
+          "default": "true",
+          "description": null
+        },
+        {
+          "name": "rowToggles",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "PermissionGroupRow",
+      "props": [
+        {
+          "name": "rowToggles",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "PermissionRow",
+      "props": [
+        {
+          "name": "permission",
+          "type": "Permission",
+          "required": true,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "rowToggles",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "PermissionCell",
+      "props": [
+        {
+          "name": "aria-label",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Defines a string value that labels the current element.\nAccessible name for the cell checkbox, e.g. \"Grant Edit to Admin\"."
+        },
+        {
+          "name": "checked",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": null
+        },
+        {
+          "name": "onCheckedChange",
+          "type": "((checked: boolean) => void)",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "disabled",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "approval-workflow": [
+    {
+      "name": "ApprovalWorkflow",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "ApprovalStep",
+      "props": [
+        {
+          "name": "status",
+          "type": "\"pending\" | \"approved\" | \"rejected\" | \"current\"",
+          "required": false,
+          "default": "\"pending\"",
+          "description": "Outcome of this stage. `current` reads as live (accent-cool, pulsing) and is the step awaiting action."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "ApprovalStepMarker",
+      "props": [
+        {
+          "name": "status",
+          "type": "\"pending\" | \"approved\" | \"rejected\" | \"current\"",
+          "required": false,
+          "default": "\"pending\"",
+          "description": "Outcome of the stage this marker belongs to."
+        },
+        {
+          "name": "src",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Avatar image for the approver. Falls back to children, then a status icon."
+        },
+        {
+          "name": "alt",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Alt text for the avatar image."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "ApprovalStepContent",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "ApprovalStepTitle",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "ApprovalStepMeta",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "ApprovalStepComment",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "ApprovalStepActions",
+      "props": [],
+      "extendsNative": true
+    }
+  ],
+  "json-viewer": [
+    {
+      "name": "JsonViewer",
+      "props": [
+        {
+          "name": "data",
+          "type": "unknown",
+          "required": true,
+          "default": null,
+          "description": "The value to render as a collapsible JSON tree."
+        },
+        {
+          "name": "defaultExpandedDepth",
+          "type": "number",
+          "required": false,
+          "default": "1",
+          "description": "Depth up to which nodes start expanded. Defaults to 1."
+        },
+        {
+          "name": "rootName",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Optional label shown as the key of the root node."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "JsonViewerRoot",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "JsonNode",
+      "props": [
+        {
+          "name": "value",
+          "type": "unknown",
+          "required": true,
+          "default": null,
+          "description": "The JSON value rendered by this node."
+        },
+        {
+          "name": "nodeKey",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "The object key or array index labeling this node, if any."
+        },
+        {
+          "name": "isIndex",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Render this node's key as a quoted array index rather than a plain key."
+        },
+        {
+          "name": "depth",
+          "type": "number",
+          "required": false,
+          "default": "0",
+          "description": "Nesting level, used for indentation."
+        },
+        {
+          "name": "defaultExpandedDepth",
+          "type": "number",
+          "required": false,
+          "default": "1",
+          "description": "Depth up to which expandable nodes start open."
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "diff-viewer": [
+    {
+      "name": "DiffViewer",
+      "props": [
+        {
+          "name": "oldText",
+          "type": "string",
+          "required": true,
+          "default": null,
+          "description": "Original text. Lines are compared against `newText` with a line LCS."
+        },
+        {
+          "name": "newText",
+          "type": "string",
+          "required": true,
+          "default": null,
+          "description": "Updated text. Lines absent from `oldText` are marked as additions."
+        },
+        {
+          "name": "mode",
+          "type": "\"unified\" | \"split\"",
+          "required": false,
+          "default": "\"unified\"",
+          "description": "Single column of +/- lines, or old and new side by side."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "DiffLine",
+      "props": [
+        {
+          "name": "type",
+          "type": "DiffType",
+          "required": true,
+          "default": null,
+          "description": "Classification of the line relative to the old text."
+        },
+        {
+          "name": "oldNumber",
+          "type": "number",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "newNumber",
+          "type": "number",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "content",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "showOldNumber",
+          "type": "boolean",
+          "required": false,
+          "default": "true",
+          "description": "Render only the start-side gutter (old number, then sign)."
+        },
+        {
+          "name": "showNewNumber",
+          "type": "boolean",
+          "required": false,
+          "default": "true",
+          "description": "Render the end-side gutter (new number)."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "DiffViewerHeader",
+      "props": [
+        {
+          "name": "fileName",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Name of the file or label shown before the old → new pair."
+        },
+        {
+          "name": "oldLabel",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "newLabel",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "log-viewer": [
+    {
+      "name": "LogViewer",
+      "props": [
+        {
+          "name": "live",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Show the pulsing tailing indicator and \"Live\" label in the toolbar."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "LogViewerToolbar",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "LogViewerSearch",
+      "props": [
+        {
+          "name": "placeholder",
+          "type": "string",
+          "required": false,
+          "default": "\"Search logs\"",
+          "description": "Placeholder for the search field."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "LogViewerLevelFilter",
+      "props": [
+        {
+          "name": "levels",
+          "type": "readonly LogLevel[]",
+          "required": false,
+          "default": "LEVELS",
+          "description": "Levels to expose as toggle chips. Defaults to all four."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "LogViewerCount",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "LogViewerLive",
+      "props": [
+        {
+          "name": "label",
+          "type": "string",
+          "required": false,
+          "default": "\"Live\"",
+          "description": "Label shown next to the pulsing dot."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "LogViewerBody",
+      "props": [
+        {
+          "name": "wrap",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Wrap long lines instead of scrolling them horizontally."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "LogLine",
+      "props": [
+        {
+          "name": "level",
+          "type": "LogLevel",
+          "required": true,
+          "default": null,
+          "description": "Severity of this line. Drives its level tag and message color."
+        },
+        {
+          "name": "time",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Timestamp shown before the message, e.g. \"12:04:31\"."
+        },
+        {
+          "name": "children",
+          "type": "string",
+          "required": true,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "request-builder": [
+    {
+      "name": "RequestBuilder",
+      "props": [
+        {
+          "name": "defaultMethod",
+          "type": "RequestMethodName",
+          "required": false,
+          "default": "\"GET\"",
+          "description": "Method selected when the builder first renders."
+        },
+        {
+          "name": "defaultUrl",
+          "type": "string",
+          "required": false,
+          "default": "\"\"",
+          "description": "URL shown in the address input when the builder first renders."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "RequestBar",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "RequestMethod",
+      "props": [
+        {
+          "name": "size",
+          "type": "\"sm\" | \"default\"",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "RequestUrl",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "RequestSend",
+      "props": [
+        {
+          "name": "size",
+          "type": "\"sm\" | \"lg\" | \"default\" | \"xs\" | \"icon\" | \"icon-xs\" | \"icon-sm\" | \"icon-lg\" | null",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "variant",
+          "type": "\"link\" | \"default\" | \"ghost\" | \"outline\" | \"destructive\" | \"secondary\" | null",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "asChild",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "pending",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Show a busy state and disable the control while a request is in flight."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "RequestSection",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "RequestKeyValues",
+      "props": [
+        {
+          "name": "rows",
+          "type": "RequestKeyValue[]",
+          "required": true,
+          "default": null,
+          "description": "The rows to render. Each needs a stable `id`."
+        },
+        {
+          "name": "onChange",
+          "type": "(rows: RequestKeyValue[]) => void",
+          "required": true,
+          "default": null,
+          "description": "Called with the next rows whenever a value, toggle, add, or remove fires."
+        },
+        {
+          "name": "addLabel",
+          "type": "string",
+          "required": false,
+          "default": "\"Add row\"",
+          "description": "Label for the add-row button."
+        },
+        {
+          "name": "namePlaceholder",
+          "type": "string",
+          "required": false,
+          "default": "\"Key\"",
+          "description": "Placeholder for the key field."
+        },
+        {
+          "name": "valuePlaceholder",
+          "type": "string",
+          "required": false,
+          "default": "\"Value\"",
+          "description": "Placeholder for the value field."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "RequestKeyValueRow",
+      "props": [
+        {
+          "name": "row",
+          "type": "RequestKeyValue",
+          "required": true,
+          "default": null,
+          "description": "The row this control edits."
+        },
+        {
+          "name": "onNameChange",
+          "type": "(name: string) => void",
+          "required": true,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "onValueChange",
+          "type": "(value: string) => void",
+          "required": true,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "onEnabledChange",
+          "type": "(enabled: boolean) => void",
+          "required": true,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "onRemove",
+          "type": "() => void",
+          "required": true,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "namePlaceholder",
+          "type": "string",
+          "required": false,
+          "default": "\"Key\"",
+          "description": null
+        },
+        {
+          "name": "valuePlaceholder",
+          "type": "string",
+          "required": false,
+          "default": "\"Value\"",
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "RequestBody",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "RequestBodyPre",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "RequestResponse",
+      "props": [
+        {
+          "name": "time",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Response time, formatted by the caller (for example \"142 ms\")."
+        },
+        {
+          "name": "size",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Response size, formatted by the caller (for example \"1.2 KB\")."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "RequestStatus",
+      "props": [
+        {
+          "name": "status",
+          "type": "number",
+          "required": true,
+          "default": null,
+          "description": "HTTP status code. 2xx/3xx read as success, 4xx/5xx as error."
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "terminal": [
+    {
+      "name": "Terminal",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "TerminalHeader",
+      "props": [
+        {
+          "name": "title",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Title shown beside the window dots."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "TerminalBody",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "TerminalLine",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "TerminalPrompt",
+      "props": [
+        {
+          "name": "symbol",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "\"$\"",
+          "description": "Prompt symbol or user@host:path label. Defaults to \"$\"."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "TerminalOutput",
+      "props": [
+        {
+          "name": "tone",
+          "type": "TerminalOutputTone",
+          "required": false,
+          "default": "\"default\"",
+          "description": "Color treatment for the output text."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "TerminalInput",
+      "props": [
+        {
+          "name": "prompt",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "\"$\"",
+          "description": "Prompt symbol shown before the editable line. Defaults to \"$\"."
+        },
+        {
+          "name": "onCommand",
+          "type": "((input: string) => React.ReactNode | string | void)",
+          "required": false,
+          "default": null,
+          "description": "Runs the entered command and returns the output to append below it.\nReturn a string or node to echo as output, or nothing to echo only the\ncommand. The component handles the echo, Up/Down history, and clearing\nthe field."
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "command-palette": [
+    {
+      "name": "CommandPalette",
+      "props": [
+        {
+          "name": "title",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "className",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "showCloseButton",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "open",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "onOpenChange",
+          "type": "((open: boolean) => void)",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "shortcut",
+          "type": "string",
+          "required": false,
+          "default": "\"k\"",
+          "description": "Single key paired with ⌘ / Ctrl to toggle the palette."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "CommandPaletteTrigger",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "CommandPaletteInput",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "CommandPaletteList",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "CommandPaletteEmpty",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "CommandPaletteGroup",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "CommandPaletteItem",
+      "props": [
+        {
+          "name": "icon",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Leading icon, typically a lucide-react icon."
+        },
+        {
+          "name": "shortcut",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Trailing keyboard hint rendered as a Kbd display."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "CommandPaletteSeparator",
+      "props": [],
+      "extendsNative": true
+    }
+  ],
+  "spotlight-search": [
+    {
+      "name": "SpotlightSearch",
+      "props": [
+        {
+          "name": "shortcut",
+          "type": "string | null",
+          "required": false,
+          "default": "\"k\"",
+          "description": "Keyboard shortcut letter that opens the overlay with Ctrl/Cmd held, e.g. \"k\". Pass null to disable."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "SpotlightSearchTrigger",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "SpotlightSearchContent",
+      "props": [
+        {
+          "name": "title",
+          "type": "string",
+          "required": false,
+          "default": "\"Search\"",
+          "description": "Accessible title for the dialog; visually hidden."
+        },
+        {
+          "name": "showCloseButton",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "SpotlightSearchInput",
+      "props": [
+        {
+          "name": "label",
+          "type": "string",
+          "required": false,
+          "default": "\"Search\"",
+          "description": "Label announced to assistive tech for the search field."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "SpotlightSearchResults",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "SpotlightSearchGroup",
+      "props": [
+        {
+          "name": "heading",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "SpotlightSearchItem",
+      "props": [
+        {
+          "name": "value",
+          "type": "string",
+          "required": true,
+          "default": null,
+          "description": "Text matched against the query, alongside the title and description."
+        },
+        {
+          "name": "icon",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Leading icon or thumbnail rendered at the start of the row."
+        },
+        {
+          "name": "description",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Secondary line shown under the title."
+        },
+        {
+          "name": "meta",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "End-aligned category tag or meta shown opposite the title."
+        },
+        {
+          "name": "onSelect",
+          "type": "(() => void)",
+          "required": false,
+          "default": null,
+          "description": "Called when the row is chosen by click or Enter."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "SpotlightSearchEmpty",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "SpotlightSearchFooter",
+      "props": [],
+      "extendsNative": true
+    }
   ]
 }

--- a/registry/hirael/registry-props.json
+++ b/registry/hirael/registry-props.json
@@ -10283,5 +10283,914 @@
       ],
       "extendsNative": true
     }
+  ],
+  "review-queue": [
+    {
+      "name": "ReviewQueue",
+      "props": [
+        {
+          "name": "items",
+          "type": "readonly TItem[]",
+          "required": true,
+          "default": null,
+          "description": "The items waiting for a decision, in queue order."
+        },
+        {
+          "name": "onDecision",
+          "type": "((id: string, decision: ReviewDecision) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called when the focused item is approved, rejected, or skipped."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "ReviewQueueItem",
+      "props": [
+        {
+          "name": "children",
+          "type": "(item: TItem) => React.ReactNode",
+          "required": true,
+          "default": null,
+          "description": "Render the focused item. Not called while the queue is empty."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "ReviewQueueProgress",
+      "props": [
+        {
+          "name": "children",
+          "type": "((position: number, total: number) => React.ReactNode)",
+          "required": false,
+          "default": null,
+          "description": "Render custom progress copy. Receives the 1-based position and total."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "ReviewQueueActions",
+      "props": [
+        {
+          "name": "approveLabel",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "\"Approve\"",
+          "description": "Label for the approve button. Defaults to \"Approve\"."
+        },
+        {
+          "name": "rejectLabel",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "\"Reject\"",
+          "description": "Label for the reject button. Defaults to \"Reject\"."
+        },
+        {
+          "name": "skipLabel",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "\"Skip\"",
+          "description": "Label for the skip button. Defaults to \"Skip\"."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "ReviewQueueEmpty",
+      "props": [
+        {
+          "name": "whenDone",
+          "type": "boolean",
+          "required": false,
+          "default": "true",
+          "description": "Hide the empty state while items remain. Defaults to true."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "ReviewQueueRemaining",
+      "props": [
+        {
+          "name": "asChild",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "variant",
+          "type": "\"link\" | \"default\" | \"ghost\" | \"outline\" | \"destructive\" | \"secondary\" | null",
+          "required": false,
+          "default": "\"secondary\"",
+          "description": null
+        },
+        {
+          "name": "children",
+          "type": "((remaining: number) => React.ReactNode)",
+          "required": false,
+          "default": null,
+          "description": "Render custom copy. Receives the number of items still to review."
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "role-manager": [
+    {
+      "name": "RoleManager",
+      "props": [
+        {
+          "name": "roles",
+          "type": "Role[]",
+          "required": true,
+          "default": null,
+          "description": "Roles to administer. The first part holds the name, member count, and a System badge for built-in roles."
+        },
+        {
+          "name": "permissions",
+          "type": "Permission[]",
+          "required": true,
+          "default": null,
+          "description": "Permissions offered in the detail checklist. Adjacent items sharing `group` render under one section header."
+        },
+        {
+          "name": "defaultSelectedId",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Id of the role selected on first render. Falls back to the first role."
+        },
+        {
+          "name": "onChange",
+          "type": "((roles: Role[]) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called with the full role set whenever a role is added, duplicated, deleted, or its permissions change."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "RoleManagerToolbar",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "RoleList",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "RoleItem",
+      "props": [
+        {
+          "name": "role",
+          "type": "Role",
+          "required": true,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "RoleManagerDetail",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "RoleManagerDetailActions",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "RolePermissions",
+      "props": [],
+      "extendsNative": true
+    }
+  ],
+  "feature-flag-manager": [
+    {
+      "name": "FeatureFlagManager",
+      "props": [
+        {
+          "name": "value",
+          "type": "FeatureFlag[]",
+          "required": false,
+          "default": null,
+          "description": "Controlled list of flags."
+        },
+        {
+          "name": "defaultValue",
+          "type": "FeatureFlag[]",
+          "required": false,
+          "default": null,
+          "description": "Uncontrolled initial list of flags."
+        },
+        {
+          "name": "onValueChange",
+          "type": "((value: FeatureFlag[]) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called with the next list whenever a flag is toggled."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "FeatureFlagManagerToolbar",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "FeatureFlagList",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "FeatureFlagItem",
+      "props": [
+        {
+          "name": "flag",
+          "type": "FeatureFlag",
+          "required": true,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "FeatureFlagSwitch",
+      "props": [
+        {
+          "name": "flag",
+          "type": "FeatureFlag",
+          "required": true,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "keyboard-shortcuts": [
+    {
+      "name": "KeyboardShortcuts",
+      "props": [
+        {
+          "name": "open",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "onOpenChange",
+          "type": "((open: boolean) => void)",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "hotkey",
+          "type": "string | null",
+          "required": false,
+          "default": "\"?\"",
+          "description": "Key that opens the cheat sheet from anywhere. Pass null to disable\nthe global hotkey."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "KeyboardShortcutsTrigger",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "KeyboardShortcutsContent",
+      "props": [
+        {
+          "name": "title",
+          "type": "string | (string & React.ReactElement<unknown, string | React.JSXElementConstructor<any>>) | (string & Iterable<React.ReactNode>) | (string & React.ReactPortal) | (string & Promise<AwaitedReactNode>)",
+          "required": false,
+          "default": "\"Keyboard shortcuts\"",
+          "description": null
+        },
+        {
+          "name": "showCloseButton",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "description",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "KeyboardShortcutsSearch",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "KeyboardShortcutsGroup",
+      "props": [
+        {
+          "name": "heading",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Group heading shown above its shortcut rows."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "KeyboardShortcut",
+      "props": [
+        {
+          "name": "keys",
+          "type": "string[]",
+          "required": true,
+          "default": null,
+          "description": "Keys in the combo, each rendered as a KbdDisplay inside a KbdGroup."
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "onboarding": [
+    {
+      "name": "Onboarding",
+      "props": [
+        {
+          "name": "step",
+          "type": "number",
+          "required": false,
+          "default": null,
+          "description": "The active step index, 0-based. Pass with `onStepChange` to control."
+        },
+        {
+          "name": "defaultStep",
+          "type": "number",
+          "required": false,
+          "default": "0",
+          "description": "The initial step index for the uncontrolled case, 0-based."
+        },
+        {
+          "name": "onStepChange",
+          "type": "((step: number) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called when the active step changes, with the next 0-based index."
+        },
+        {
+          "name": "onComplete",
+          "type": "(() => void)",
+          "required": false,
+          "default": null,
+          "description": "Called once when the last step is finished."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "OnboardingProgress",
+      "props": [
+        {
+          "name": "variant",
+          "type": "\"dots\" | \"bar\"",
+          "required": false,
+          "default": "\"dots\"",
+          "description": "Render a continuous bar instead of one dot per step."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "OnboardingStep",
+      "props": [
+        {
+          "name": "value",
+          "type": "number",
+          "required": true,
+          "default": null,
+          "description": "This step's index, 0-based. Renders only while it is the active step."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "OnboardingStepTitle",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "OnboardingStepDescription",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "OnboardingStepBody",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "OnboardingComplete",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "OnboardingActions",
+      "props": [
+        {
+          "name": "showSkip",
+          "type": "boolean",
+          "required": false,
+          "default": "true",
+          "description": "Show the Skip button on non-final steps."
+        },
+        {
+          "name": "finishLabel",
+          "type": "string",
+          "required": false,
+          "default": "\"Finish\"",
+          "description": "Label for the advance button on the last step."
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "breadcrumb-generator": [
+    {
+      "name": "BreadcrumbGenerator",
+      "props": [
+        {
+          "name": "items",
+          "type": "BreadcrumbCrumb[]",
+          "required": false,
+          "default": null,
+          "description": "Crumbs to render. The last item becomes the current page."
+        },
+        {
+          "name": "path",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "A URL path to derive crumbs from when `items` is omitted."
+        },
+        {
+          "name": "basePath",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Prefix prepended to each `href` generated from `path`."
+        },
+        {
+          "name": "maxItems",
+          "type": "number",
+          "required": false,
+          "default": "4",
+          "description": "Collapse the middle into an ellipsis when the trail exceeds this."
+        },
+        {
+          "name": "showHome",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Prepend a Home crumb linking to `homeHref`."
+        },
+        {
+          "name": "homeHref",
+          "type": "string",
+          "required": false,
+          "default": "\"/\"",
+          "description": "Destination for the leading Home crumb."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "BreadcrumbGeneratorItem",
+      "props": [
+        {
+          "name": "label",
+          "type": "string",
+          "required": true,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "href",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "isCurrent",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": "Render as the current page (non-link) instead of a link."
+        }
+      ],
+      "extendsNative": false
+    }
+  ],
+  "advanced-search-bar": [
+    {
+      "name": "AdvancedSearchBar",
+      "props": [
+        {
+          "name": "defaultValue",
+          "type": "string | (readonly string[] & string)",
+          "required": false,
+          "default": null,
+          "description": "Default query text when uncontrolled."
+        },
+        {
+          "name": "scopes",
+          "type": "SearchScopeItem[]",
+          "required": false,
+          "default": "[{ value: \"all\", label: \"All\" }]",
+          "description": "The selectable search scopes shown in the leading dropdown."
+        },
+        {
+          "name": "scope",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "The active scope value (controlled)."
+        },
+        {
+          "name": "defaultScope",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Default scope value when uncontrolled."
+        },
+        {
+          "name": "onScopeChange",
+          "type": "((scope: string) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called when the active scope changes."
+        },
+        {
+          "name": "value",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "The query text (controlled)."
+        },
+        {
+          "name": "onValueChange",
+          "type": "((value: string) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called when the query text changes."
+        },
+        {
+          "name": "tokens",
+          "type": "string[]",
+          "required": false,
+          "default": null,
+          "description": "The active filter tokens, each `key:value` (controlled)."
+        },
+        {
+          "name": "defaultTokens",
+          "type": "string[]",
+          "required": false,
+          "default": null,
+          "description": "Default filter tokens when uncontrolled."
+        },
+        {
+          "name": "onTokensChange",
+          "type": "((tokens: string[]) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called when the active filter tokens change."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "SearchScope",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "SearchField",
+      "props": [
+        {
+          "name": "placeholder",
+          "type": "string",
+          "required": false,
+          "default": "\"Search…\"",
+          "description": "Placeholder shown in the text input."
+        },
+        {
+          "name": "icon",
+          "type": "boolean",
+          "required": false,
+          "default": "true",
+          "description": "Render the leading search icon."
+        },
+        {
+          "name": "filters",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Render the trailing filters button."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "SearchTokens",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "SearchToken",
+      "props": [
+        {
+          "name": "asChild",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "variant",
+          "type": "\"link\" | \"default\" | \"ghost\" | \"outline\" | \"destructive\" | \"secondary\" | null",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "index",
+          "type": "number",
+          "required": true,
+          "default": null,
+          "description": "Index of the token in the active filter list."
+        },
+        {
+          "name": "children",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "SearchSuggestions",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "SearchSuggestionGroup",
+      "props": [
+        {
+          "name": "label",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Heading shown above the group."
+        },
+        {
+          "name": "live",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Mark the group as live results, adding the active-state indicator."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "SearchSuggestion",
+      "props": [
+        {
+          "name": "value",
+          "type": "string",
+          "required": true,
+          "default": null,
+          "description": "Inserted as the query, or added as a token when it reads `key:value`."
+        },
+        {
+          "name": "icon",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Optional leading icon."
+        },
+        {
+          "name": "onSelect",
+          "type": "((value: string) => void)",
+          "required": false,
+          "default": null,
+          "description": "Run instead of the default insert/add when this suggestion is chosen."
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "changelog-viewer": [
+    {
+      "name": "ChangelogViewer",
+      "props": [
+        {
+          "name": "entries",
+          "type": "ChangelogEntryConfig[]",
+          "required": false,
+          "default": null,
+          "description": "Config-driven entries. Omit to compose `ChangelogEntry` children instead."
+        },
+        {
+          "name": "children",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "ChangelogEntry",
+      "props": [
+        {
+          "name": "version",
+          "type": "React.ReactNode",
+          "required": true,
+          "default": null,
+          "description": "Release version, e.g. `v1.4.0`."
+        },
+        {
+          "name": "date",
+          "type": "React.ReactNode",
+          "required": true,
+          "default": null,
+          "description": "Release date, rendered as a `time` element."
+        },
+        {
+          "name": "title",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Optional headline for the release."
+        },
+        {
+          "name": "latest",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Marks this as the newest release with a live accent-cool marker."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "ChangelogSection",
+      "props": [
+        {
+          "name": "type",
+          "type": "ChangelogChangeType",
+          "required": true,
+          "default": null,
+          "description": "Change category. Sets the tag Badge label, icon, and token shade."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "ChangelogList",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "ChangelogItem",
+      "props": [],
+      "extendsNative": true
+    }
+  ],
+  "release-notes": [
+    {
+      "name": "ReleaseNotes",
+      "props": [
+        {
+          "name": "title",
+          "type": "string | (string & React.ReactElement<unknown, string | React.JSXElementConstructor<any>>) | (string & Iterable<React.ReactNode>) | (string & React.ReactPortal) | (string & Promise<AwaitedReactNode>)",
+          "required": false,
+          "default": null,
+          "description": "Release title shown as the heading in the default header."
+        },
+        {
+          "name": "version",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Version label shown as a badge in the default header, e.g. \"v2.0\"."
+        },
+        {
+          "name": "date",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Release date shown beside the version, e.g. \"June 18, 2026\"."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "ReleaseNotesHeader",
+      "props": [
+        {
+          "name": "title",
+          "type": "string | (string & React.ReactElement<unknown, string | React.JSXElementConstructor<any>>) | (string & Iterable<React.ReactNode>) | (string & React.ReactPortal) | (string & Promise<AwaitedReactNode>)",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "version",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "date",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "ReleaseNotesSummary",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "ReleaseNotesHighlights",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "ReleaseNotesHighlight",
+      "props": [
+        {
+          "name": "icon",
+          "type": "false | React.ReactElement<unknown, string | React.JSXElementConstructor<any>> | React.ElementType<any, keyof React.JSX.IntrinsicElements>",
+          "required": false,
+          "default": null,
+          "description": "Optional leading icon. Defaults to a sparkles glyph."
+        },
+        {
+          "name": "title",
+          "type": "React.ReactNode",
+          "required": true,
+          "default": null,
+          "description": "Short headline for the highlight."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "ReleaseNotesSection",
+      "props": [
+        {
+          "name": "label",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Label shown above the grouped content."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "ReleaseNotesFooter",
+      "props": [],
+      "extendsNative": true
+    }
   ]
 }

--- a/registry/hirael/registry-props.json
+++ b/registry/hirael/registry-props.json
@@ -8845,5 +8845,691 @@
       "props": [],
       "extendsNative": true
     }
+  ],
+  "discount-builder": [
+    {
+      "name": "DiscountType",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "DiscountCondition",
+      "props": [
+        {
+          "name": "condition",
+          "type": "DiscountCondition",
+          "required": true,
+          "default": null,
+          "description": "The condition row this part renders."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "DiscountBuilder",
+      "props": [
+        {
+          "name": "value",
+          "type": "Discount",
+          "required": false,
+          "default": null,
+          "description": "Controlled discount configuration."
+        },
+        {
+          "name": "defaultValue",
+          "type": "Discount",
+          "required": false,
+          "default": null,
+          "description": "Initial discount for an uncontrolled builder."
+        },
+        {
+          "name": "onValueChange",
+          "type": "((value: Discount) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called whenever the discount changes."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "DiscountValue",
+      "props": [
+        {
+          "name": "placeholder",
+          "type": "string",
+          "required": false,
+          "default": "\"0\"",
+          "description": "Placeholder shown in the empty amount field."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "DiscountConditions",
+      "props": [
+        {
+          "name": "emptyHint",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "\"No conditions. The discount applies to every order.\"",
+          "description": "Shown when no conditions have been added."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "DiscountAddCondition",
+      "props": [
+        {
+          "name": "size",
+          "type": "\"sm\" | \"lg\" | \"default\" | \"xs\" | \"icon\" | \"icon-xs\" | \"icon-sm\" | \"icon-lg\" | null",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "variant",
+          "type": "\"link\" | \"default\" | \"ghost\" | \"outline\" | \"destructive\" | \"secondary\" | null",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "asChild",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "DiscountSummary",
+      "props": [
+        {
+          "name": "asChild",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "variant",
+          "type": "\"link\" | \"default\" | \"ghost\" | \"outline\" | \"destructive\" | \"secondary\" | null",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "bundle-builder": [
+    {
+      "name": "BundleBuilder",
+      "props": [
+        {
+          "name": "products",
+          "type": "BundleProduct[]",
+          "required": true,
+          "default": null,
+          "description": "Catalog of products the picker can add to the bundle."
+        },
+        {
+          "name": "value",
+          "type": "BundleLine[]",
+          "required": false,
+          "default": null,
+          "description": "Controlled list of bundle lines."
+        },
+        {
+          "name": "defaultValue",
+          "type": "BundleLine[]",
+          "required": false,
+          "default": null,
+          "description": "Initial bundle lines for an uncontrolled builder."
+        },
+        {
+          "name": "onValueChange",
+          "type": "((value: BundleLine[]) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called whenever the bundle lines change."
+        },
+        {
+          "name": "discount",
+          "type": "number",
+          "required": false,
+          "default": null,
+          "description": "Controlled bundle discount as a percentage from 0 to 100."
+        },
+        {
+          "name": "defaultDiscount",
+          "type": "number",
+          "required": false,
+          "default": "0",
+          "description": "Initial discount percentage for an uncontrolled builder."
+        },
+        {
+          "name": "onDiscountChange",
+          "type": "((discount: number) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called whenever the discount percentage changes."
+        },
+        {
+          "name": "locale",
+          "type": "string",
+          "required": false,
+          "default": "\"en-US\"",
+          "description": "BCP 47 locale used to format prices."
+        },
+        {
+          "name": "currency",
+          "type": "string",
+          "required": false,
+          "default": "\"USD\"",
+          "description": "ISO 4217 currency code used to format prices."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "BundlePicker",
+      "props": [
+        {
+          "name": "placeholder",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "\"Add a product\"",
+          "description": "Placeholder shown in the picker before a product is chosen."
+        },
+        {
+          "name": "addLabel",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "\"Add\"",
+          "description": "Label for the add button."
+        },
+        {
+          "name": "variant",
+          "type": "\"select\" | \"list\"",
+          "required": false,
+          "default": "\"select\"",
+          "description": "Render an add-button list instead of a Select."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "BundleItems",
+      "props": [
+        {
+          "name": "emptyHint",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "\"No products in the bundle yet.\"",
+          "description": "Shown when the bundle has no lines yet."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "BundleItem",
+      "props": [
+        {
+          "name": "line",
+          "type": "BundleLine",
+          "required": true,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "BundleSummary",
+      "props": [
+        {
+          "name": "showDiscount",
+          "type": "boolean",
+          "required": false,
+          "default": "true",
+          "description": "Show the discount percentage input."
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "vendor-comparison": [
+    {
+      "name": "VendorComparison",
+      "props": [
+        {
+          "name": "vendors",
+          "type": "Vendor[]",
+          "required": true,
+          "default": null,
+          "description": "Columns of the table. Mark one vendor `recommended` to tint its column and label it."
+        },
+        {
+          "name": "features",
+          "type": "Feature[]",
+          "required": false,
+          "default": null,
+          "description": "Rows of the table. Pass to render config-driven; omit to compose rows as children. Group adjacent features with `group`."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "VendorComparisonHeader",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "VendorComparisonGroup",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "VendorComparisonRow",
+      "props": [
+        {
+          "name": "label",
+          "type": "React.ReactNode",
+          "required": true,
+          "default": null,
+          "description": "Feature name shown in the sticky start column."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "VendorComparisonCell",
+      "props": [
+        {
+          "name": "value",
+          "type": "CellValue",
+          "required": false,
+          "default": null,
+          "description": "Cell content. `true`/`false` render a check or x icon; strings and numbers render as text."
+        },
+        {
+          "name": "recommended",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": "Tint the cell to match a recommended vendor column."
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "inventory-matrix": [
+    {
+      "name": "InventoryMatrix",
+      "props": [
+        {
+          "name": "variants",
+          "type": "Variant[]",
+          "required": true,
+          "default": null,
+          "description": "Rows of the grid. Each variant (size, SKU, …) renders one stock row."
+        },
+        {
+          "name": "locations",
+          "type": "Location[]",
+          "required": true,
+          "default": null,
+          "description": "Columns of the grid. Each location or warehouse renders one stock column."
+        },
+        {
+          "name": "value",
+          "type": "StockMap",
+          "required": false,
+          "default": null,
+          "description": "Controlled stock map of variant id to location id to on-hand quantity."
+        },
+        {
+          "name": "defaultValue",
+          "type": "StockMap",
+          "required": false,
+          "default": null,
+          "description": "Initial stock map for uncontrolled use."
+        },
+        {
+          "name": "onValueChange",
+          "type": "((value: StockMap) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called with the next stock map whenever a cell changes."
+        },
+        {
+          "name": "lowStockThreshold",
+          "type": "number",
+          "required": false,
+          "default": "5",
+          "description": "Quantities at or below this count tint as low stock. Zero or less is out of stock."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "InventoryMatrixHeader",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "InventoryRow",
+      "props": [
+        {
+          "name": "variant",
+          "type": "Variant",
+          "required": true,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "InventoryCell",
+      "props": [
+        {
+          "name": "aria-label",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Defines a string value that labels the current element.\nAccessible name for the cell input, e.g. \"Stock for M at Berlin\"."
+        },
+        {
+          "name": "value",
+          "type": "number",
+          "required": true,
+          "default": null,
+          "description": "On-hand quantity shown in the cell input."
+        },
+        {
+          "name": "state",
+          "type": "StockState",
+          "required": true,
+          "default": null,
+          "description": "Stock state derived from the low-stock threshold, driving the cell tint."
+        },
+        {
+          "name": "onValueChange",
+          "type": "((value: number) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called with the parsed quantity when the cell input changes."
+        },
+        {
+          "name": "disabled",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "InventoryTotals",
+      "props": [],
+      "extendsNative": true
+    }
+  ],
+  "variant-editor": [
+    {
+      "name": "VariantOption",
+      "props": [
+        {
+          "name": "option",
+          "type": "VariantOption",
+          "required": true,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "VariantRow",
+      "props": [
+        {
+          "name": "row",
+          "type": "VariantRow",
+          "required": true,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "axisNames",
+          "type": "string[]",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "VariantEditor",
+      "props": [
+        {
+          "name": "value",
+          "type": "VariantEditorState",
+          "required": false,
+          "default": null,
+          "description": "Controlled options and generated rows."
+        },
+        {
+          "name": "defaultValue",
+          "type": "VariantEditorState",
+          "required": false,
+          "default": null,
+          "description": "Initial options and rows for an uncontrolled editor."
+        },
+        {
+          "name": "onValueChange",
+          "type": "((value: VariantEditorState) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called whenever the options or any row changes."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "VariantOptions",
+      "props": [
+        {
+          "name": "addLabel",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "\"Add option\"",
+          "description": "Override the add-axis control label."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "VariantValues",
+      "props": [
+        {
+          "name": "option",
+          "type": "VariantOption",
+          "required": true,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "VariantTable",
+      "props": [
+        {
+          "name": "emptyHint",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "\"Add options with values to generate variants.\"",
+          "description": "Shown when no variants are generated yet."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "VariantCount",
+      "props": [
+        {
+          "name": "children",
+          "type": "((count: number) => React.ReactNode)",
+          "required": false,
+          "default": null,
+          "description": "Render the label from the variant count."
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "pricing-rules-builder": [
+    {
+      "name": "PricingRules",
+      "props": [
+        {
+          "name": "fields",
+          "type": "PricingField[]",
+          "required": false,
+          "default": "DEFAULT_FIELDS",
+          "description": "Condition fields a rule can target. `operators` overrides the default operator list per field."
+        },
+        {
+          "name": "actions",
+          "type": "PricingAction[]",
+          "required": false,
+          "default": "DEFAULT_ACTIONS",
+          "description": "Price actions a rule can apply. `unit` decorates the action value in the summary chip."
+        },
+        {
+          "name": "value",
+          "type": "PricingRule[]",
+          "required": false,
+          "default": null,
+          "description": "Controlled list of rules."
+        },
+        {
+          "name": "defaultValue",
+          "type": "PricingRule[]",
+          "required": false,
+          "default": null,
+          "description": "Initial rules for an uncontrolled builder."
+        },
+        {
+          "name": "onValueChange",
+          "type": "((value: PricingRule[]) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called whenever the rule list changes."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "PricingRule",
+      "props": [
+        {
+          "name": "rule",
+          "type": "PricingRule",
+          "required": true,
+          "default": null,
+          "description": "The rule this row renders."
+        },
+        {
+          "name": "index",
+          "type": "number",
+          "required": false,
+          "default": null,
+          "description": "Order in which the rule is evaluated, shown as an ordinal. Rules apply top-down."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "PricingRuleCondition",
+      "props": [
+        {
+          "name": "label",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "\"When\"",
+          "description": "Label shown before the condition controls."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "PricingRuleAction",
+      "props": [
+        {
+          "name": "label",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "\"then\"",
+          "description": "Label shown before the action controls."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "PricingRuleSummary",
+      "props": [
+        {
+          "name": "asChild",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "variant",
+          "type": "\"link\" | \"default\" | \"ghost\" | \"outline\" | \"destructive\" | \"secondary\" | null",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "PricingRulesAdd",
+      "props": [
+        {
+          "name": "size",
+          "type": "\"sm\" | \"lg\" | \"default\" | \"xs\" | \"icon\" | \"icon-xs\" | \"icon-sm\" | \"icon-lg\" | null",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "variant",
+          "type": "\"link\" | \"default\" | \"ghost\" | \"outline\" | \"destructive\" | \"secondary\" | null",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "asChild",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    }
   ]
 }

--- a/registry/hirael/registry-props.json
+++ b/registry/hirael/registry-props.json
@@ -9531,5 +9531,757 @@
       ],
       "extendsNative": true
     }
+  ],
+  "upload-manager": [
+    {
+      "name": "UploadItem",
+      "props": [
+        {
+          "name": "item",
+          "type": "UploadItem",
+          "required": true,
+          "default": null,
+          "description": "The queue entry to render."
+        },
+        {
+          "name": "onCancel",
+          "type": "((id: string) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called when the user cancels an in-flight upload."
+        },
+        {
+          "name": "onRetry",
+          "type": "((id: string) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called when the user retries a failed upload."
+        },
+        {
+          "name": "onRemove",
+          "type": "((id: string) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called when the user removes the entry. Falls back to the root's remove."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "UploadManager",
+      "props": [
+        {
+          "name": "value",
+          "type": "UploadItem[]",
+          "required": false,
+          "default": null,
+          "description": "Controlled queue of upload items."
+        },
+        {
+          "name": "defaultValue",
+          "type": "UploadItem[]",
+          "required": false,
+          "default": null,
+          "description": "Initial queue when uncontrolled."
+        },
+        {
+          "name": "onValueChange",
+          "type": "((items: UploadItem[]) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called whenever the queue changes (add, remove, or progress update)."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "UploadDropzone",
+      "props": [
+        {
+          "name": "accept",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Restrict the native file picker, e.g. \"image/*,.pdf\"."
+        },
+        {
+          "name": "multiple",
+          "type": "boolean",
+          "required": false,
+          "default": "true",
+          "description": "Allow selecting more than one file at a time."
+        },
+        {
+          "name": "disabled",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "onAdd",
+          "type": "((files: File[]) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called with the selected or dropped files so the queue can append them."
+        },
+        {
+          "name": "headline",
+          "type": "string",
+          "required": false,
+          "default": "\"Drop files here, or click to browse\"",
+          "description": null
+        },
+        {
+          "name": "subline",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "children",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "UploadList",
+      "props": [
+        {
+          "name": "empty",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Shown when the queue is empty. Hides the list entirely if omitted."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "UploadSummary",
+      "props": [
+        {
+          "name": "children",
+          "type": "((summary: { total: number; done: number; uploading: number; error: number; queued: number; progress: number; }) => React.ReactNode)",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "file-explorer": [
+    {
+      "name": "FileExplorer",
+      "props": [
+        {
+          "name": "tree",
+          "type": "FileNode",
+          "required": true,
+          "default": null,
+          "description": "Root folder rendered in the tree and browsed in the main pane."
+        },
+        {
+          "name": "defaultPath",
+          "type": "string[]",
+          "required": false,
+          "default": null,
+          "description": "Initial folder path, as folder names from the root's children down."
+        },
+        {
+          "name": "path",
+          "type": "string[]",
+          "required": false,
+          "default": null,
+          "description": "Controlled folder path, as folder names from the root's children down."
+        },
+        {
+          "name": "onPathChange",
+          "type": "((path: string[]) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called with the new path when the user navigates."
+        },
+        {
+          "name": "defaultView",
+          "type": "FileView",
+          "required": false,
+          "default": "\"list\"",
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "FileExplorerSidebar",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "FileExplorerTree",
+      "props": [
+        {
+          "name": "node",
+          "type": "FileNode",
+          "required": false,
+          "default": null,
+          "description": "Folder to render. Defaults to the explorer's root tree."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "FileExplorerBreadcrumb",
+      "props": [
+        {
+          "name": "rootLabel",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "\"Home\"",
+          "description": "Label for the root crumb."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "FileExplorerToolbar",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "FileExplorerList",
+      "props": [
+        {
+          "name": "emptyState",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "\"Empty folder\"",
+          "description": "Shown when the current folder has no children."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "FileExplorerItem",
+      "props": [
+        {
+          "name": "node",
+          "type": "FileNode",
+          "required": true,
+          "default": null,
+          "description": "The file or folder this row represents."
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "asset-manager": [
+    {
+      "name": "AssetManager",
+      "props": [
+        {
+          "name": "assets",
+          "type": "Asset[]",
+          "required": true,
+          "default": null,
+          "description": "Assets to display in the library."
+        },
+        {
+          "name": "defaultView",
+          "type": "AssetView",
+          "required": false,
+          "default": "\"grid\"",
+          "description": "Initial layout for an uncontrolled manager."
+        },
+        {
+          "name": "defaultSelectedId",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Id of the asset selected on first render."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AssetLibrary",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "AssetToolbar",
+      "props": [
+        {
+          "name": "searchPlaceholder",
+          "type": "string",
+          "required": false,
+          "default": "\"Search assets\"",
+          "description": "Placeholder for the search field."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AssetGrid",
+      "props": [
+        {
+          "name": "emptyState",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Rendered when no assets match the current search."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AssetCard",
+      "props": [
+        {
+          "name": "asset",
+          "type": "Asset",
+          "required": true,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AssetThumbnail",
+      "props": [
+        {
+          "name": "asset",
+          "type": "Asset",
+          "required": true,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AssetDetail",
+      "props": [
+        {
+          "name": "emptyState",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Rendered when nothing is selected."
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "kanban-board": [
+    {
+      "name": "KanbanBoard",
+      "props": [
+        {
+          "name": "value",
+          "type": "KanbanColumnData[]",
+          "required": false,
+          "default": null,
+          "description": "Controlled list of columns with their cards."
+        },
+        {
+          "name": "defaultValue",
+          "type": "KanbanColumnData[]",
+          "required": false,
+          "default": "[]",
+          "description": "Initial columns when uncontrolled."
+        },
+        {
+          "name": "onValueChange",
+          "type": "((value: KanbanColumnData[]) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called with the next columns after any move."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "KanbanColumn",
+      "props": [
+        {
+          "name": "value",
+          "type": "string",
+          "required": true,
+          "default": null,
+          "description": "Unique id matching a column in the root value."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "KanbanColumnHeader",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "KanbanCards",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "KanbanCard",
+      "props": [
+        {
+          "name": "value",
+          "type": "string",
+          "required": true,
+          "default": null,
+          "description": "Unique id matching a card in this column."
+        },
+        {
+          "name": "index",
+          "type": "number",
+          "required": true,
+          "default": null,
+          "description": "Position of this card within its column, used for the drop indicator."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "KanbanAddCard",
+      "props": [],
+      "extendsNative": true
+    }
+  ],
+  "nested-sortable": [
+    {
+      "name": "NestedSortable",
+      "props": [
+        {
+          "name": "value",
+          "type": "NestedItem[]",
+          "required": false,
+          "default": null,
+          "description": "Controlled tree of items."
+        },
+        {
+          "name": "defaultValue",
+          "type": "NestedItem[]",
+          "required": false,
+          "default": "[]",
+          "description": "Initial tree of items when uncontrolled."
+        },
+        {
+          "name": "onValueChange",
+          "type": "((value: NestedItem[]) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called with the rebuilt tree after a reorder, indent, or outdent."
+        },
+        {
+          "name": "maxDepth",
+          "type": "number",
+          "required": false,
+          "default": "Infinity",
+          "description": "Deepest nesting level allowed, where the top level is 0."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "NestedSortableItem",
+      "props": [
+        {
+          "name": "value",
+          "type": "string",
+          "required": true,
+          "default": null,
+          "description": "Unique id matching an entry in the root tree."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "NestedSortableHandle",
+      "props": [
+        {
+          "name": "size",
+          "type": "\"sm\" | \"lg\" | \"default\" | \"xs\" | \"icon\" | \"icon-xs\" | \"icon-sm\" | \"icon-lg\" | null",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "variant",
+          "type": "\"link\" | \"default\" | \"ghost\" | \"outline\" | \"destructive\" | \"secondary\" | null",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "asChild",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "NestedSortableLabel",
+      "props": [],
+      "extendsNative": true
+    }
+  ],
+  "shipment-tracker": [
+    {
+      "name": "ShipmentTracker",
+      "props": [
+        {
+          "name": "orientation",
+          "type": "ShipmentOrientation",
+          "required": false,
+          "default": "\"horizontal\"",
+          "description": "Lays the stage stepper out along the inline axis or stacked vertically. Defaults to `horizontal`."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "ShipmentStages",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "ShipmentStage",
+      "props": [
+        {
+          "name": "status",
+          "type": "\"current\" | \"complete\" | \"upcoming\"",
+          "required": false,
+          "default": "\"upcoming\"",
+          "description": "Progress of this stage. `current` reads as live (accent-cool, pulsing)."
+        },
+        {
+          "name": "orientation",
+          "type": "\"horizontal\" | \"vertical\" | null",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "label",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Short stage name, e.g. \"Out for delivery\"."
+        },
+        {
+          "name": "time",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "When the stage was reached. Omit for stages not yet hit."
+        },
+        {
+          "name": "icon",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Replaces the default stage icon."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "ShipmentEvents",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "ShipmentEvent",
+      "props": [
+        {
+          "name": "time",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "When the event happened."
+        },
+        {
+          "name": "location",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Where the event happened."
+        },
+        {
+          "name": "description",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "What happened."
+        },
+        {
+          "name": "icon",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Replaces the default location marker icon."
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "auction-timeline": [
+    {
+      "name": "AuctionTimeline",
+      "props": [
+        {
+          "name": "endsAt",
+          "type": "string | number | Date",
+          "required": false,
+          "default": null,
+          "description": "When the auction closes. Read by `AuctionCountdown` to drive the live clock."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AuctionHeader",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "AuctionBid",
+      "props": [
+        {
+          "name": "amount",
+          "type": "React.ReactNode",
+          "required": true,
+          "default": null,
+          "description": "The current leading bid, already formatted (e.g. \"$2,450\")."
+        },
+        {
+          "name": "bids",
+          "type": "number",
+          "required": false,
+          "default": null,
+          "description": "Number of bids placed so far."
+        },
+        {
+          "name": "label",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "\"Current bid\"",
+          "description": "Label above the amount."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AuctionCountdown",
+      "props": [
+        {
+          "name": "endedLabel",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "\"Bidding closed\"",
+          "description": "Shown once the countdown reaches zero."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AuctionStatus",
+      "props": [
+        {
+          "name": "state",
+          "type": "AuctionStatusState",
+          "required": true,
+          "default": null,
+          "description": "Current lifecycle of the auction. `live` and `closing` read as active."
+        },
+        {
+          "name": "children",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AuctionHistory",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "AuctionBidRow",
+      "props": [
+        {
+          "name": "bidder",
+          "type": "React.ReactNode",
+          "required": true,
+          "default": null,
+          "description": "Name of the bidder."
+        },
+        {
+          "name": "amount",
+          "type": "React.ReactNode",
+          "required": true,
+          "default": null,
+          "description": "Bid amount, already formatted."
+        },
+        {
+          "name": "time",
+          "type": "React.ReactNode",
+          "required": true,
+          "default": null,
+          "description": "When the bid was placed."
+        },
+        {
+          "name": "leading",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Marks this as the current leading bid."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AuctionWinner",
+      "props": [
+        {
+          "name": "winner",
+          "type": "React.ReactNode",
+          "required": true,
+          "default": null,
+          "description": "Name of the winning bidder."
+        },
+        {
+          "name": "amount",
+          "type": "React.ReactNode",
+          "required": true,
+          "default": null,
+          "description": "Winning amount, already formatted."
+        },
+        {
+          "name": "label",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "\"Winner\"",
+          "description": "Label above the winner."
+        }
+      ],
+      "extendsNative": true
+    }
   ]
 }

--- a/registry/hirael/registry-props.json
+++ b/registry/hirael/registry-props.json
@@ -7050,5 +7050,575 @@
       ],
       "extendsNative": true
     }
+  ],
+  "ai-chat": [
+    {
+      "name": "AiChat",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "AiChatMessages",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "AiChatMessage",
+      "props": [
+        {
+          "name": "role",
+          "type": "\"user\" | \"assistant\"",
+          "required": true,
+          "default": null,
+          "description": "Who sent the message. Lays the row out from the start (assistant) or the end (user)."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AiChatAvatar",
+      "props": [
+        {
+          "name": "src",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Image source for the avatar. Falls back to children (initials or an icon) when absent."
+        },
+        {
+          "name": "alt",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Alt text for the avatar image."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AiChatGroup",
+      "props": [
+        {
+          "name": "role",
+          "type": "\"user\" | \"assistant\"",
+          "required": true,
+          "default": null,
+          "description": "Aligns the bubble, actions, and timestamp stack to the start (assistant) or the end (user)."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AiChatBubble",
+      "props": [
+        {
+          "name": "role",
+          "type": "\"user\" | \"assistant\"",
+          "required": true,
+          "default": null,
+          "description": "Who sent the message. Selects the user or assistant surface."
+        },
+        {
+          "name": "tone",
+          "type": "\"muted\" | \"solid\" | null",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AiChatActions",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "AiChatTyping",
+      "props": [
+        {
+          "name": "label",
+          "type": "string",
+          "required": false,
+          "default": "\"Assistant is typing\"",
+          "description": "Accessible label announced while the reply is pending. Defaults to \"Assistant is typing\"."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AiChatComposer",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "AiChatInput",
+      "props": [
+        {
+          "name": "onSubmit",
+          "type": "(() => void)",
+          "required": false,
+          "default": null,
+          "description": "Called when the message is submitted with Enter (Shift+Enter inserts a newline)."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AiChatSend",
+      "props": [
+        {
+          "name": "size",
+          "type": "\"sm\" | \"lg\" | \"default\" | \"xs\" | \"icon\" | \"icon-xs\" | \"icon-sm\" | \"icon-lg\" | null",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "variant",
+          "type": "\"link\" | \"default\" | \"ghost\" | \"outline\" | \"destructive\" | \"secondary\" | null",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "asChild",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "label",
+          "type": "string",
+          "required": false,
+          "default": "\"Send message\"",
+          "description": "Accessible label for the send button. Defaults to \"Send message\"."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AiChatTimestamp",
+      "props": [],
+      "extendsNative": true
+    }
+  ],
+  "prompt-editor": [
+    {
+      "name": "PromptEditor",
+      "props": [
+        {
+          "name": "value",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Controlled template text. Use with `onValueChange`."
+        },
+        {
+          "name": "defaultValue",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Initial template text when uncontrolled."
+        },
+        {
+          "name": "onValueChange",
+          "type": "((value: string) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called with the next template text whenever it changes."
+        },
+        {
+          "name": "disabled",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": "Disable the field and variable chips."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "PromptEditorToolbar",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "PromptEditorField",
+      "props": [
+        {
+          "name": "rows",
+          "type": "number",
+          "required": false,
+          "default": "6",
+          "description": "Minimum number of visible text rows."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "PromptEditorVariables",
+      "props": [
+        {
+          "name": "label",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Heading text shown before the chips."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "PromptEditorVariable",
+      "props": [
+        {
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "default": null,
+          "description": "Variable name inserted as `{{name}}` at the caret on click."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "PromptEditorFooter",
+      "props": [
+        {
+          "name": "children",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": "Render custom footer content instead of the default counts."
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "ai-completion-input": [
+    {
+      "name": "AiCompletionInput",
+      "props": [
+        {
+          "name": "value",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "The current text. Controls the field when provided."
+        },
+        {
+          "name": "defaultValue",
+          "type": "string",
+          "required": false,
+          "default": "\"\"",
+          "description": null
+        },
+        {
+          "name": "onValueChange",
+          "type": "((value: string) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called with the next text whenever the typed value changes."
+        },
+        {
+          "name": "suggestion",
+          "type": "string",
+          "required": false,
+          "default": "\"\"",
+          "description": "The predicted completion string, supplied by the consumer. The part not already typed is shown as ghost text."
+        },
+        {
+          "name": "onAccept",
+          "type": "((value: string) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called with the full accepted text when the ghost suggestion is accepted."
+        },
+        {
+          "name": "disabled",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AiCompletionField",
+      "props": [
+        {
+          "name": "placeholder",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AiCompletionGhost",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "AiCompletionHint",
+      "props": [
+        {
+          "name": "idleChildren",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": "null",
+          "description": "Shown when no suggestion is pending. Hidden by default."
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "ai-tool-call": [
+    {
+      "name": "AiToolCall",
+      "props": [
+        {
+          "name": "status",
+          "type": "AiToolCallStatus",
+          "required": false,
+          "default": "\"pending\"",
+          "description": "Lifecycle of the tool call. Drives the badge, dot, and default open state."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AiToolCallTrigger",
+      "props": [
+        {
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "default": null,
+          "description": "The tool or function name, rendered in mono as the row label."
+        },
+        {
+          "name": "icon",
+          "type": "React.ReactNode",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AiToolCallStatusBadge",
+      "props": [
+        {
+          "name": "status",
+          "type": "\"success\" | \"error\" | \"pending\" | null",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AiToolCallStatusDot",
+      "props": [
+        {
+          "name": "status",
+          "type": "AiToolCallStatus",
+          "required": false,
+          "default": null,
+          "description": null
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AiToolCallContent",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "AiToolCallSection",
+      "props": [
+        {
+          "name": "label",
+          "type": "React.ReactNode",
+          "required": true,
+          "default": null,
+          "description": "Label shown above the block, e.g. \"Arguments\" or \"Result\"."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AiToolCallArguments",
+      "props": [
+        {
+          "name": "value",
+          "type": "unknown",
+          "required": true,
+          "default": null,
+          "description": "The call arguments object, shown as pretty-printed JSON."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AiToolCallResult",
+      "props": [
+        {
+          "name": "value",
+          "type": "unknown",
+          "required": true,
+          "default": null,
+          "description": "The value the tool returned, shown as pretty-printed JSON."
+        }
+      ],
+      "extendsNative": true
+    }
+  ],
+  "agent-workflow": [
+    {
+      "name": "AgentWorkflow",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "AgentWorkflowStep",
+      "props": [
+        {
+          "name": "status",
+          "type": "\"done\" | \"error\" | \"pending\" | \"running\"",
+          "required": false,
+          "default": "\"pending\"",
+          "description": "Lifecycle of this step. `running` reads as live (accent-cool, pulsing)."
+        },
+        {
+          "name": "kind",
+          "type": "AgentWorkflowKind",
+          "required": false,
+          "default": null,
+          "description": "What the step represents, used to pick a default marker icon."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AgentWorkflowMarker",
+      "props": [
+        {
+          "name": "status",
+          "type": "\"done\" | \"error\" | \"pending\" | \"running\"",
+          "required": false,
+          "default": "\"pending\"",
+          "description": "Lifecycle of the step this marker belongs to."
+        },
+        {
+          "name": "kind",
+          "type": "AgentWorkflowKind",
+          "required": false,
+          "default": null,
+          "description": "What the step represents. Picks the fallback icon when no children are passed."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "AgentWorkflowContent",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "AgentWorkflowTitle",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "AgentWorkflowMeta",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "AgentWorkflowDetail",
+      "props": [],
+      "extendsNative": true
+    }
+  ],
+  "rag-citations": [
+    {
+      "name": "RagCitations",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "RagCitationsAnswer",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "RagCitationMark",
+      "props": [
+        {
+          "name": "index",
+          "type": "number",
+          "required": true,
+          "default": null,
+          "description": "Citation number, matching the source card with the same index."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "RagCitationsSources",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "RagCitationSource",
+      "props": [
+        {
+          "name": "index",
+          "type": "number",
+          "required": true,
+          "default": null,
+          "description": "Citation number, matching the inline mark with the same index."
+        }
+      ],
+      "extendsNative": true
+    },
+    {
+      "name": "RagCitationSourceTitle",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "RagCitationSourceSnippet",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "RagCitationSourceUrl",
+      "props": [],
+      "extendsNative": true
+    },
+    {
+      "name": "RagCitationScore",
+      "props": [
+        {
+          "name": "score",
+          "type": "React.ReactNode",
+          "required": true,
+          "default": null,
+          "description": "Relevance score for the source, shown as a small chip."
+        }
+      ],
+      "extendsNative": true
+    }
   ]
 }

--- a/registry/hirael/ui/advanced-search-bar.tsx
+++ b/registry/hirael/ui/advanced-search-bar.tsx
@@ -1,0 +1,700 @@
+"use client";
+
+import * as React from "react";
+import { Search, X, ChevronDown, SlidersHorizontal } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@/registry/hirael/ui/input-group";
+import { Badge } from "@/registry/hirael/ui/badge";
+import { Button } from "@/registry/hirael/ui/button";
+
+export type SearchScopeItem = {
+  value: string;
+  label: string;
+};
+
+type RegisteredSuggestion = {
+  value: string;
+  onSelect?: (value: string) => void;
+};
+
+type Ctx = {
+  scopes: SearchScopeItem[];
+  scope: string;
+  setScope: (next: string) => void;
+  query: string;
+  setQuery: (next: string) => void;
+  tokens: string[];
+  addToken: (token: string) => void;
+  removeToken: (index: number) => void;
+  open: boolean;
+  setOpen: (next: boolean) => void;
+  activeId: string | null;
+  setActiveId: (next: string | null) => void;
+  scopeOpen: boolean;
+  setScopeOpen: (next: boolean) => void;
+  registry: React.RefObject<Map<string, RegisteredSuggestion>>;
+  listRef: React.RefObject<HTMLDivElement | null>;
+  move: (delta: number) => void;
+  select: (id: string) => void;
+  commitQuery: () => void;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  rootId: string;
+  listboxId: string;
+};
+
+const AdvancedSearchBarContext = React.createContext<Ctx | null>(null);
+
+function useAdvancedSearchBar() {
+  const ctx = React.useContext(AdvancedSearchBarContext);
+  if (!ctx) {
+    throw new Error(
+      "AdvancedSearchBar compound parts must be used inside <AdvancedSearchBar>",
+    );
+  }
+  return ctx;
+}
+
+const TOKEN_RE = /^([\w.-]+):(\S.*)$/;
+
+function parseToken(raw: string): string | null {
+  const text = raw.trim();
+  const match = TOKEN_RE.exec(text);
+  if (!match) return null;
+  return `${match[1]}:${match[2].trim()}`;
+}
+
+export type AdvancedSearchBarProps = Omit<
+  React.ComponentProps<"div">,
+  "onChange"
+> & {
+  /** The selectable search scopes shown in the leading dropdown. */
+  scopes?: SearchScopeItem[];
+  /** The active scope value (controlled). */
+  scope?: string;
+  /** Default scope value when uncontrolled. */
+  defaultScope?: string;
+  /** Called when the active scope changes. */
+  onScopeChange?: (scope: string) => void;
+  /** The query text (controlled). */
+  value?: string;
+  /** Default query text when uncontrolled. */
+  defaultValue?: string;
+  /** Called when the query text changes. */
+  onValueChange?: (value: string) => void;
+  /** The active filter tokens, each `key:value` (controlled). */
+  tokens?: string[];
+  /** Default filter tokens when uncontrolled. */
+  defaultTokens?: string[];
+  /** Called when the active filter tokens change. */
+  onTokensChange?: (tokens: string[]) => void;
+};
+
+function AdvancedSearchBar({
+  scopes = [{ value: "all", label: "All" }],
+  scope: scopeProp,
+  defaultScope,
+  onScopeChange,
+  value: valueProp,
+  defaultValue,
+  onValueChange,
+  tokens: tokensProp,
+  defaultTokens,
+  onTokensChange,
+  className,
+  children,
+  ...props
+}: AdvancedSearchBarProps) {
+  const rootId = React.useId();
+  const listboxId = `${rootId}-listbox`;
+
+  const [internalScope, setInternalScope] = React.useState(
+    defaultScope ?? scopes[0]?.value ?? "all",
+  );
+  const scope = scopeProp ?? internalScope;
+  const setScope = React.useCallback(
+    (next: string) => {
+      if (scopeProp === undefined) setInternalScope(next);
+      onScopeChange?.(next);
+    },
+    [scopeProp, onScopeChange],
+  );
+
+  const [internalQuery, setInternalQuery] = React.useState(defaultValue ?? "");
+  const query = valueProp ?? internalQuery;
+  const setQuery = React.useCallback(
+    (next: string) => {
+      if (valueProp === undefined) setInternalQuery(next);
+      onValueChange?.(next);
+    },
+    [valueProp, onValueChange],
+  );
+
+  const [internalTokens, setInternalTokens] = React.useState<string[]>(
+    defaultTokens ?? [],
+  );
+  const tokens = tokensProp ?? internalTokens;
+  const setTokens = React.useCallback(
+    (next: string[]) => {
+      if (tokensProp === undefined) setInternalTokens(next);
+      onTokensChange?.(next);
+    },
+    [tokensProp, onTokensChange],
+  );
+
+  const addToken = React.useCallback(
+    (token: string) => {
+      const parsed = parseToken(token);
+      if (!parsed) return;
+      const current = tokensProp ?? internalTokens;
+      if (current.includes(parsed)) return;
+      setTokens([...current, parsed]);
+    },
+    [tokensProp, internalTokens, setTokens],
+  );
+
+  const removeToken = React.useCallback(
+    (index: number) => {
+      const current = tokensProp ?? internalTokens;
+      setTokens(current.filter((_, i) => i !== index));
+    },
+    [tokensProp, internalTokens, setTokens],
+  );
+
+  const [open, setOpen] = React.useState(false);
+  const [activeId, setActiveId] = React.useState<string | null>(null);
+  const [scopeOpen, setScopeOpen] = React.useState(false);
+
+  const registry = React.useRef<Map<string, RegisteredSuggestion>>(new Map());
+  const listRef = React.useRef<HTMLDivElement | null>(null);
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+
+  const optionIds = React.useCallback(() => {
+    const list = listRef.current;
+    if (!list) return [];
+    return Array.from(
+      list.querySelectorAll<HTMLElement>('[data-slot="search-suggestion"]'),
+    ).map((el) => el.id);
+  }, []);
+
+  const move = React.useCallback(
+    (delta: number) => {
+      const ids = optionIds();
+      if (ids.length === 0) return;
+      setOpen(true);
+      setActiveId((current) => {
+        const at = current ? ids.indexOf(current) : -1;
+        const base = at < 0 ? (delta > 0 ? -1 : 0) : at;
+        const nextIndex = (base + delta + ids.length) % ids.length;
+        const nextId = ids[nextIndex];
+        requestAnimationFrame(() => {
+          document
+            .getElementById(nextId)
+            ?.scrollIntoView({ block: "nearest" });
+        });
+        return nextId;
+      });
+    },
+    [optionIds],
+  );
+
+  const commitQuery = React.useCallback(() => {
+    const parsed = parseToken(query);
+    if (parsed) {
+      addToken(parsed);
+      setQuery("");
+    }
+  }, [query, addToken, setQuery]);
+
+  const select = React.useCallback(
+    (id: string) => {
+      const item = registry.current.get(id);
+      if (!item) return;
+      if (item.onSelect) {
+        item.onSelect(item.value);
+      } else if (parseToken(item.value)) {
+        addToken(item.value);
+        setQuery("");
+      } else {
+        setQuery(item.value);
+      }
+      setOpen(false);
+      setActiveId(null);
+      inputRef.current?.focus();
+    },
+    [addToken, setQuery],
+  );
+
+  const ctx = React.useMemo<Ctx>(
+    () => ({
+      scopes,
+      scope,
+      setScope,
+      query,
+      setQuery,
+      tokens,
+      addToken,
+      removeToken,
+      open,
+      setOpen,
+      activeId,
+      setActiveId,
+      scopeOpen,
+      setScopeOpen,
+      registry,
+      listRef,
+      move,
+      select,
+      commitQuery,
+      inputRef,
+      rootId,
+      listboxId,
+    }),
+    [
+      scopes,
+      scope,
+      setScope,
+      query,
+      setQuery,
+      tokens,
+      addToken,
+      removeToken,
+      open,
+      activeId,
+      scopeOpen,
+      move,
+      select,
+      commitQuery,
+      rootId,
+      listboxId,
+    ],
+  );
+
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
+
+  React.useEffect(() => {
+    if (!open && !scopeOpen) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+        setScopeOpen(false);
+        setActiveId(null);
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open, scopeOpen]);
+
+  return (
+    <AdvancedSearchBarContext.Provider value={ctx}>
+      <div
+        ref={containerRef}
+        data-slot="advanced-search-bar"
+        className={cn("relative w-full", className)}
+        {...props}
+      >
+        {children}
+      </div>
+    </AdvancedSearchBarContext.Provider>
+  );
+}
+
+function SearchScope({
+  className,
+  ...props
+}: Omit<React.ComponentProps<"div">, "children">) {
+  const ctx = useAdvancedSearchBar();
+  const active = ctx.scopes.find((s) => s.value === ctx.scope) ?? ctx.scopes[0];
+  const menuId = `${ctx.rootId}-scope`;
+
+  return (
+    <div
+      data-slot="search-scope"
+      className={cn("relative shrink-0", className)}
+      onKeyDown={(e) => {
+        if (e.key === "Escape" && ctx.scopeOpen) {
+          e.preventDefault();
+          ctx.setScopeOpen(false);
+        }
+      }}
+      {...props}
+    >
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        data-slot="search-scope-trigger"
+        aria-haspopup="menu"
+        aria-expanded={ctx.scopeOpen}
+        aria-controls={menuId}
+        onClick={() => ctx.setScopeOpen(!ctx.scopeOpen)}
+        className="h-7 gap-1 rounded-sm border-e border-input px-2 text-muted-foreground hover:text-foreground"
+      >
+        <span className="text-sm">{active?.label}</span>
+        <ChevronDown
+          className={cn(
+            "size-3.5 transition-transform",
+            ctx.scopeOpen && "rotate-180",
+          )}
+        />
+      </Button>
+      {ctx.scopeOpen && (
+        <div
+          id={menuId}
+          role="menu"
+          aria-label="Search scope"
+          data-slot="search-scope-menu"
+          className="absolute top-full z-50 mt-1 min-w-36 overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
+        >
+          {ctx.scopes.map((item) => (
+            <button
+              key={item.value}
+              type="button"
+              role="menuitemradio"
+              aria-checked={item.value === ctx.scope}
+              data-slot="search-scope-item"
+              data-active={item.value === ctx.scope || undefined}
+              onClick={() => {
+                ctx.setScope(item.value);
+                ctx.setScopeOpen(false);
+                ctx.inputRef.current?.focus();
+              }}
+              className={cn(
+                "flex w-full cursor-default items-center rounded-sm px-2 py-1.5 text-start text-sm outline-none",
+                "hover:bg-accent hover:text-accent-foreground",
+                item.value === ctx.scope && "bg-accent text-accent-foreground",
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+type SearchFieldProps = Omit<React.ComponentProps<"div">, "onChange"> & {
+  /** Placeholder shown in the text input. */
+  placeholder?: string;
+  /** Render the leading search icon. */
+  icon?: boolean;
+  /** Render the trailing filters button. */
+  filters?: boolean;
+};
+
+function SearchField({
+  className,
+  placeholder = "Search…",
+  icon = true,
+  filters = false,
+  children,
+  ...props
+}: SearchFieldProps) {
+  const ctx = useAdvancedSearchBar();
+  const { query, tokens, open, activeId, listboxId } = ctx;
+  const hasQuery = query.length > 0;
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      ctx.move(1);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      ctx.move(-1);
+    } else if (e.key === "Enter") {
+      if (open && activeId) {
+        e.preventDefault();
+        ctx.select(activeId);
+      } else if (parseToken(query)) {
+        e.preventDefault();
+        ctx.commitQuery();
+      }
+    } else if (e.key === "Escape") {
+      if (open) {
+        e.preventDefault();
+        ctx.setOpen(false);
+        ctx.setActiveId(null);
+      }
+    } else if (e.key === "Backspace" && query.length === 0 && tokens.length > 0) {
+      ctx.removeToken(tokens.length - 1);
+    }
+  };
+
+  return (
+    <InputGroup
+      data-slot="search-field"
+      className={cn("h-auto min-h-9 flex-wrap gap-1 py-1 ps-2 pe-1", className)}
+      {...props}
+    >
+      {icon && (
+        <Search
+          data-slot="search-field-icon"
+          aria-hidden
+          className="size-4 shrink-0 text-muted-foreground"
+        />
+      )}
+      {children}
+      <InputGroupInput
+        ref={ctx.inputRef}
+        type="text"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listboxId}
+        aria-autocomplete="list"
+        aria-activedescendant={open && activeId ? activeId : undefined}
+        data-slot="search-field-input"
+        value={query}
+        placeholder={placeholder}
+        onChange={(e) => {
+          const next = e.target.value;
+          if (/\s$/.test(next) && parseToken(next)) {
+            ctx.addToken(next);
+            ctx.setQuery("");
+            return;
+          }
+          ctx.setQuery(next);
+          ctx.setOpen(true);
+          ctx.setActiveId(null);
+        }}
+        onFocus={() => ctx.setOpen(true)}
+        onKeyDown={handleKeyDown}
+        className="w-auto min-w-32 flex-1 px-1"
+      />
+      {hasQuery && (
+        <InputGroupButton
+          type="button"
+          size="icon-xs"
+          variant="ghost"
+          data-slot="search-field-clear"
+          aria-label="Clear search"
+          onClick={() => {
+            ctx.setQuery("");
+            ctx.setActiveId(null);
+            ctx.inputRef.current?.focus();
+          }}
+          className="order-last text-muted-foreground"
+        >
+          <X />
+        </InputGroupButton>
+      )}
+      {filters && (
+        <InputGroupAddon align="inline-end" className="ps-0">
+          <InputGroupButton
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            data-slot="search-field-filters"
+            aria-label="Filters"
+            className="text-muted-foreground"
+          >
+            <SlidersHorizontal />
+          </InputGroupButton>
+        </InputGroupAddon>
+      )}
+    </InputGroup>
+  );
+}
+
+function SearchTokens({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div">) {
+  const ctx = useAdvancedSearchBar();
+  if (ctx.tokens.length === 0 && !children) return null;
+  return (
+    <div
+      data-slot="search-tokens"
+      className={cn("flex flex-wrap items-center gap-1", className)}
+      {...props}
+    >
+      {children ??
+        ctx.tokens.map((token, i) => (
+          <SearchToken key={`${token}-${i}`} index={i} />
+        ))}
+    </div>
+  );
+}
+
+type SearchTokenProps = Omit<React.ComponentProps<typeof Badge>, "children"> & {
+  /** Index of the token in the active filter list. */
+  index: number;
+  children?: React.ReactNode;
+};
+
+function SearchToken({ index, className, children, ...props }: SearchTokenProps) {
+  const ctx = useAdvancedSearchBar();
+  const token = ctx.tokens[index];
+  if (token === undefined) return null;
+  const [key, ...rest] = token.split(":");
+  const val = rest.join(":");
+  return (
+    <Badge
+      variant="secondary"
+      data-slot="search-token"
+      className={cn("gap-1 ps-2 pe-1 font-normal", className)}
+      {...props}
+    >
+      <span className="min-w-0 truncate">
+        {children ?? (
+          <>
+            <span className="text-muted-foreground">{key}:</span>
+            {val}
+          </>
+        )}
+      </span>
+      <button
+        type="button"
+        tabIndex={-1}
+        aria-label={`Remove ${token}`}
+        onClick={() => ctx.removeToken(index)}
+        className="inline-flex size-3.5 items-center justify-center rounded-[2px] text-secondary-foreground/70 transition-colors hover:bg-secondary-foreground/20 hover:text-secondary-foreground"
+      >
+        <X className="size-2.5" />
+      </button>
+    </Badge>
+  );
+}
+
+function SearchSuggestions({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div">) {
+  const ctx = useAdvancedSearchBar();
+  if (!ctx.open) return null;
+
+  return (
+    <div
+      ref={ctx.listRef}
+      id={ctx.listboxId}
+      role="listbox"
+      aria-label="Suggestions"
+      data-slot="search-suggestions"
+      className={cn(
+        "absolute top-full z-50 mt-1.5 max-h-80 w-full overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+type SearchSuggestionGroupProps = React.ComponentProps<"div"> & {
+  /** Heading shown above the group. */
+  label?: React.ReactNode;
+  /** Mark the group as live results, adding the active-state indicator. */
+  live?: boolean;
+};
+
+function SearchSuggestionGroup({
+  className,
+  label,
+  live = false,
+  children,
+  ...props
+}: SearchSuggestionGroupProps) {
+  return (
+    <div
+      role="group"
+      data-slot="search-suggestion-group"
+      className={cn("py-1 first:pt-0.5 last:pb-0.5", className)}
+      {...props}
+    >
+      {label !== undefined && (
+        <div
+          data-slot="search-suggestion-group-label"
+          className="flex items-center gap-1.5 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground"
+        >
+          {live && <span className="state-dot" aria-hidden />}
+          {label}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}
+
+type SearchSuggestionProps = Omit<React.ComponentProps<"div">, "onSelect"> & {
+  /** Inserted as the query, or added as a token when it reads `key:value`. */
+  value: string;
+  /** Optional leading icon. */
+  icon?: React.ReactNode;
+  /** Run instead of the default insert/add when this suggestion is chosen. */
+  onSelect?: (value: string) => void;
+};
+
+function SearchSuggestion({
+  value,
+  icon,
+  onSelect,
+  className,
+  children,
+  ...props
+}: SearchSuggestionProps) {
+  const ctx = useAdvancedSearchBar();
+  const id = React.useId();
+  const { registry, activeId } = ctx;
+
+  React.useEffect(() => {
+    const map = registry.current;
+    map.set(id, { value, onSelect });
+    return () => {
+      map.delete(id);
+    };
+  }, [registry, id, value, onSelect]);
+
+  const active = activeId === id;
+
+  return (
+    <div
+      id={id}
+      role="option"
+      aria-selected={active}
+      data-slot="search-suggestion"
+      data-active={active || undefined}
+      onPointerDown={(e) => e.preventDefault()}
+      onClick={() => ctx.select(id)}
+      onMouseMove={() => {
+        if (activeId !== id) ctx.setActiveId(id);
+      }}
+      className={cn(
+        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none",
+        active && "bg-accent text-accent-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {icon !== undefined && (
+        <span
+          data-slot="search-suggestion-icon"
+          className="flex size-4 shrink-0 items-center justify-center text-muted-foreground [&_svg]:size-4"
+        >
+          {icon}
+        </span>
+      )}
+      <span className="min-w-0 flex-1 truncate text-start">
+        {children ?? value}
+      </span>
+    </div>
+  );
+}
+
+export {
+  AdvancedSearchBar,
+  SearchScope,
+  SearchField,
+  SearchTokens,
+  SearchToken,
+  SearchSuggestions,
+  SearchSuggestionGroup,
+  SearchSuggestion,
+};

--- a/registry/hirael/ui/agent-workflow.tsx
+++ b/registry/hirael/ui/agent-workflow.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import {
+  Brain,
+  Check,
+  FileOutput,
+  Loader2,
+  Sparkles,
+  Wrench,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type AgentWorkflowStatus = "pending" | "running" | "done" | "error";
+
+type AgentWorkflowKind = "thought" | "tool" | "output";
+
+type AgentWorkflowProps = React.ComponentProps<"ol">;
+
+function AgentWorkflow({ className, ...props }: AgentWorkflowProps) {
+  return (
+    <ol
+      data-slot="agent-workflow"
+      className={cn("flex flex-col", className)}
+      {...props}
+    />
+  );
+}
+
+const agentWorkflowStepVariants = cva(
+  cn(
+    "group/step relative flex gap-3 pb-5 ps-9 last:pb-0",
+    "before:absolute before:start-[11px] before:top-7 before:bottom-0 before:w-px before:bg-border",
+    "last:before:hidden",
+  ),
+  {
+    variants: {
+      status: {
+        pending: "before:bg-border",
+        running: "before:bg-accent-cool/40",
+        done: "before:bg-border",
+        error: "before:bg-border",
+      },
+    },
+    defaultVariants: {
+      status: "pending",
+    },
+  },
+);
+
+type AgentWorkflowStepProps = React.ComponentProps<"li"> &
+  VariantProps<typeof agentWorkflowStepVariants> & {
+    /** Lifecycle of this step. `running` reads as live (accent-cool, pulsing). */
+    status?: AgentWorkflowStatus;
+    /** What the step represents, used to pick a default marker icon. */
+    kind?: AgentWorkflowKind;
+  };
+
+function AgentWorkflowStep({
+  status = "pending",
+  kind,
+  className,
+  ...props
+}: AgentWorkflowStepProps) {
+  return (
+    <li
+      data-slot="agent-workflow-step"
+      data-status={status}
+      data-kind={kind}
+      className={cn(agentWorkflowStepVariants({ status }), className)}
+      {...props}
+    />
+  );
+}
+
+const kindIcons: Record<AgentWorkflowKind, LucideIcon> = {
+  thought: Brain,
+  tool: Wrench,
+  output: Sparkles,
+};
+
+const agentWorkflowMarkerVariants = cva(
+  "absolute start-0 top-0 z-10 inline-flex size-[22px] shrink-0 items-center justify-center rounded-full border bg-background [&_svg]:size-3",
+  {
+    variants: {
+      status: {
+        pending: "border-border text-muted-foreground",
+        running:
+          "border-accent-cool text-accent-cool shadow-[0_0_10px_1px_var(--accent-cool-glow)]",
+        done: "border-success/40 text-success",
+        error: "border-destructive/40 text-destructive",
+      },
+    },
+    defaultVariants: {
+      status: "pending",
+    },
+  },
+);
+
+type AgentWorkflowMarkerProps = React.ComponentProps<"span"> &
+  VariantProps<typeof agentWorkflowMarkerVariants> & {
+    /** Lifecycle of the step this marker belongs to. */
+    status?: AgentWorkflowStatus;
+    /** What the step represents. Picks the fallback icon when no children are passed. */
+    kind?: AgentWorkflowKind;
+  };
+
+function AgentWorkflowMarker({
+  status = "pending",
+  kind,
+  className,
+  children,
+  ...props
+}: AgentWorkflowMarkerProps) {
+  return (
+    <span
+      data-slot="agent-workflow-marker"
+      data-status={status}
+      className={cn(agentWorkflowMarkerVariants({ status }), className)}
+      {...props}
+    >
+      {children ?? renderMarkerIcon(status, kind)}
+      {status === "running" ? (
+        <span aria-hidden className="state-dot absolute -end-0.5 -top-0.5" />
+      ) : null}
+    </span>
+  );
+}
+
+function renderMarkerIcon(
+  status: AgentWorkflowStatus,
+  kind?: AgentWorkflowKind,
+): React.ReactElement {
+  if (status === "done") return <Check aria-hidden />;
+  if (status === "error") return <X aria-hidden />;
+  if (status === "running") {
+    return (
+      <Loader2 aria-hidden className="animate-spin motion-reduce:animate-none" />
+    );
+  }
+  const Icon = kind ? kindIcons[kind] : FileOutput;
+  return <Icon aria-hidden />;
+}
+
+type AgentWorkflowContentProps = React.ComponentProps<"div">;
+
+function AgentWorkflowContent({
+  className,
+  ...props
+}: AgentWorkflowContentProps) {
+  return (
+    <div
+      data-slot="agent-workflow-content"
+      className={cn("flex min-w-0 flex-1 flex-col gap-1", className)}
+      {...props}
+    />
+  );
+}
+
+type AgentWorkflowTitleProps = React.ComponentProps<"p">;
+
+function AgentWorkflowTitle({ className, ...props }: AgentWorkflowTitleProps) {
+  return (
+    <p
+      data-slot="agent-workflow-title"
+      className={cn(
+        "text-sm font-medium leading-snug text-foreground group-data-[status=pending]/step:text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type AgentWorkflowMetaProps = React.ComponentProps<"div">;
+
+function AgentWorkflowMeta({ className, ...props }: AgentWorkflowMetaProps) {
+  return (
+    <div
+      data-slot="agent-workflow-meta"
+      className={cn(
+        "flex flex-wrap items-center gap-x-2 gap-y-0.5 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type AgentWorkflowDetailProps = React.ComponentProps<"div">;
+
+function AgentWorkflowDetail({ className, ...props }: AgentWorkflowDetailProps) {
+  return (
+    <div
+      data-slot="agent-workflow-detail"
+      className={cn(
+        "mt-1 rounded-md border border-border bg-muted/30 px-3 py-2 text-[13px] leading-relaxed text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  AgentWorkflow,
+  AgentWorkflowStep,
+  AgentWorkflowMarker,
+  AgentWorkflowContent,
+  AgentWorkflowTitle,
+  AgentWorkflowMeta,
+  AgentWorkflowDetail,
+};

--- a/registry/hirael/ui/ai-chat.tsx
+++ b/registry/hirael/ui/ai-chat.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/registry/hirael/ui/button";
+
+type AiChatProps = React.ComponentProps<"div">;
+
+function AiChat({ className, ...props }: AiChatProps) {
+  return (
+    <div
+      data-slot="ai-chat"
+      className={cn(
+        "flex flex-col overflow-hidden rounded-lg border border-border bg-card text-card-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type AiChatMessagesProps = React.ComponentProps<"div">;
+
+function AiChatMessages({ className, ...props }: AiChatMessagesProps) {
+  return (
+    <div
+      data-slot="ai-chat-messages"
+      className={cn("flex flex-1 flex-col gap-5 overflow-y-auto p-4", className)}
+      {...props}
+    />
+  );
+}
+
+type AiChatMessageProps = React.ComponentProps<"div"> & {
+  /** Who sent the message. Lays the row out from the start (assistant) or the end (user). */
+  role: "user" | "assistant";
+};
+
+function AiChatMessage({ role, className, ...props }: AiChatMessageProps) {
+  return (
+    <div
+      data-slot="ai-chat-message"
+      data-role={role}
+      className={cn(
+        "flex w-full gap-3",
+        role === "user" ? "flex-row-reverse" : "flex-row",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type AiChatAvatarProps = React.ComponentProps<"span"> & {
+  /** Image source for the avatar. Falls back to children (initials or an icon) when absent. */
+  src?: string;
+  /** Alt text for the avatar image. */
+  alt?: string;
+};
+
+function AiChatAvatar({
+  src,
+  alt,
+  className,
+  children,
+  ...props
+}: AiChatAvatarProps) {
+  return (
+    <span
+      data-slot="ai-chat-avatar"
+      className={cn(
+        "inline-flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-full border border-border bg-muted text-[11px] font-medium text-muted-foreground [&_svg]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {src ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={src}
+          alt={alt ?? ""}
+          loading="lazy"
+          className="size-full object-cover"
+        />
+      ) : (
+        children
+      )}
+    </span>
+  );
+}
+
+type AiChatGroupProps = React.ComponentProps<"div"> & {
+  /** Aligns the bubble, actions, and timestamp stack to the start (assistant) or the end (user). */
+  role: "user" | "assistant";
+};
+
+function AiChatGroup({ role, className, ...props }: AiChatGroupProps) {
+  return (
+    <div
+      data-slot="ai-chat-group"
+      data-role={role}
+      className={cn(
+        "flex min-w-0 flex-col gap-1.5",
+        role === "user" ? "items-end" : "items-start",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const bubbleVariants = cva(
+  "w-fit max-w-[34rem] rounded-2xl px-3.5 py-2.5 text-sm leading-relaxed whitespace-pre-wrap break-words",
+  {
+    variants: {
+      role: {
+        user: "rounded-ee-sm bg-primary text-primary-foreground",
+        assistant: "rounded-es-sm border border-border bg-card text-foreground",
+      },
+      tone: {
+        solid: "",
+        muted: "",
+      },
+    },
+    compoundVariants: [
+      {
+        role: "user",
+        tone: "muted",
+        className: "bg-muted text-foreground",
+      },
+    ],
+    defaultVariants: {
+      role: "assistant",
+      tone: "solid",
+    },
+  },
+);
+
+type AiChatBubbleProps = React.ComponentProps<"div"> &
+  VariantProps<typeof bubbleVariants> & {
+    /** Who sent the message. Selects the user or assistant surface. */
+    role: "user" | "assistant";
+  };
+
+function AiChatBubble({ role, tone, className, ...props }: AiChatBubbleProps) {
+  return (
+    <div
+      data-slot="ai-chat-bubble"
+      data-role={role}
+      className={cn(bubbleVariants({ role, tone }), className)}
+      {...props}
+    />
+  );
+}
+
+type AiChatActionsProps = React.ComponentProps<"div">;
+
+function AiChatActions({ className, ...props }: AiChatActionsProps) {
+  return (
+    <div
+      data-slot="ai-chat-actions"
+      className={cn(
+        "flex items-center gap-0.5 text-muted-foreground [&_svg]:size-3.5",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type AiChatTypingProps = React.ComponentProps<"div"> & {
+  /** Accessible label announced while the reply is pending. Defaults to "Assistant is typing". */
+  label?: string;
+};
+
+function AiChatTyping({
+  label = "Assistant is typing",
+  className,
+  ...props
+}: AiChatTypingProps) {
+  return (
+    <div
+      data-slot="ai-chat-typing"
+      role="status"
+      aria-live="polite"
+      aria-label={label}
+      className={cn(
+        "flex w-fit items-center gap-1 rounded-2xl rounded-es-sm border border-border bg-card px-3.5 py-3",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        aria-hidden
+        className="size-1.5 animate-bounce rounded-full bg-muted-foreground/70 [animation-delay:-0.3s] motion-reduce:animate-pulse"
+      />
+      <span
+        aria-hidden
+        className="size-1.5 animate-bounce rounded-full bg-muted-foreground/70 [animation-delay:-0.15s] motion-reduce:animate-pulse"
+      />
+      <span
+        aria-hidden
+        className="size-1.5 animate-bounce rounded-full bg-muted-foreground/70 motion-reduce:animate-pulse"
+      />
+      <span className="sr-only">{label}</span>
+    </div>
+  );
+}
+
+type AiChatComposerProps = React.ComponentProps<"form">;
+
+function AiChatComposer({ className, ...props }: AiChatComposerProps) {
+  return (
+    <form
+      data-slot="ai-chat-composer"
+      className={cn(
+        "flex items-end gap-2 border-t border-border bg-card p-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type AiChatInputProps = Omit<React.ComponentProps<"textarea">, "onSubmit"> & {
+  /** Called when the message is submitted with Enter (Shift+Enter inserts a newline). */
+  onSubmit?: () => void;
+};
+
+function AiChatInput({
+  className,
+  rows = 1,
+  onKeyDown,
+  onSubmit,
+  ...props
+}: AiChatInputProps) {
+  function handleKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
+    onKeyDown?.(event);
+    if (event.defaultPrevented) return;
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      if (onSubmit) {
+        onSubmit();
+      } else {
+        event.currentTarget.form?.requestSubmit();
+      }
+    }
+  }
+
+  return (
+    <textarea
+      data-slot="ai-chat-input"
+      rows={rows}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        "field-sizing-content max-h-40 min-h-9 w-full resize-none rounded-md border border-input bg-background px-3 py-2 text-sm leading-relaxed text-foreground outline-none transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type AiChatSendProps = React.ComponentProps<typeof Button> & {
+  /** Accessible label for the send button. Defaults to "Send message". */
+  label?: string;
+};
+
+function AiChatSend({
+  label = "Send message",
+  className,
+  children,
+  ...props
+}: AiChatSendProps) {
+  return (
+    <Button
+      type="submit"
+      size="icon"
+      data-slot="ai-chat-send"
+      aria-label={label}
+      className={cn("shrink-0", className)}
+      {...props}
+    >
+      {children}
+    </Button>
+  );
+}
+
+type AiChatTimestampProps = React.ComponentProps<"time">;
+
+function AiChatTimestamp({ className, ...props }: AiChatTimestampProps) {
+  return (
+    <time
+      data-slot="ai-chat-timestamp"
+      className={cn(
+        "font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  AiChat,
+  AiChatMessages,
+  AiChatMessage,
+  AiChatAvatar,
+  AiChatGroup,
+  AiChatBubble,
+  AiChatActions,
+  AiChatTyping,
+  AiChatComposer,
+  AiChatInput,
+  AiChatSend,
+  AiChatTimestamp,
+};

--- a/registry/hirael/ui/ai-completion-input.tsx
+++ b/registry/hirael/ui/ai-completion-input.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type AiCompletionCtx = {
+  value: string;
+  setValue: (next: string) => void;
+  suggestion: string;
+  remainder: string;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  fieldId: string;
+  hintId: string;
+  disabled: boolean;
+  accept: () => void;
+  dismiss: () => void;
+};
+
+const AiCompletionContext = React.createContext<AiCompletionCtx | null>(null);
+
+function useAiCompletion() {
+  const ctx = React.useContext(AiCompletionContext);
+  if (!ctx) {
+    throw new Error(
+      "AiCompletionInput compound parts must be used inside <AiCompletionInput>",
+    );
+  }
+  return ctx;
+}
+
+function getRemainder(value: string, suggestion: string) {
+  if (!suggestion) return "";
+  if (!value) return suggestion;
+  if (!suggestion.startsWith(value)) return "";
+  return suggestion.slice(value.length);
+}
+
+export type AiCompletionInputProps = Omit<
+  React.ComponentProps<"div">,
+  "defaultValue" | "onChange"
+> & {
+  /** The current text. Controls the field when provided. */
+  value?: string;
+  defaultValue?: string;
+  /** Called with the next text whenever the typed value changes. */
+  onValueChange?: (value: string) => void;
+  /** The predicted completion string, supplied by the consumer. The part not already typed is shown as ghost text. */
+  suggestion?: string;
+  /** Called with the full accepted text when the ghost suggestion is accepted. */
+  onAccept?: (value: string) => void;
+  disabled?: boolean;
+};
+
+function AiCompletionInput({
+  value: valueProp,
+  defaultValue = "",
+  onValueChange,
+  suggestion = "",
+  onAccept,
+  disabled = false,
+  className,
+  children,
+  ...props
+}: AiCompletionInputProps) {
+  const fieldId = React.useId();
+  const hintId = `${fieldId}-hint`;
+
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+
+  const [internalValue, setInternalValue] = React.useState(defaultValue);
+  const value = valueProp ?? internalValue;
+
+  const setValue = React.useCallback(
+    (next: string) => {
+      if (valueProp === undefined) setInternalValue(next);
+      onValueChange?.(next);
+    },
+    [valueProp, onValueChange],
+  );
+
+  const remainder = getRemainder(value, suggestion);
+
+  const accept = React.useCallback(() => {
+    if (disabled || !remainder) return;
+    const next = value + remainder;
+    setValue(next);
+    onAccept?.(next);
+    const node = inputRef.current;
+    if (node) {
+      requestAnimationFrame(() => {
+        node.focus();
+        node.setSelectionRange(next.length, next.length);
+      });
+    }
+  }, [disabled, remainder, value, setValue, onAccept]);
+
+  const dismiss = React.useCallback(() => {
+    const node = inputRef.current;
+    if (node) node.focus();
+  }, []);
+
+  const ctx = React.useMemo<AiCompletionCtx>(
+    () => ({
+      value,
+      setValue,
+      suggestion,
+      remainder,
+      inputRef,
+      fieldId,
+      hintId,
+      disabled,
+      accept,
+      dismiss,
+    }),
+    [
+      value,
+      setValue,
+      suggestion,
+      remainder,
+      fieldId,
+      hintId,
+      disabled,
+      accept,
+      dismiss,
+    ],
+  );
+
+  return (
+    <AiCompletionContext.Provider value={ctx}>
+      <div
+        data-slot="ai-completion-input"
+        data-disabled={disabled || undefined}
+        className={cn("group/ai-completion grid w-full gap-1.5", className)}
+        {...props}
+      >
+        {children}
+      </div>
+    </AiCompletionContext.Provider>
+  );
+}
+
+const METRICS =
+  "h-9 w-full rounded-md border px-3 py-1 text-sm leading-normal";
+
+export type AiCompletionFieldProps = Omit<
+  React.ComponentProps<"input">,
+  "value" | "defaultValue" | "onChange" | "type"
+> & {
+  placeholder?: string;
+};
+
+function AiCompletionField({
+  className,
+  placeholder,
+  onKeyDown,
+  ...props
+}: AiCompletionFieldProps) {
+  const {
+    value,
+    setValue,
+    remainder,
+    inputRef,
+    fieldId,
+    hintId,
+    disabled,
+    accept,
+    dismiss,
+  } = useAiCompletion();
+
+  const [dismissed, setDismissed] = React.useState(false);
+  const visible = remainder.length > 0 && !dismissed;
+
+  return (
+    <div
+      data-slot="ai-completion-field"
+      data-disabled={disabled || undefined}
+      className={cn(
+        "relative w-full",
+        disabled && "cursor-not-allowed opacity-50",
+        className,
+      )}
+    >
+      <div
+        aria-hidden
+        data-slot="ai-completion-overlay"
+        className={cn(
+          METRICS,
+          "pointer-events-none absolute inset-0 flex items-center overflow-hidden whitespace-pre border-transparent text-transparent",
+        )}
+      >
+        <span className="whitespace-pre">{value}</span>
+        {visible ? (
+          <span
+            data-slot="ai-completion-ghost"
+            className="whitespace-pre text-muted-foreground"
+          >
+            {remainder}
+          </span>
+        ) : null}
+      </div>
+      <input
+        ref={inputRef}
+        id={fieldId}
+        type="text"
+        value={value}
+        placeholder={placeholder}
+        disabled={disabled}
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
+        aria-describedby={visible ? hintId : undefined}
+        data-slot="ai-completion-control"
+        onChange={(event) => {
+          setDismissed(false);
+          setValue(event.target.value);
+        }}
+        onKeyDown={(event) => {
+          onKeyDown?.(event);
+          if (event.defaultPrevented) return;
+          if (!visible) return;
+          const node = event.currentTarget;
+          const atEnd =
+            node.selectionStart === node.value.length &&
+            node.selectionEnd === node.value.length;
+          if (event.key === "Tab" || (event.key === "ArrowRight" && atEnd)) {
+            event.preventDefault();
+            accept();
+          } else if (event.key === "Escape") {
+            event.preventDefault();
+            setDismissed(true);
+            dismiss();
+          }
+        }}
+        className={cn(
+          METRICS,
+          "relative bg-transparent text-foreground border-input shadow-xs transition-[color,box-shadow] outline-none",
+          "selection:bg-primary selection:text-primary-foreground",
+          "placeholder:text-muted-foreground",
+          "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+          "disabled:pointer-events-none",
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+export type AiCompletionGhostProps = React.ComponentProps<"span">;
+
+function AiCompletionGhost({
+  className,
+  children,
+  ...props
+}: AiCompletionGhostProps) {
+  const { remainder } = useAiCompletion();
+
+  if (!remainder) return null;
+
+  return (
+    <span
+      data-slot="ai-completion-ghost"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    >
+      {children ?? remainder}
+    </span>
+  );
+}
+
+export type AiCompletionHintProps = React.ComponentProps<"div"> & {
+  /** Shown when no suggestion is pending. Hidden by default. */
+  idleChildren?: React.ReactNode;
+};
+
+function AiCompletionHint({
+  className,
+  children,
+  idleChildren = null,
+  ...props
+}: AiCompletionHintProps) {
+  const { remainder, hintId } = useAiCompletion();
+
+  if (!remainder) {
+    if (!idleChildren) return null;
+    return (
+      <div
+        data-slot="ai-completion-hint"
+        data-state="idle"
+        className={cn(
+          "flex items-center gap-1.5 text-xs text-muted-foreground",
+          className,
+        )}
+        {...props}
+      >
+        {idleChildren}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      id={hintId}
+      data-slot="ai-completion-hint"
+      data-state="active"
+      className={cn(
+        "flex items-center gap-1.5 text-xs text-muted-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <span
+            data-slot="ai-completion-hint-key"
+            className="inline-flex h-5 min-w-5 items-center justify-center rounded-sm border border-border bg-muted px-1 font-sans text-[11px] font-medium text-muted-foreground"
+          >
+            Tab
+          </span>
+          <span>to accept</span>
+        </>
+      )}
+    </div>
+  );
+}
+
+export {
+  AiCompletionInput,
+  AiCompletionField,
+  AiCompletionGhost,
+  AiCompletionHint,
+};

--- a/registry/hirael/ui/ai-tool-call.tsx
+++ b/registry/hirael/ui/ai-tool-call.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Check, ChevronDown, Wrench, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/registry/hirael/ui/collapsible";
+
+type AiToolCallStatus = "pending" | "success" | "error";
+
+const AiToolCallStatusContext = React.createContext<AiToolCallStatus>("pending");
+
+function useAiToolCallStatus() {
+  return React.useContext(AiToolCallStatusContext);
+}
+
+type AiToolCallProps = Omit<
+  React.ComponentProps<typeof Collapsible>,
+  "asChild"
+> & {
+  /** Lifecycle of the tool call. Drives the badge, dot, and default open state. */
+  status?: AiToolCallStatus;
+};
+
+function AiToolCall({
+  status = "pending",
+  open,
+  defaultOpen,
+  className,
+  children,
+  ...props
+}: AiToolCallProps) {
+  return (
+    <AiToolCallStatusContext.Provider value={status}>
+      <Collapsible
+        data-slot="ai-tool-call"
+        data-status={status}
+        open={open}
+        defaultOpen={defaultOpen ?? status === "error"}
+        className={cn(
+          "overflow-hidden rounded-md border border-border bg-card",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </Collapsible>
+    </AiToolCallStatusContext.Provider>
+  );
+}
+
+type AiToolCallTriggerProps = Omit<
+  React.ComponentProps<typeof CollapsibleTrigger>,
+  "children"
+> & {
+  /** The tool or function name, rendered in mono as the row label. */
+  name: string;
+  icon?: React.ReactNode;
+};
+
+function AiToolCallTrigger({
+  name,
+  icon,
+  className,
+  ...props
+}: AiToolCallTriggerProps) {
+  return (
+    <CollapsibleTrigger
+      data-slot="ai-tool-call-trigger"
+      className={cn(
+        "group flex w-full items-center gap-3 px-4 py-3 text-start transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        data-slot="ai-tool-call-icon"
+        className="flex size-6 shrink-0 items-center justify-center rounded-sm border border-border bg-muted/40 text-muted-foreground [&_svg]:size-3.5"
+        aria-hidden
+      >
+        {icon ?? <Wrench />}
+      </span>
+      <code
+        data-slot="ai-tool-call-name"
+        className="min-w-0 flex-1 truncate font-mono text-sm text-foreground"
+      >
+        {name}
+      </code>
+      <AiToolCallStatusBadge />
+      <ChevronDown
+        aria-hidden
+        className="size-3.5 shrink-0 text-muted-foreground transition-transform duration-150 group-data-[state=open]:rotate-180 rtl:rotate-180 rtl:group-data-[state=open]:rotate-0"
+      />
+    </CollapsibleTrigger>
+  );
+}
+
+const aiToolCallBadgeVariants = cva(
+  "inline-flex shrink-0 items-center gap-1.5 rounded-sm border px-1.5 py-0.5 font-mono text-[10px] uppercase leading-none tracking-[0.08em] [&_svg]:size-3",
+  {
+    variants: {
+      status: {
+        pending: "border-border text-muted-foreground",
+        success: "border-success/30 text-success",
+        error: "border-destructive/30 text-destructive",
+      },
+    },
+    defaultVariants: {
+      status: "pending",
+    },
+  },
+);
+
+const aiToolCallStatusLabels: Record<AiToolCallStatus, string> = {
+  pending: "Running",
+  success: "Done",
+  error: "Error",
+};
+
+type AiToolCallStatusBadgeProps = Omit<
+  React.ComponentProps<"span">,
+  "children"
+> &
+  VariantProps<typeof aiToolCallBadgeVariants>;
+
+function AiToolCallStatusBadge({
+  status: statusProp,
+  className,
+  ...props
+}: AiToolCallStatusBadgeProps) {
+  const contextStatus = useAiToolCallStatus();
+  const status = statusProp ?? contextStatus;
+
+  return (
+    <span
+      data-slot="ai-tool-call-status"
+      data-status={status}
+      className={cn(aiToolCallBadgeVariants({ status }), className)}
+      {...props}
+    >
+      <AiToolCallStatusDot status={status} />
+      {aiToolCallStatusLabels[status]}
+    </span>
+  );
+}
+
+type AiToolCallStatusDotProps = React.ComponentProps<"span"> & {
+  status?: AiToolCallStatus;
+};
+
+function AiToolCallStatusDot({
+  status: statusProp,
+  className,
+  ...props
+}: AiToolCallStatusDotProps) {
+  const contextStatus = useAiToolCallStatus();
+  const status = statusProp ?? contextStatus;
+
+  if (status === "pending") {
+    return (
+      <span
+        data-slot="ai-tool-call-status-dot"
+        data-status={status}
+        className={cn("state-dot", className)}
+        {...props}
+      />
+    );
+  }
+
+  if (status === "success") {
+    return <Check data-slot="ai-tool-call-status-dot" aria-hidden />;
+  }
+
+  return <X data-slot="ai-tool-call-status-dot" aria-hidden />;
+}
+
+type AiToolCallContentProps = React.ComponentProps<typeof CollapsibleContent>;
+
+function AiToolCallContent({
+  className,
+  children,
+  ...props
+}: AiToolCallContentProps) {
+  return (
+    <CollapsibleContent asChild>
+      <div
+        data-slot="ai-tool-call-content"
+        className={cn(
+          "flex flex-col gap-4 border-t border-border bg-muted/30 px-4 py-3",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </CollapsibleContent>
+  );
+}
+
+type AiToolCallSectionProps = React.ComponentProps<"section"> & {
+  /** Label shown above the block, e.g. "Arguments" or "Result". */
+  label: React.ReactNode;
+};
+
+function AiToolCallSection({
+  label,
+  className,
+  children,
+  ...props
+}: AiToolCallSectionProps) {
+  return (
+    <section
+      data-slot="ai-tool-call-section"
+      className={cn("flex flex-col gap-1.5", className)}
+      {...props}
+    >
+      <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+        {label}
+      </p>
+      {children}
+    </section>
+  );
+}
+
+function AiToolCallJson({
+  value,
+  className,
+  ...props
+}: React.ComponentProps<"pre"> & {
+  /** Any JSON-serializable value, rendered pretty-printed with two-space indent. */
+  value: unknown;
+}) {
+  return (
+    <pre
+      className={cn(
+        "overflow-x-auto rounded-sm border border-border bg-background p-3 font-mono text-[12px] leading-relaxed text-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {JSON.stringify(value, null, 2)}
+    </pre>
+  );
+}
+
+type AiToolCallArgumentsProps = Omit<
+  React.ComponentProps<typeof AiToolCallJson>,
+  "value"
+> & {
+  /** The call arguments object, shown as pretty-printed JSON. */
+  value: unknown;
+};
+
+function AiToolCallArguments({ ...props }: AiToolCallArgumentsProps) {
+  return <AiToolCallJson data-slot="ai-tool-call-arguments" {...props} />;
+}
+
+type AiToolCallResultProps = Omit<
+  React.ComponentProps<typeof AiToolCallJson>,
+  "value"
+> & {
+  /** The value the tool returned, shown as pretty-printed JSON. */
+  value: unknown;
+};
+
+function AiToolCallResult({ ...props }: AiToolCallResultProps) {
+  return <AiToolCallJson data-slot="ai-tool-call-result" {...props} />;
+}
+
+export {
+  AiToolCall,
+  AiToolCallTrigger,
+  AiToolCallStatusBadge,
+  AiToolCallStatusDot,
+  AiToolCallContent,
+  AiToolCallSection,
+  AiToolCallArguments,
+  AiToolCallResult,
+  type AiToolCallStatus,
+};

--- a/registry/hirael/ui/approval-workflow.tsx
+++ b/registry/hirael/ui/approval-workflow.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Check, Clock, User, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type ApprovalWorkflowStatus = "approved" | "rejected" | "pending" | "current";
+
+type ApprovalWorkflowProps = React.ComponentProps<"ol">;
+
+function ApprovalWorkflow({ className, ...props }: ApprovalWorkflowProps) {
+  return (
+    <ol
+      data-slot="approval-workflow"
+      className={cn("flex flex-col", className)}
+      {...props}
+    />
+  );
+}
+
+const approvalStepVariants = cva(
+  cn(
+    "group/step relative flex gap-3 pb-6 ps-12 last:pb-0",
+    "before:absolute before:start-[15px] before:top-9 before:bottom-0 before:w-px",
+    "last:before:hidden",
+  ),
+  {
+    variants: {
+      status: {
+        approved: "before:bg-success/40",
+        rejected: "before:bg-destructive/40",
+        pending: "before:bg-border",
+        current: "before:bg-accent-cool/40",
+      },
+    },
+    defaultVariants: {
+      status: "pending",
+    },
+  },
+);
+
+type ApprovalStepProps = React.ComponentProps<"li"> &
+  VariantProps<typeof approvalStepVariants> & {
+    /** Outcome of this stage. `current` reads as live (accent-cool, pulsing) and is the step awaiting action. */
+    status?: ApprovalWorkflowStatus;
+  };
+
+function ApprovalStep({
+  status = "pending",
+  className,
+  ...props
+}: ApprovalStepProps) {
+  return (
+    <li
+      data-slot="approval-step"
+      data-status={status}
+      className={cn(approvalStepVariants({ status }), className)}
+      {...props}
+    />
+  );
+}
+
+const approvalStepMarkerVariants = cva(
+  "absolute start-0 top-0 z-10 inline-flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-full border bg-background text-[11px] font-medium [&_svg]:size-4",
+  {
+    variants: {
+      status: {
+        approved: "border-success/40 text-success",
+        rejected: "border-destructive/40 text-destructive",
+        pending: "border-border text-muted-foreground",
+        current:
+          "border-accent-cool text-accent-cool shadow-[0_0_10px_1px_var(--accent-cool-glow)]",
+      },
+    },
+    defaultVariants: {
+      status: "pending",
+    },
+  },
+);
+
+type ApprovalStepMarkerProps = React.ComponentProps<"span"> &
+  VariantProps<typeof approvalStepMarkerVariants> & {
+    /** Outcome of the stage this marker belongs to. */
+    status?: ApprovalWorkflowStatus;
+    /** Avatar image for the approver. Falls back to children, then a status icon. */
+    src?: string;
+    /** Alt text for the avatar image. */
+    alt?: string;
+  };
+
+function ApprovalStepMarker({
+  status = "pending",
+  src,
+  alt,
+  className,
+  children,
+  ...props
+}: ApprovalStepMarkerProps) {
+  return (
+    <span
+      data-slot="approval-step-marker"
+      data-status={status}
+      className={cn(approvalStepMarkerVariants({ status }), className)}
+      {...props}
+    >
+      {src ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={src}
+          alt={alt ?? ""}
+          loading="lazy"
+          className="size-full object-cover"
+        />
+      ) : (
+        (children ?? renderMarkerIcon(status))
+      )}
+      {status === "current" ? (
+        <span aria-hidden className="state-dot absolute -end-0.5 -top-0.5" />
+      ) : null}
+    </span>
+  );
+}
+
+function renderMarkerIcon(
+  status: ApprovalWorkflowStatus,
+): React.ReactElement {
+  if (status === "approved") return <Check aria-hidden />;
+  if (status === "rejected") return <X aria-hidden />;
+  if (status === "pending") return <Clock aria-hidden />;
+  return <User aria-hidden />;
+}
+
+type ApprovalStepContentProps = React.ComponentProps<"div">;
+
+function ApprovalStepContent({
+  className,
+  ...props
+}: ApprovalStepContentProps) {
+  return (
+    <div
+      data-slot="approval-step-content"
+      className={cn("flex min-w-0 flex-1 flex-col gap-1 pt-1", className)}
+      {...props}
+    />
+  );
+}
+
+type ApprovalStepTitleProps = React.ComponentProps<"p">;
+
+function ApprovalStepTitle({ className, ...props }: ApprovalStepTitleProps) {
+  return (
+    <p
+      data-slot="approval-step-title"
+      className={cn(
+        "text-sm font-medium leading-snug text-foreground group-data-[status=pending]/step:text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type ApprovalStepMetaProps = React.ComponentProps<"div">;
+
+function ApprovalStepMeta({ className, ...props }: ApprovalStepMetaProps) {
+  return (
+    <div
+      data-slot="approval-step-meta"
+      className={cn(
+        "flex flex-wrap items-center gap-x-2 gap-y-0.5 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type ApprovalStepCommentProps = React.ComponentProps<"blockquote">;
+
+function ApprovalStepComment({
+  className,
+  ...props
+}: ApprovalStepCommentProps) {
+  return (
+    <blockquote
+      data-slot="approval-step-comment"
+      className={cn(
+        "mt-1 border-s-2 border-border bg-muted/30 px-3 py-2 text-[13px] leading-relaxed text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type ApprovalStepActionsProps = React.ComponentProps<"div">;
+
+function ApprovalStepActions({
+  className,
+  ...props
+}: ApprovalStepActionsProps) {
+  return (
+    <div
+      data-slot="approval-step-actions"
+      className={cn("mt-2 flex flex-wrap items-center gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  ApprovalWorkflow,
+  ApprovalStep,
+  ApprovalStepMarker,
+  ApprovalStepContent,
+  ApprovalStepTitle,
+  ApprovalStepMeta,
+  ApprovalStepComment,
+  ApprovalStepActions,
+};

--- a/registry/hirael/ui/asset-manager.tsx
+++ b/registry/hirael/ui/asset-manager.tsx
@@ -1,0 +1,611 @@
+"use client";
+
+import * as React from "react";
+import {
+  Download,
+  FileText,
+  Film,
+  Image as ImageIcon,
+  LayoutGrid,
+  List,
+  Music,
+  Search,
+  Trash2,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/registry/hirael/ui/badge";
+import { Button } from "@/registry/hirael/ui/button";
+
+export type AssetType = "image" | "video" | "audio" | "document";
+
+export type Asset = {
+  id: string;
+  name: string;
+  type: AssetType;
+  size: number;
+  url?: string;
+  modified?: string;
+  dimensions?: string;
+  tags?: string[];
+};
+
+export type AssetView = "grid" | "list";
+
+const TYPE_ICON: Record<AssetType, React.ComponentType<{ className?: string }>> =
+  {
+    image: ImageIcon,
+    video: Film,
+    audio: Music,
+    document: FileText,
+  };
+
+const TYPE_LABEL: Record<AssetType, string> = {
+  image: "Image",
+  video: "Video",
+  audio: "Audio",
+  document: "Document",
+};
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"] as const;
+  let i = 0;
+  let n = bytes;
+  while (n >= 1024 && i < units.length - 1) {
+    n /= 1024;
+    i++;
+  }
+  const fixed = i === 0 ? n.toFixed(0) : n.toFixed(1);
+  return `${fixed} ${units[i]}`;
+}
+
+type Ctx = {
+  assets: Asset[];
+  filtered: Asset[];
+  view: AssetView;
+  setView: (view: AssetView) => void;
+  query: string;
+  setQuery: (query: string) => void;
+  selectedIds: string[];
+  selectedAsset: Asset | null;
+  isSelected: (id: string) => boolean;
+  select: (id: string, additive?: boolean) => void;
+  toggle: (id: string) => void;
+};
+
+const AssetManagerContext = React.createContext<Ctx | null>(null);
+
+function useAssetManager(): Ctx {
+  const ctx = React.useContext(AssetManagerContext);
+  if (!ctx) {
+    throw new Error(
+      "AssetManager compound parts must be used inside <AssetManager>",
+    );
+  }
+  return ctx;
+}
+
+export type AssetManagerProps = React.ComponentProps<"div"> & {
+  /** Assets to display in the library. */
+  assets: Asset[];
+  /** Initial layout for an uncontrolled manager. */
+  defaultView?: AssetView;
+  /** Id of the asset selected on first render. */
+  defaultSelectedId?: string;
+};
+
+function AssetManager({
+  assets,
+  defaultView = "grid",
+  defaultSelectedId,
+  className,
+  children,
+  ...props
+}: AssetManagerProps) {
+  const [view, setView] = React.useState<AssetView>(defaultView);
+  const [query, setQuery] = React.useState("");
+  const [selectedIds, setSelectedIds] = React.useState<string[]>(
+    defaultSelectedId ? [defaultSelectedId] : [],
+  );
+
+  const filtered = React.useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return assets;
+    return assets.filter(
+      (asset) =>
+        asset.name.toLowerCase().includes(q) ||
+        asset.type.toLowerCase().includes(q) ||
+        asset.tags?.some((tag) => tag.toLowerCase().includes(q)),
+    );
+  }, [assets, query]);
+
+  const isSelected = React.useCallback(
+    (id: string) => selectedIds.includes(id),
+    [selectedIds],
+  );
+
+  const select = React.useCallback((id: string, additive = false) => {
+    setSelectedIds((current) => {
+      if (additive) {
+        return current.includes(id)
+          ? current.filter((value) => value !== id)
+          : [...current, id];
+      }
+      return [id];
+    });
+  }, []);
+
+  const toggle = React.useCallback((id: string) => {
+    setSelectedIds((current) =>
+      current.includes(id)
+        ? current.filter((value) => value !== id)
+        : [...current, id],
+    );
+  }, []);
+
+  const selectedAsset = React.useMemo(() => {
+    const lastId = selectedIds[selectedIds.length - 1];
+    return assets.find((asset) => asset.id === lastId) ?? null;
+  }, [assets, selectedIds]);
+
+  const ctx = React.useMemo<Ctx>(
+    () => ({
+      assets,
+      filtered,
+      view,
+      setView,
+      query,
+      setQuery,
+      selectedIds,
+      selectedAsset,
+      isSelected,
+      select,
+      toggle,
+    }),
+    [
+      assets,
+      filtered,
+      view,
+      query,
+      selectedIds,
+      selectedAsset,
+      isSelected,
+      select,
+      toggle,
+    ],
+  );
+
+  return (
+    <AssetManagerContext.Provider value={ctx}>
+      <div
+        data-slot="asset-manager"
+        className={cn(
+          "flex w-full flex-col gap-3 sm:flex-row sm:items-start",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </AssetManagerContext.Provider>
+  );
+}
+
+type AssetLibraryProps = React.ComponentProps<"div">;
+
+function AssetLibrary({ className, ...props }: AssetLibraryProps) {
+  return (
+    <div
+      data-slot="asset-library"
+      className={cn("flex min-w-0 flex-1 flex-col gap-3", className)}
+      {...props}
+    />
+  );
+}
+
+type AssetToolbarProps = React.ComponentProps<"div"> & {
+  /** Placeholder for the search field. */
+  searchPlaceholder?: string;
+};
+
+function AssetToolbar({
+  searchPlaceholder = "Search assets",
+  className,
+  children,
+  ...props
+}: AssetToolbarProps) {
+  const { query, setQuery, view, setView, filtered } = useAssetManager();
+  const searchId = React.useId();
+
+  return (
+    <div
+      data-slot="asset-toolbar"
+      className={cn("flex items-center gap-2", className)}
+      {...props}
+    >
+      <div className="relative min-w-0 flex-1">
+        <Search
+          aria-hidden
+          className="pointer-events-none absolute start-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+        />
+        <input
+          id={searchId}
+          type="search"
+          role="searchbox"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder={searchPlaceholder}
+          data-slot="asset-toolbar-search"
+          className="h-8 w-full rounded-md border border-border bg-background ps-8 pe-2.5 text-sm text-foreground outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 [&::-webkit-search-cancel-button]:appearance-none"
+        />
+      </div>
+      {children}
+      <div
+        role="group"
+        aria-label="View"
+        data-slot="asset-toolbar-view"
+        className="flex shrink-0 items-center gap-0.5 rounded-md border border-border p-0.5"
+      >
+        <Button
+          type="button"
+          variant={view === "grid" ? "secondary" : "ghost"}
+          size="icon-xs"
+          aria-label="Grid view"
+          aria-pressed={view === "grid"}
+          onClick={() => setView("grid")}
+        >
+          <LayoutGrid />
+        </Button>
+        <Button
+          type="button"
+          variant={view === "list" ? "secondary" : "ghost"}
+          size="icon-xs"
+          aria-label="List view"
+          aria-pressed={view === "list"}
+          onClick={() => setView("list")}
+        >
+          <List />
+        </Button>
+      </div>
+      <span
+        data-slot="asset-toolbar-count"
+        className="shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground"
+      >
+        {filtered.length}
+      </span>
+    </div>
+  );
+}
+
+type AssetThumbnailProps = React.ComponentProps<"div"> & {
+  asset: Asset;
+};
+
+function AssetThumbnail({
+  asset,
+  className,
+  children,
+  ...props
+}: AssetThumbnailProps) {
+  const Icon = TYPE_ICON[asset.type];
+  return (
+    <div
+      data-slot="asset-thumbnail"
+      data-type={asset.type}
+      className={cn(
+        "relative flex items-center justify-center overflow-hidden bg-muted text-muted-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {asset.url ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={asset.url}
+          alt={asset.name}
+          loading="lazy"
+          className="size-full object-cover"
+        />
+      ) : (
+        <Icon className="size-1/3 max-h-10 max-w-10" aria-hidden />
+      )}
+      {children}
+    </div>
+  );
+}
+
+type AssetGridProps = React.ComponentProps<"div"> & {
+  /** Rendered when no assets match the current search. */
+  emptyState?: React.ReactNode;
+};
+
+function AssetGrid({
+  emptyState,
+  className,
+  children,
+  ...props
+}: AssetGridProps) {
+  const { filtered, view } = useAssetManager();
+
+  if (filtered.length === 0) {
+    return (
+      <div
+        data-slot="asset-grid-empty"
+        className={cn(
+          "flex min-h-32 items-center justify-center rounded-lg border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground",
+          className,
+        )}
+      >
+        {emptyState ?? "No assets found"}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role={view === "list" ? "listbox" : "grid"}
+      aria-label="Assets"
+      data-slot="asset-grid"
+      data-view={view}
+      className={cn(
+        view === "grid"
+          ? "grid grid-cols-[repeat(auto-fill,minmax(7rem,1fr))] gap-2"
+          : "flex flex-col gap-1",
+        className,
+      )}
+      {...props}
+    >
+      {children ??
+        filtered.map((asset) => <AssetCard key={asset.id} asset={asset} />)}
+    </div>
+  );
+}
+
+type AssetCardProps = Omit<React.ComponentProps<"div">, "onSelect"> & {
+  asset: Asset;
+};
+
+function AssetCard({ asset, className, ...props }: AssetCardProps) {
+  const { view, isSelected, select, toggle } = useAssetManager();
+  const selected = isSelected(asset.id);
+  const Icon = TYPE_ICON[asset.type];
+
+  const onClick = (event: React.MouseEvent) => {
+    select(asset.id, event.metaKey || event.ctrlKey || event.shiftKey);
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      select(asset.id, event.metaKey || event.ctrlKey || event.shiftKey);
+    }
+  };
+
+  if (view === "list") {
+    return (
+      <div
+        role="option"
+        data-slot="asset-card"
+        data-type={asset.type}
+        data-selected={selected}
+        aria-selected={selected}
+        tabIndex={0}
+        onClick={onClick}
+        onKeyDown={onKeyDown}
+        className={cn(
+          "group flex cursor-default items-center gap-3 rounded-md border border-transparent px-2 py-1.5 text-start transition-colors outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+          selected && "border-primary/40 bg-primary/10",
+          className,
+        )}
+        {...props}
+      >
+        <input
+          type="checkbox"
+          checked={selected}
+          aria-label={`Select ${asset.name}`}
+          onClick={(event) => event.stopPropagation()}
+          onChange={() => toggle(asset.id)}
+          className="size-3.5 shrink-0 cursor-pointer accent-primary"
+        />
+        <AssetThumbnail
+          asset={asset}
+          className="size-9 shrink-0 rounded-md [&_svg]:size-4"
+        />
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate text-sm font-medium text-foreground">
+            {asset.name}
+          </span>
+          <span className="font-mono text-[11px] text-muted-foreground">
+            {formatBytes(asset.size)}
+          </span>
+        </div>
+        <Badge variant="outline" className="shrink-0 gap-1">
+          <Icon aria-hidden />
+          {TYPE_LABEL[asset.type]}
+        </Badge>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="gridcell"
+      data-slot="asset-card"
+      data-type={asset.type}
+      data-selected={selected}
+      aria-selected={selected}
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+      className={cn(
+        "group relative flex cursor-default flex-col gap-2 rounded-lg border border-border bg-card p-2 text-start transition-colors outline-none hover:border-ring/50 focus-visible:ring-2 focus-visible:ring-ring",
+        selected && "border-primary ring-2 ring-primary",
+        className,
+      )}
+      {...props}
+    >
+      <input
+        type="checkbox"
+        checked={selected}
+        aria-label={`Select ${asset.name}`}
+        onClick={(event) => event.stopPropagation()}
+        onChange={() => toggle(asset.id)}
+        className={cn(
+          "absolute end-2 top-2 z-10 size-4 cursor-pointer accent-primary opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 data-[selected=true]:opacity-100",
+          selected && "opacity-100",
+        )}
+      />
+      <AssetThumbnail asset={asset} className="aspect-square rounded-md" />
+      <div className="flex flex-col gap-1">
+        <span className="truncate text-xs font-medium text-foreground">
+          {asset.name}
+        </span>
+        <div className="flex items-center justify-between gap-1">
+          <Badge variant="outline" className="gap-1">
+            <Icon aria-hidden />
+            {TYPE_LABEL[asset.type]}
+          </Badge>
+          <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+            {formatBytes(asset.size)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type AssetDetailProps = React.ComponentProps<"aside"> & {
+  /** Rendered when nothing is selected. */
+  emptyState?: React.ReactNode;
+};
+
+function AssetDetailRow({
+  label,
+  children,
+}: {
+  label: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      data-slot="asset-detail-row"
+      className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)] items-baseline gap-2"
+    >
+      <span className="truncate text-xs text-muted-foreground">{label}</span>
+      <span className="min-w-0 text-end text-xs text-foreground">
+        {children}
+      </span>
+    </div>
+  );
+}
+
+function AssetDetail({
+  emptyState,
+  className,
+  children,
+  ...props
+}: AssetDetailProps) {
+  const { selectedAsset } = useAssetManager();
+
+  return (
+    <aside
+      data-slot="asset-detail"
+      className={cn(
+        "flex w-full shrink-0 flex-col overflow-hidden rounded-lg border border-border bg-card text-card-foreground sm:max-w-64",
+        className,
+      )}
+      {...props}
+    >
+      {selectedAsset ? (
+        children ?? <AssetDetailContent asset={selectedAsset} />
+      ) : (
+        <div
+          data-slot="asset-detail-empty"
+          className="flex flex-1 items-center justify-center px-4 py-10 text-center text-sm text-muted-foreground"
+        >
+          {emptyState ?? "Select an asset"}
+        </div>
+      )}
+    </aside>
+  );
+}
+
+type AssetDetailContentProps = {
+  asset: Asset;
+};
+
+function AssetDetailContent({ asset }: AssetDetailContentProps) {
+  const Icon = TYPE_ICON[asset.type];
+
+  return (
+    <div className="flex flex-col" data-slot="asset-detail-content">
+      <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2.5">
+        <p className="font-mono text-[11px] uppercase tracking-[0.1em] text-muted-foreground">
+          Details
+        </p>
+        <Badge variant="outline" className="gap-1">
+          <Icon aria-hidden />
+          {TYPE_LABEL[asset.type]}
+        </Badge>
+      </div>
+
+      <AssetThumbnail
+        asset={asset}
+        className="aspect-video border-b border-border [&_svg]:size-10"
+      />
+
+      <div className="flex flex-col gap-2 px-3 py-3">
+        <p className="truncate text-sm font-medium text-foreground">
+          {asset.name}
+        </p>
+        <AssetDetailRow label="Type">{TYPE_LABEL[asset.type]}</AssetDetailRow>
+        <AssetDetailRow label="Size">{formatBytes(asset.size)}</AssetDetailRow>
+        {asset.dimensions ? (
+          <AssetDetailRow label="Dimensions">{asset.dimensions}</AssetDetailRow>
+        ) : null}
+        {asset.modified ? (
+          <AssetDetailRow label="Modified">{asset.modified}</AssetDetailRow>
+        ) : null}
+        {asset.tags && asset.tags.length > 0 ? (
+          <div
+            data-slot="asset-detail-tags"
+            className="flex flex-wrap gap-1 pt-1"
+          >
+            {asset.tags.map((tag) => (
+              <Badge key={tag} variant="secondary">
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="mt-auto flex items-center gap-2 border-t border-border px-3 py-2.5">
+        <Button type="button" variant="outline" size="sm" className="flex-1">
+          <Download />
+          Download
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Delete asset"
+        >
+          <Trash2 />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export {
+  AssetManager,
+  AssetLibrary,
+  AssetToolbar,
+  AssetGrid,
+  AssetCard,
+  AssetThumbnail,
+  AssetDetail,
+  useAssetManager,
+};

--- a/registry/hirael/ui/auction-timeline.tsx
+++ b/registry/hirael/ui/auction-timeline.tsx
@@ -1,0 +1,417 @@
+"use client";
+
+import * as React from "react";
+import { Check, Clock, Gavel, TrendingUp } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/registry/hirael/ui/badge";
+
+type AuctionContextValue = {
+  endsAt?: number;
+  now: number;
+};
+
+const AuctionContext = React.createContext<AuctionContextValue | null>(null);
+
+function useAuctionContext() {
+  const ctx = React.useContext(AuctionContext);
+  if (!ctx) {
+    throw new Error(
+      "AuctionTimeline compound parts must be used inside <AuctionTimeline>",
+    );
+  }
+  return ctx;
+}
+
+const toTimestamp = (value: Date | string | number) =>
+  value instanceof Date ? value.getTime() : new Date(value).getTime();
+
+const useReducedMotion = () => {
+  const [reduced, setReduced] = React.useState(false);
+  React.useEffect(() => {
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduced(query.matches);
+    const onChange = (event: MediaQueryListEvent) => setReduced(event.matches);
+    query.addEventListener("change", onChange);
+    return () => query.removeEventListener("change", onChange);
+  }, []);
+  return reduced;
+};
+
+export type AuctionTimelineProps = React.ComponentProps<"div"> & {
+  /** When the auction closes. Read by `AuctionCountdown` to drive the live clock. */
+  endsAt?: Date | string | number;
+};
+
+function AuctionTimeline({
+  endsAt,
+  className,
+  children,
+  ...props
+}: AuctionTimelineProps) {
+  const endsAtMs = endsAt === undefined ? undefined : toTimestamp(endsAt);
+  const [now, setNow] = React.useState<number>(() =>
+    endsAtMs === undefined ? 0 : endsAtMs,
+  );
+  const reduceMotion = useReducedMotion();
+
+  React.useEffect(() => {
+    if (endsAtMs === undefined) return;
+    setNow(Date.now());
+    if (Date.now() >= endsAtMs) return;
+    const id = setInterval(() => {
+      const next = Date.now();
+      setNow(next);
+      if (next >= endsAtMs) clearInterval(id);
+    }, 1000);
+    return () => clearInterval(id);
+  }, [endsAtMs, reduceMotion]);
+
+  const value = React.useMemo<AuctionContextValue>(
+    () => ({ endsAt: endsAtMs, now }),
+    [endsAtMs, now],
+  );
+
+  return (
+    <AuctionContext.Provider value={value}>
+      <div
+        data-slot="auction-timeline"
+        className={cn(
+          "flex flex-col gap-4 rounded-xl border border-border bg-card p-5 text-card-foreground",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </AuctionContext.Provider>
+  );
+}
+
+type AuctionHeaderProps = React.ComponentProps<"div">;
+
+function AuctionHeader({ className, ...props }: AuctionHeaderProps) {
+  return (
+    <div
+      data-slot="auction-header"
+      className={cn(
+        "flex flex-wrap items-start justify-between gap-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export type AuctionBidProps = Omit<React.ComponentProps<"div">, "children"> & {
+  /** The current leading bid, already formatted (e.g. "$2,450"). */
+  amount: React.ReactNode;
+  /** Number of bids placed so far. */
+  bids?: number;
+  /** Label above the amount. */
+  label?: React.ReactNode;
+};
+
+function AuctionBid({
+  amount,
+  bids,
+  label = "Current bid",
+  className,
+  ...props
+}: AuctionBidProps) {
+  return (
+    <div
+      data-slot="auction-bid"
+      className={cn("flex min-w-0 flex-col gap-1", className)}
+      {...props}
+    >
+      <span
+        data-slot="auction-bid-label"
+        className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground"
+      >
+        {label}
+      </span>
+      <span
+        data-slot="auction-bid-amount"
+        className="text-2xl font-semibold leading-none tracking-tight text-foreground"
+        style={{ color: "var(--accent-cool)" }}
+      >
+        {amount}
+      </span>
+      {bids !== undefined ? (
+        <span
+          data-slot="auction-bid-count"
+          className="flex items-center gap-1.5 text-xs text-muted-foreground"
+        >
+          <Gavel aria-hidden className="size-3" />
+          {bids} {bids === 1 ? "bid" : "bids"}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+export type AuctionStatusState = "live" | "closing" | "closed";
+
+const statusContent: Record<
+  AuctionStatusState,
+  { label: string; live: boolean }
+> = {
+  live: { label: "Live", live: true },
+  closing: { label: "Closing soon", live: true },
+  closed: { label: "Closed", live: false },
+};
+
+export type AuctionStatusProps = Omit<
+  React.ComponentProps<"span">,
+  "children"
+> & {
+  /** Current lifecycle of the auction. `live` and `closing` read as active. */
+  state: AuctionStatusState;
+  children?: React.ReactNode;
+};
+
+function AuctionStatus({
+  state,
+  className,
+  children,
+  ...props
+}: AuctionStatusProps) {
+  const { label, live } = statusContent[state];
+  return (
+    <Badge
+      data-slot="auction-status"
+      data-state={state}
+      variant="outline"
+      className={cn("gap-1.5", className)}
+      {...props}
+    >
+      {live ? (
+        <span aria-hidden className="state-dot" />
+      ) : (
+        <Check aria-hidden className="size-3 text-muted-foreground" />
+      )}
+      {children ?? label}
+    </Badge>
+  );
+}
+
+const formatRemaining = (ms: number) => {
+  const totalSeconds = Math.max(Math.floor(ms / 1000), 0);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const pad = (value: number) => String(value).padStart(2, "0");
+  if (days > 0) {
+    return `${days}d ${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+  }
+  return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+};
+
+export type AuctionCountdownProps = Omit<
+  React.ComponentProps<"div">,
+  "children"
+> & {
+  /** Shown once the countdown reaches zero. */
+  endedLabel?: React.ReactNode;
+};
+
+function AuctionCountdown({
+  endedLabel = "Bidding closed",
+  className,
+  ...props
+}: AuctionCountdownProps) {
+  const { endsAt, now } = useAuctionContext();
+  const mounted = now > 0;
+  const remaining = endsAt === undefined ? 0 : Math.max(endsAt - now, 0);
+  const ended = endsAt !== undefined && mounted && remaining <= 0;
+
+  return (
+    <div
+      data-slot="auction-countdown"
+      role="timer"
+      className={cn(
+        "flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2",
+        className,
+      )}
+      {...props}
+    >
+      <Clock aria-hidden className="size-4 text-muted-foreground" />
+      {ended ? (
+        <span
+          data-slot="auction-countdown-ended"
+          className="text-sm font-medium text-muted-foreground"
+        >
+          {endedLabel}
+        </span>
+      ) : (
+        <>
+          <span
+            data-slot="auction-countdown-label"
+            className="text-xs text-muted-foreground"
+          >
+            Ends in
+          </span>
+          <span
+            data-slot="auction-countdown-value"
+            className="ms-auto font-mono text-sm font-medium tabular-nums text-foreground"
+          >
+            {mounted && endsAt !== undefined ? formatRemaining(remaining) : "--:--:--"}
+          </span>
+        </>
+      )}
+    </div>
+  );
+}
+
+type AuctionHistoryProps = React.ComponentProps<"ol">;
+
+function AuctionHistory({ className, ...props }: AuctionHistoryProps) {
+  return (
+    <ol
+      data-slot="auction-history"
+      className={cn("relative flex flex-col", className)}
+      {...props}
+    />
+  );
+}
+
+export type AuctionBidRowProps = Omit<React.ComponentProps<"li">, "children"> & {
+  /** Name of the bidder. */
+  bidder: React.ReactNode;
+  /** Bid amount, already formatted. */
+  amount: React.ReactNode;
+  /** When the bid was placed. */
+  time: React.ReactNode;
+  /** Marks this as the current leading bid. */
+  leading?: boolean;
+};
+
+function AuctionBidRow({
+  bidder,
+  amount,
+  time,
+  leading = false,
+  className,
+  ...props
+}: AuctionBidRowProps) {
+  return (
+    <li
+      data-slot="auction-bid-row"
+      data-leading={leading || undefined}
+      className={cn(
+        "group relative flex items-center gap-3 ps-6 pb-4 last:pb-0",
+        "before:absolute before:start-[3px] before:top-5 before:bottom-0 before:w-px before:bg-border",
+        "last:before:hidden",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        data-slot="auction-bid-marker"
+        aria-hidden
+        className={cn(
+          "absolute start-0 top-1.5 z-10 inline-flex size-[7px] rounded-full ring-2 ring-card",
+          leading ? "state-dot" : "bg-muted-foreground",
+        )}
+      />
+      <div
+        data-slot="auction-bid-row-main"
+        className="flex min-w-0 flex-1 flex-col gap-0.5"
+      >
+        <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+          <span className="truncate">{bidder}</span>
+          {leading ? (
+            <span
+              data-slot="auction-bid-leading"
+              className="inline-flex items-center gap-1 text-[11px] font-medium"
+              style={{ color: "var(--accent-cool)" }}
+            >
+              <TrendingUp aria-hidden className="size-3" />
+              Leading
+            </span>
+          ) : null}
+        </span>
+        <time
+          data-slot="auction-bid-time"
+          className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground"
+        >
+          {time}
+        </time>
+      </div>
+      <span
+        data-slot="auction-bid-row-amount"
+        className={cn(
+          "shrink-0 text-sm font-semibold tabular-nums",
+          leading ? "" : "text-muted-foreground",
+        )}
+        style={leading ? { color: "var(--accent-cool)" } : undefined}
+      >
+        {amount}
+      </span>
+    </li>
+  );
+}
+
+export type AuctionWinnerProps = Omit<
+  React.ComponentProps<"div">,
+  "children"
+> & {
+  /** Name of the winning bidder. */
+  winner: React.ReactNode;
+  /** Winning amount, already formatted. */
+  amount: React.ReactNode;
+  /** Label above the winner. */
+  label?: React.ReactNode;
+};
+
+function AuctionWinner({
+  winner,
+  amount,
+  label = "Winner",
+  className,
+  ...props
+}: AuctionWinnerProps) {
+  return (
+    <div
+      data-slot="auction-winner"
+      className={cn(
+        "flex items-center justify-between gap-3 rounded-lg border border-border bg-background px-3 py-2.5",
+        className,
+      )}
+      {...props}
+    >
+      <div className="flex min-w-0 items-center gap-2.5">
+        <span
+          aria-hidden
+          className="inline-flex size-7 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground [&_svg]:size-3.5"
+        >
+          <Check />
+        </span>
+        <div className="flex min-w-0 flex-col">
+          <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+            {label}
+          </span>
+          <span className="truncate text-sm font-medium text-foreground">
+            {winner}
+          </span>
+        </div>
+      </div>
+      <span className="shrink-0 text-sm font-semibold tabular-nums text-foreground">
+        {amount}
+      </span>
+    </div>
+  );
+}
+
+export {
+  AuctionTimeline,
+  AuctionHeader,
+  AuctionBid,
+  AuctionCountdown,
+  AuctionStatus,
+  AuctionHistory,
+  AuctionBidRow,
+  AuctionWinner,
+};

--- a/registry/hirael/ui/breadcrumb-generator.tsx
+++ b/registry/hirael/ui/breadcrumb-generator.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import * as React from "react";
+import { ChevronRight, Home } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import {
+  Breadcrumb,
+  BreadcrumbEllipsis,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/registry/hirael/ui/breadcrumb";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/registry/hirael/ui/dropdown-menu";
+
+type BreadcrumbCrumb = {
+  label: string;
+  href?: string;
+};
+
+function humanizeSegment(segment: string) {
+  const decoded = (() => {
+    try {
+      return decodeURIComponent(segment);
+    } catch {
+      return segment;
+    }
+  })();
+
+  return decoded
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+/**
+ * Split a URL path into breadcrumb crumbs, humanizing each segment and
+ * building a cumulative `href` for every level.
+ *
+ * @param path - The path to split, e.g. `/settings/billing/invoices`.
+ * @param basePath - Prefix prepended to each generated `href`, e.g. `/app`.
+ */
+function segmentsFromPath(path: string, basePath = ""): BreadcrumbCrumb[] {
+  const cleanBase = basePath.replace(/\/+$/, "");
+  const segments = path.split("/").filter(Boolean);
+
+  return segments.map((segment, index) => ({
+    label: humanizeSegment(segment),
+    href: `${cleanBase}/${segments.slice(0, index + 1).join("/")}`,
+  }));
+}
+
+/**
+ * A single rendered crumb. Pass `isCurrent` for the trailing item so it
+ * renders as the current page instead of a link.
+ */
+function BreadcrumbGeneratorItem({
+  label,
+  href,
+  isCurrent,
+}: BreadcrumbCrumb & {
+  /** Render as the current page (non-link) instead of a link. */
+  isCurrent?: boolean;
+}) {
+  return (
+    <BreadcrumbItem data-slot="breadcrumb-generator-item">
+      {isCurrent || !href ? (
+        <BreadcrumbPage>{label}</BreadcrumbPage>
+      ) : (
+        <BreadcrumbLink href={href}>{label}</BreadcrumbLink>
+      )}
+    </BreadcrumbItem>
+  );
+}
+
+function BreadcrumbGenerator({
+  items,
+  path,
+  basePath,
+  maxItems = 4,
+  showHome = false,
+  homeHref = "/",
+  className,
+  ...props
+}: React.ComponentProps<typeof Breadcrumb> & {
+  /** Crumbs to render. The last item becomes the current page. */
+  items?: BreadcrumbCrumb[];
+  /** A URL path to derive crumbs from when `items` is omitted. */
+  path?: string;
+  /** Prefix prepended to each `href` generated from `path`. */
+  basePath?: string;
+  /** Collapse the middle into an ellipsis when the trail exceeds this. */
+  maxItems?: number;
+  /** Prepend a Home crumb linking to `homeHref`. */
+  showHome?: boolean;
+  /** Destination for the leading Home crumb. */
+  homeHref?: string;
+}) {
+  const crumbs = React.useMemo<BreadcrumbCrumb[]>(() => {
+    if (items) return items;
+    if (path) return segmentsFromPath(path, basePath);
+    return [];
+  }, [items, path, basePath]);
+
+  const lastIndex = crumbs.length - 1;
+  const isCollapsed = crumbs.length > maxItems;
+
+  const head = isCollapsed ? crumbs.slice(0, 1) : crumbs.slice(0, lastIndex);
+  const hidden = isCollapsed ? crumbs.slice(1, lastIndex) : [];
+  const tail = crumbs[lastIndex];
+
+  return (
+    <Breadcrumb
+      data-slot="breadcrumb-generator"
+      className={cn(className)}
+      {...props}
+    >
+      <BreadcrumbList>
+        {showHome ? (
+          <>
+            <BreadcrumbItem data-slot="breadcrumb-generator-home">
+              <BreadcrumbLink href={homeHref} aria-label="Home">
+                <Home className="size-3.5" />
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            {crumbs.length > 0 ? (
+              <BreadcrumbSeparator>
+                <ChevronRight className="rtl:rotate-180" />
+              </BreadcrumbSeparator>
+            ) : null}
+          </>
+        ) : null}
+
+        {head.map((crumb, index) => (
+          <React.Fragment key={`${crumb.label}-${index}`}>
+            <BreadcrumbGeneratorItem {...crumb} />
+            <BreadcrumbSeparator>
+              <ChevronRight className="rtl:rotate-180" />
+            </BreadcrumbSeparator>
+          </React.Fragment>
+        ))}
+
+        {isCollapsed && hidden.length > 0 ? (
+          <>
+            <BreadcrumbItem data-slot="breadcrumb-generator-collapsed">
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  data-slot="breadcrumb-generator-collapsed-trigger"
+                  className="flex items-center justify-center rounded-sm outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                  aria-label="Show hidden crumbs"
+                >
+                  <BreadcrumbEllipsis />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  align="start"
+                  data-slot="breadcrumb-generator-collapsed-content"
+                >
+                  {hidden.map((crumb, index) =>
+                    crumb.href ? (
+                      <DropdownMenuItem
+                        key={`${crumb.label}-${index}`}
+                        asChild
+                      >
+                        <a href={crumb.href}>{crumb.label}</a>
+                      </DropdownMenuItem>
+                    ) : (
+                      <DropdownMenuItem
+                        key={`${crumb.label}-${index}`}
+                        disabled
+                      >
+                        {crumb.label}
+                      </DropdownMenuItem>
+                    ),
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator>
+              <ChevronRight className="rtl:rotate-180" />
+            </BreadcrumbSeparator>
+          </>
+        ) : null}
+
+        {tail ? <BreadcrumbGeneratorItem {...tail} isCurrent /> : null}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}
+
+export {
+  BreadcrumbGenerator,
+  BreadcrumbGeneratorItem,
+  segmentsFromPath,
+  type BreadcrumbCrumb,
+};

--- a/registry/hirael/ui/bundle-builder.tsx
+++ b/registry/hirael/ui/bundle-builder.tsx
@@ -1,0 +1,571 @@
+"use client";
+
+import * as React from "react";
+import { Minus, Package, Plus, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/registry/hirael/ui/badge";
+import { Button } from "@/registry/hirael/ui/button";
+import { Input } from "@/registry/hirael/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/registry/hirael/ui/select";
+
+export type BundleProduct = {
+  id: string;
+  name: string;
+  price: number;
+};
+
+export type BundleLine = {
+  id: string;
+  productId: string;
+  quantity: number;
+};
+
+function formatPrice(value: number, locale: string, currency: string): string {
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: "currency",
+      currency,
+    }).format(value);
+  } catch {
+    return value.toFixed(2);
+  }
+}
+
+function productById(
+  products: BundleProduct[],
+  productId: string,
+): BundleProduct | undefined {
+  return products.find((product) => product.id === productId);
+}
+
+function lineTotal(products: BundleProduct[], line: BundleLine): number {
+  const product = productById(products, line.productId);
+  return product ? product.price * line.quantity : 0;
+}
+
+type Ctx = {
+  products: BundleProduct[];
+  value: BundleLine[];
+  discount: number;
+  locale: string;
+  currency: string;
+  add: (productId: string) => void;
+  setQuantity: (id: string, quantity: number) => void;
+  remove: (id: string) => void;
+  setDiscount: (discount: number) => void;
+  subtotal: number;
+  savings: number;
+  total: number;
+  nextId: () => string;
+};
+
+const BundleBuilderContext = React.createContext<Ctx | null>(null);
+
+function useBundleBuilder(): Ctx {
+  const ctx = React.useContext(BundleBuilderContext);
+  if (!ctx) {
+    throw new Error(
+      "BundleBuilder compound parts must be used inside <BundleBuilder>",
+    );
+  }
+  return ctx;
+}
+
+export type BundleBuilderProps = Omit<
+  React.ComponentProps<"div">,
+  "onChange" | "defaultValue"
+> & {
+  /** Catalog of products the picker can add to the bundle. */
+  products: BundleProduct[];
+  /** Controlled list of bundle lines. */
+  value?: BundleLine[];
+  /** Initial bundle lines for an uncontrolled builder. */
+  defaultValue?: BundleLine[];
+  /** Called whenever the bundle lines change. */
+  onValueChange?: (value: BundleLine[]) => void;
+  /** Controlled bundle discount as a percentage from 0 to 100. */
+  discount?: number;
+  /** Initial discount percentage for an uncontrolled builder. */
+  defaultDiscount?: number;
+  /** Called whenever the discount percentage changes. */
+  onDiscountChange?: (discount: number) => void;
+  /** BCP 47 locale used to format prices. */
+  locale?: string;
+  /** ISO 4217 currency code used to format prices. */
+  currency?: string;
+};
+
+function BundleBuilder({
+  products,
+  value: valueProp,
+  defaultValue,
+  onValueChange,
+  discount: discountProp,
+  defaultDiscount = 0,
+  onDiscountChange,
+  locale = "en-US",
+  currency = "USD",
+  className,
+  children,
+  ...props
+}: BundleBuilderProps) {
+  const reactId = React.useId();
+  const seedRef = React.useRef(0);
+
+  const [internalValue, setInternalValue] = React.useState<BundleLine[]>(
+    defaultValue ?? [],
+  );
+  const value = valueProp ?? internalValue;
+
+  const [internalDiscount, setInternalDiscount] =
+    React.useState<number>(defaultDiscount);
+  const discount = discountProp ?? internalDiscount;
+
+  const nextId = React.useCallback(
+    () => `${reactId}-line-${seedRef.current++}`,
+    [reactId],
+  );
+
+  const setValue = React.useCallback(
+    (next: BundleLine[]) => {
+      if (valueProp === undefined) setInternalValue(next);
+      onValueChange?.(next);
+    },
+    [valueProp, onValueChange],
+  );
+
+  const setDiscount = React.useCallback(
+    (next: number) => {
+      const clamped = Math.max(0, Math.min(100, next));
+      if (discountProp === undefined) setInternalDiscount(clamped);
+      onDiscountChange?.(clamped);
+    },
+    [discountProp, onDiscountChange],
+  );
+
+  const add = React.useCallback(
+    (productId: string) => {
+      if (!productById(products, productId)) return;
+      const existing = value.find((line) => line.productId === productId);
+      if (existing) {
+        setValue(
+          value.map((line) =>
+            line.id === existing.id
+              ? { ...line, quantity: line.quantity + 1 }
+              : line,
+          ),
+        );
+        return;
+      }
+      setValue([...value, { id: nextId(), productId, quantity: 1 }]);
+    },
+    [products, value, setValue, nextId],
+  );
+
+  const setQuantity = React.useCallback(
+    (id: string, quantity: number) => {
+      const next = Math.max(1, Math.trunc(quantity));
+      setValue(
+        value.map((line) => (line.id === id ? { ...line, quantity: next } : line)),
+      );
+    },
+    [value, setValue],
+  );
+
+  const remove = React.useCallback(
+    (id: string) => {
+      setValue(value.filter((line) => line.id !== id));
+    },
+    [value, setValue],
+  );
+
+  const subtotal = React.useMemo(
+    () => value.reduce((sum, line) => sum + lineTotal(products, line), 0),
+    [products, value],
+  );
+
+  const savings = React.useMemo(
+    () => (subtotal * discount) / 100,
+    [subtotal, discount],
+  );
+
+  const total = subtotal - savings;
+
+  const ctx = React.useMemo<Ctx>(
+    () => ({
+      products,
+      value,
+      discount,
+      locale,
+      currency,
+      add,
+      setQuantity,
+      remove,
+      setDiscount,
+      subtotal,
+      savings,
+      total,
+      nextId,
+    }),
+    [
+      products,
+      value,
+      discount,
+      locale,
+      currency,
+      add,
+      setQuantity,
+      remove,
+      setDiscount,
+      subtotal,
+      savings,
+      total,
+      nextId,
+    ],
+  );
+
+  return (
+    <BundleBuilderContext.Provider value={ctx}>
+      <div
+        data-slot="bundle-builder"
+        className={cn(
+          "flex w-full flex-col gap-4 rounded-lg border border-border bg-card p-5 text-card-foreground",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </BundleBuilderContext.Provider>
+  );
+}
+
+type BundlePickerProps = Omit<
+  React.ComponentProps<"div">,
+  "children"
+> & {
+  /** Placeholder shown in the picker before a product is chosen. */
+  placeholder?: React.ReactNode;
+  /** Label for the add button. */
+  addLabel?: React.ReactNode;
+  /** Render an add-button list instead of a Select. */
+  variant?: "select" | "list";
+};
+
+function BundlePicker({
+  placeholder = "Add a product",
+  addLabel = "Add",
+  variant = "select",
+  className,
+  ...props
+}: BundlePickerProps) {
+  const ctx = useBundleBuilder();
+  const [selected, setSelected] = React.useState("");
+
+  if (variant === "list") {
+    return (
+      <div
+        data-slot="bundle-picker"
+        data-variant="list"
+        className={cn("flex flex-col gap-1.5", className)}
+        {...props}
+      >
+        {ctx.products.map((product) => (
+          <button
+            key={product.id}
+            type="button"
+            data-slot="bundle-picker-item"
+            onClick={() => ctx.add(product.id)}
+            className="flex items-center justify-between gap-3 rounded-md border border-border bg-background px-3 py-2 text-start text-sm transition-colors hover:border-foreground hover:bg-accent"
+          >
+            <span className="min-w-0 truncate font-medium text-foreground">
+              {product.name}
+            </span>
+            <span className="flex items-center gap-2">
+              <span className="font-mono text-xs tabular-nums text-muted-foreground">
+                {formatPrice(product.price, ctx.locale, ctx.currency)}
+              </span>
+              <Plus className="size-3.5 text-muted-foreground" />
+            </span>
+          </button>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-slot="bundle-picker"
+      data-variant="select"
+      className={cn("flex items-center gap-2", className)}
+      {...props}
+    >
+      <Select value={selected} onValueChange={setSelected}>
+        <SelectTrigger
+          data-slot="bundle-picker-trigger"
+          className="flex-1"
+          aria-label="Product"
+        >
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          {ctx.products.map((product) => (
+            <SelectItem key={product.id} value={product.id}>
+              <span className="flex w-full items-center justify-between gap-4">
+                <span>{product.name}</span>
+                <span className="font-mono text-xs tabular-nums text-muted-foreground">
+                  {formatPrice(product.price, ctx.locale, ctx.currency)}
+                </span>
+              </span>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Button
+        type="button"
+        variant="outline"
+        data-slot="bundle-picker-add"
+        disabled={!selected}
+        onClick={() => {
+          if (!selected) return;
+          ctx.add(selected);
+          setSelected("");
+        }}
+      >
+        <Plus />
+        {addLabel}
+      </Button>
+    </div>
+  );
+}
+
+type BundleItemsProps = Omit<React.ComponentProps<"div">, "children"> & {
+  /** Shown when the bundle has no lines yet. */
+  emptyHint?: React.ReactNode;
+};
+
+function BundleItems({
+  className,
+  emptyHint = "No products in the bundle yet.",
+  ...props
+}: BundleItemsProps) {
+  const ctx = useBundleBuilder();
+
+  if (ctx.value.length === 0) {
+    return (
+      <div
+        data-slot="bundle-items"
+        data-empty="true"
+        className={cn(
+          "flex flex-col items-center justify-center gap-2 rounded-md border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground",
+          className,
+        )}
+        {...props}
+      >
+        <Package className="size-5 text-muted-foreground" />
+        {emptyHint}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-slot="bundle-items"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    >
+      {ctx.value.map((line) => (
+        <BundleItem key={line.id} line={line} />
+      ))}
+    </div>
+  );
+}
+
+type BundleItemProps = Omit<React.ComponentProps<"div">, "children"> & {
+  line: BundleLine;
+};
+
+function BundleItem({ line, className, ...props }: BundleItemProps) {
+  const ctx = useBundleBuilder();
+  const product = productById(ctx.products, line.productId);
+  if (!product) return null;
+
+  return (
+    <div
+      data-slot="bundle-item"
+      className={cn(
+        "flex flex-wrap items-center gap-3 rounded-md border border-border bg-background px-3 py-2",
+        className,
+      )}
+      {...props}
+    >
+      <div data-slot="bundle-item-info" className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-sm font-medium text-foreground">
+          {product.name}
+        </span>
+        <span className="font-mono text-xs tabular-nums text-muted-foreground">
+          {formatPrice(product.price, ctx.locale, ctx.currency)} each
+        </span>
+      </div>
+
+      <div
+        data-slot="bundle-item-stepper"
+        className="flex items-center gap-1 rounded-md border border-border p-0.5"
+      >
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          data-slot="bundle-item-decrement"
+          aria-label={`Decrease ${product.name} quantity`}
+          disabled={line.quantity <= 1}
+          onClick={() => ctx.setQuantity(line.id, line.quantity - 1)}
+        >
+          <Minus />
+        </Button>
+        <span
+          data-slot="bundle-item-quantity"
+          aria-live="polite"
+          className="min-w-7 text-center font-mono text-sm tabular-nums text-foreground"
+        >
+          {line.quantity}
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          data-slot="bundle-item-increment"
+          aria-label={`Increase ${product.name} quantity`}
+          onClick={() => ctx.setQuantity(line.id, line.quantity + 1)}
+        >
+          <Plus />
+        </Button>
+      </div>
+
+      <span
+        data-slot="bundle-item-total"
+        className="w-20 text-end font-mono text-sm tabular-nums font-medium text-foreground"
+      >
+        {formatPrice(product.price * line.quantity, ctx.locale, ctx.currency)}
+      </span>
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        data-slot="bundle-item-remove"
+        aria-label={`Remove ${product.name}`}
+        onClick={() => ctx.remove(line.id)}
+        className="text-muted-foreground"
+      >
+        <X />
+      </Button>
+    </div>
+  );
+}
+
+type BundleSummaryProps = Omit<React.ComponentProps<"div">, "children"> & {
+  /** Show the discount percentage input. */
+  showDiscount?: boolean;
+};
+
+function BundleSummary({
+  className,
+  showDiscount = true,
+  ...props
+}: BundleSummaryProps) {
+  const ctx = useBundleBuilder();
+  const discountId = React.useId();
+
+  return (
+    <div
+      data-slot="bundle-summary"
+      className={cn(
+        "flex flex-col gap-2 border-t border-border pt-4 text-sm",
+        className,
+      )}
+      {...props}
+    >
+      <div
+        data-slot="bundle-summary-row"
+        className="flex items-center justify-between gap-3"
+      >
+        <span className="text-muted-foreground">Items</span>
+        <span className="font-mono tabular-nums text-foreground">
+          {formatPrice(ctx.subtotal, ctx.locale, ctx.currency)}
+        </span>
+      </div>
+
+      {showDiscount ? (
+        <div
+          data-slot="bundle-summary-discount"
+          className="flex items-center justify-between gap-3"
+        >
+          <label
+            htmlFor={discountId}
+            className="text-muted-foreground"
+            data-slot="bundle-summary-discount-label"
+          >
+            Bundle discount
+          </label>
+          <div className="flex items-center gap-1.5">
+            <Input
+              id={discountId}
+              type="number"
+              inputMode="numeric"
+              min={0}
+              max={100}
+              value={ctx.discount === 0 ? "" : String(ctx.discount)}
+              placeholder="0"
+              aria-label="Bundle discount percentage"
+              data-slot="bundle-summary-discount-input"
+              onChange={(event) => {
+                const parsed = Number(event.target.value);
+                ctx.setDiscount(Number.isFinite(parsed) ? parsed : 0);
+              }}
+              className="h-8 w-16 text-end font-mono tabular-nums"
+            />
+            <span className="text-muted-foreground">%</span>
+          </div>
+        </div>
+      ) : null}
+
+      {ctx.savings > 0 ? (
+        <div
+          data-slot="bundle-summary-savings"
+          className="flex items-center justify-between gap-3"
+        >
+          <span className="text-muted-foreground">You save</span>
+          <Badge variant="secondary" className="font-mono tabular-nums font-normal">
+            −{formatPrice(ctx.savings, ctx.locale, ctx.currency)}
+          </Badge>
+        </div>
+      ) : null}
+
+      <div
+        data-slot="bundle-summary-total"
+        className="mt-1 flex items-center justify-between gap-3 border-t border-border pt-3 text-base font-semibold"
+      >
+        <span className="text-foreground">Bundle price</span>
+        <span className="font-mono tabular-nums text-foreground">
+          {formatPrice(ctx.total, ctx.locale, ctx.currency)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export {
+  BundleBuilder,
+  BundlePicker,
+  BundleItems,
+  BundleItem,
+  BundleSummary,
+};

--- a/registry/hirael/ui/changelog-viewer.tsx
+++ b/registry/hirael/ui/changelog-viewer.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import * as React from "react";
+import {
+  Plus,
+  Sparkles,
+  Trash2,
+  Wrench,
+  type LucideIcon,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/registry/hirael/ui/badge";
+
+type ChangelogChangeType = "added" | "fixed" | "changed" | "removed";
+
+type ChangelogSectionConfig = {
+  type: ChangelogChangeType;
+  changes: React.ReactNode[];
+};
+
+type ChangelogEntryConfig = {
+  version: React.ReactNode;
+  date: React.ReactNode;
+  title?: React.ReactNode;
+  latest?: boolean;
+  sections: ChangelogSectionConfig[];
+};
+
+const sectionMeta: Record<
+  ChangelogChangeType,
+  { label: string; icon: LucideIcon; badge: string; marker: string }
+> = {
+  added: {
+    label: "Added",
+    icon: Plus,
+    badge: "bg-primary text-primary-foreground",
+    marker: "bg-primary",
+  },
+  fixed: {
+    label: "Fixed",
+    icon: Wrench,
+    badge: "border-border bg-transparent text-foreground",
+    marker: "bg-foreground",
+  },
+  changed: {
+    label: "Changed",
+    icon: Sparkles,
+    badge: "bg-muted text-muted-foreground",
+    marker: "bg-muted-foreground",
+  },
+  removed: {
+    label: "Removed",
+    icon: Trash2,
+    badge: "bg-destructive/15 text-destructive",
+    marker: "bg-destructive",
+  },
+};
+
+type ChangelogViewerProps = Omit<React.ComponentProps<"ol">, "children"> & {
+  /** Config-driven entries. Omit to compose `ChangelogEntry` children instead. */
+  entries?: ChangelogEntryConfig[];
+  children?: React.ReactNode;
+};
+
+function ChangelogViewer({
+  entries,
+  className,
+  children,
+  ...props
+}: ChangelogViewerProps) {
+  const content =
+    children ??
+    entries?.map((entry, index) => (
+      <ChangelogEntry
+        key={index}
+        version={entry.version}
+        date={entry.date}
+        title={entry.title}
+        latest={entry.latest}
+      >
+        {entry.sections.map((section, sectionIndex) => (
+          <ChangelogSection key={sectionIndex} type={section.type}>
+            <ChangelogList>
+              {section.changes.map((change, changeIndex) => (
+                <ChangelogItem key={changeIndex}>{change}</ChangelogItem>
+              ))}
+            </ChangelogList>
+          </ChangelogSection>
+        ))}
+      </ChangelogEntry>
+    ));
+
+  if (!content) return null;
+
+  return (
+    <ol
+      data-slot="changelog-viewer"
+      className={cn("relative flex flex-col", className)}
+      {...props}
+    >
+      {content}
+    </ol>
+  );
+}
+
+type ChangelogEntryProps = Omit<React.ComponentProps<"li">, "title"> & {
+  /** Release version, e.g. `v1.4.0`. */
+  version: React.ReactNode;
+  /** Release date, rendered as a `time` element. */
+  date: React.ReactNode;
+  /** Optional headline for the release. */
+  title?: React.ReactNode;
+  /** Marks this as the newest release with a live accent-cool marker. */
+  latest?: boolean;
+};
+
+function ChangelogEntry({
+  version,
+  date,
+  title,
+  latest = false,
+  className,
+  children,
+  ...props
+}: ChangelogEntryProps) {
+  return (
+    <li
+      data-slot="changelog-entry"
+      data-latest={latest || undefined}
+      className={cn(
+        "group relative flex gap-4 pb-8 ps-7 last:pb-0",
+        "before:absolute before:start-[3px] before:top-2 before:bottom-0 before:w-px before:bg-border",
+        "last:before:hidden",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        data-slot="changelog-marker"
+        aria-hidden
+        className={cn(
+          "absolute start-0 top-1.5 z-10 inline-flex size-[7px] items-center justify-center rounded-full ring-2 ring-background",
+          latest ? "state-dot ring-2" : "bg-muted-foreground",
+        )}
+      />
+      <div
+        data-slot="changelog-entry-content"
+        className="flex min-w-0 flex-1 flex-col gap-3"
+      >
+        <div
+          data-slot="changelog-entry-header"
+          className="flex flex-wrap items-center gap-x-2 gap-y-1"
+        >
+          <span
+            data-slot="changelog-version"
+            className="font-mono text-sm font-medium text-foreground"
+          >
+            {version}
+          </span>
+          {latest ? (
+            <Badge
+              variant="outline"
+              data-slot="changelog-latest"
+              className="border-accent-cool/40 text-accent-cool"
+            >
+              Latest
+            </Badge>
+          ) : null}
+          <time
+            data-slot="changelog-date"
+            className="ms-auto font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground"
+          >
+            {date}
+          </time>
+        </div>
+        {title ? (
+          <p
+            data-slot="changelog-title"
+            className="text-sm font-medium text-foreground"
+          >
+            {title}
+          </p>
+        ) : null}
+        {children}
+      </div>
+    </li>
+  );
+}
+
+type ChangelogSectionProps = React.ComponentProps<"div"> & {
+  /** Change category. Sets the tag Badge label, icon, and token shade. */
+  type: ChangelogChangeType;
+};
+
+function ChangelogSection({
+  type,
+  className,
+  children,
+  ...props
+}: ChangelogSectionProps) {
+  const meta = sectionMeta[type];
+  const Icon = meta.icon;
+
+  return (
+    <div
+      data-slot="changelog-section"
+      data-type={type}
+      className={cn("flex flex-col gap-1.5", className)}
+      {...props}
+    >
+      <Badge
+        data-slot="changelog-tag"
+        className={cn("gap-1 font-normal", meta.badge)}
+      >
+        <Icon aria-hidden />
+        {meta.label}
+      </Badge>
+      {children}
+    </div>
+  );
+}
+
+type ChangelogListProps = React.ComponentProps<"ul">;
+
+function ChangelogList({ className, ...props }: ChangelogListProps) {
+  return (
+    <ul
+      data-slot="changelog-list"
+      className={cn("flex flex-col gap-1", className)}
+      {...props}
+    />
+  );
+}
+
+type ChangelogItemProps = React.ComponentProps<"li">;
+
+function ChangelogItem({ className, ...props }: ChangelogItemProps) {
+  return (
+    <li
+      data-slot="changelog-item"
+      className={cn(
+        "relative ps-4 text-sm text-muted-foreground",
+        "before:absolute before:start-0 before:top-2 before:size-1 before:rounded-full before:bg-muted-foreground/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  ChangelogViewer,
+  ChangelogEntry,
+  ChangelogSection,
+  ChangelogList,
+  ChangelogItem,
+};

--- a/registry/hirael/ui/command-palette.tsx
+++ b/registry/hirael/ui/command-palette.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { KbdDisplay, KbdGroup } from "@/registry/hirael/ui/kbd";
+import {
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+} from "@/registry/hirael/ui/command";
+
+type CommandPaletteProps = Omit<
+  React.ComponentProps<typeof CommandDialog>,
+  "open" | "onOpenChange"
+> & {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /**
+   * Single key paired with ⌘ / Ctrl to toggle the palette.
+   * @default "k"
+   */
+  shortcut?: string;
+};
+
+function useControllableOpen(
+  open: boolean | undefined,
+  onOpenChange: ((open: boolean) => void) | undefined,
+) {
+  const [uncontrolled, setUncontrolled] = React.useState(false);
+  const isControlled = open !== undefined;
+  const value = isControlled ? open : uncontrolled;
+
+  const setValue = React.useCallback(
+    (next: boolean) => {
+      if (!isControlled) setUncontrolled(next);
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  return [value, setValue] as const;
+}
+
+function CommandPalette({
+  open,
+  onOpenChange,
+  shortcut = "k",
+  children,
+  ...props
+}: CommandPaletteProps) {
+  const [isOpen, setIsOpen] = useControllableOpen(open, onOpenChange);
+  const key = shortcut.toLowerCase();
+
+  React.useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() === key && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        setIsOpen(!isOpen);
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [key, isOpen, setIsOpen]);
+
+  return (
+    <CommandDialog open={isOpen} onOpenChange={setIsOpen} {...props}>
+      {children}
+    </CommandDialog>
+  );
+}
+
+function CommandPaletteTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"button">) {
+  return (
+    <button
+      type="button"
+      data-slot="command-palette-trigger"
+      className={cn(
+        "inline-flex h-9 w-full items-center gap-2 rounded-md border border-input bg-background px-3 text-sm text-muted-foreground shadow-xs transition-colors outline-none hover:border-foreground/40 hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+        className,
+      )}
+      {...props}
+    >
+      {children ?? <span className="text-start">Search…</span>}
+      <KbdGroup
+        data-slot="command-palette-trigger-kbd"
+        className="ms-auto opacity-70"
+      >
+        <KbdDisplay>⌘</KbdDisplay>
+        <KbdDisplay>K</KbdDisplay>
+      </KbdGroup>
+    </button>
+  );
+}
+
+function CommandPaletteInput({
+  ...props
+}: React.ComponentProps<typeof CommandInput>) {
+  return <CommandInput data-slot="command-palette-input" {...props} />;
+}
+
+function CommandPaletteList({
+  ...props
+}: React.ComponentProps<typeof CommandList>) {
+  return <CommandList data-slot="command-palette-list" {...props} />;
+}
+
+function CommandPaletteEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandEmpty>) {
+  return <CommandEmpty data-slot="command-palette-empty" {...props} />;
+}
+
+function CommandPaletteGroup({
+  ...props
+}: React.ComponentProps<typeof CommandGroup>) {
+  return <CommandGroup data-slot="command-palette-group" {...props} />;
+}
+
+type CommandPaletteItemProps = React.ComponentProps<typeof CommandItem> & {
+  /** Leading icon, typically a lucide-react icon. */
+  icon?: React.ReactNode;
+  /** Trailing keyboard hint rendered as a Kbd display. */
+  shortcut?: string;
+};
+
+function CommandPaletteItem({
+  icon,
+  shortcut,
+  children,
+  ...props
+}: CommandPaletteItemProps) {
+  return (
+    <CommandItem data-slot="command-palette-item" {...props}>
+      {icon != null && (
+        <span data-slot="command-palette-item-icon" className="shrink-0">
+          {icon}
+        </span>
+      )}
+      <span data-slot="command-palette-item-label">{children}</span>
+      {shortcut != null && (
+        <CommandShortcut data-slot="command-palette-item-shortcut">
+          <KbdDisplay>{shortcut}</KbdDisplay>
+        </CommandShortcut>
+      )}
+    </CommandItem>
+  );
+}
+
+function CommandPaletteSeparator({
+  ...props
+}: React.ComponentProps<typeof CommandSeparator>) {
+  return <CommandSeparator data-slot="command-palette-separator" {...props} />;
+}
+
+export {
+  CommandPalette,
+  CommandPaletteTrigger,
+  CommandPaletteInput,
+  CommandPaletteList,
+  CommandPaletteEmpty,
+  CommandPaletteGroup,
+  CommandPaletteItem,
+  CommandPaletteSeparator,
+};

--- a/registry/hirael/ui/diff-viewer.tsx
+++ b/registry/hirael/ui/diff-viewer.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type DiffType = "add" | "remove" | "context";
+
+type DiffRow = {
+  type: DiffType;
+  oldNumber?: number;
+  newNumber?: number;
+  content: string;
+};
+
+function diffLines(oldText: string, newText: string): DiffRow[] {
+  const oldLines = oldText.split("\n");
+  const newLines = newText.split("\n");
+  const rows = oldLines.length;
+  const cols = newLines.length;
+
+  const table: number[][] = Array.from({ length: rows + 1 }, () =>
+    new Array<number>(cols + 1).fill(0),
+  );
+
+  for (let i = rows - 1; i >= 0; i--) {
+    for (let j = cols - 1; j >= 0; j--) {
+      table[i][j] =
+        oldLines[i] === newLines[j]
+          ? table[i + 1][j + 1] + 1
+          : Math.max(table[i + 1][j], table[i][j + 1]);
+    }
+  }
+
+  const result: DiffRow[] = [];
+  let i = 0;
+  let j = 0;
+  let oldNumber = 1;
+  let newNumber = 1;
+
+  while (i < rows && j < cols) {
+    if (oldLines[i] === newLines[j]) {
+      result.push({
+        type: "context",
+        oldNumber: oldNumber++,
+        newNumber: newNumber++,
+        content: oldLines[i],
+      });
+      i++;
+      j++;
+    } else if (table[i + 1][j] >= table[i][j + 1]) {
+      result.push({ type: "remove", oldNumber: oldNumber++, content: oldLines[i] });
+      i++;
+    } else {
+      result.push({ type: "add", newNumber: newNumber++, content: newLines[j] });
+      j++;
+    }
+  }
+  while (i < rows) {
+    result.push({ type: "remove", oldNumber: oldNumber++, content: oldLines[i] });
+    i++;
+  }
+  while (j < cols) {
+    result.push({ type: "add", newNumber: newNumber++, content: newLines[j] });
+    j++;
+  }
+
+  return result;
+}
+
+type SplitPair = { old?: DiffRow; new?: DiffRow };
+
+function pairForSplit(rows: DiffRow[]): SplitPair[] {
+  const pairs: SplitPair[] = [];
+  let index = 0;
+
+  while (index < rows.length) {
+    const row = rows[index];
+    if (row.type === "context") {
+      pairs.push({ old: row, new: row });
+      index++;
+      continue;
+    }
+
+    const removed: DiffRow[] = [];
+    const added: DiffRow[] = [];
+    while (index < rows.length && rows[index].type === "remove") {
+      removed.push(rows[index]);
+      index++;
+    }
+    while (index < rows.length && rows[index].type === "add") {
+      added.push(rows[index]);
+      index++;
+    }
+
+    const span = Math.max(removed.length, added.length);
+    for (let offset = 0; offset < span; offset++) {
+      pairs.push({ old: removed[offset], new: added[offset] });
+    }
+  }
+
+  return pairs;
+}
+
+const DIFF_SIGN: Record<DiffType, string> = {
+  add: "+",
+  remove: "−",
+  context: " ",
+};
+
+export type DiffLineProps = Omit<React.ComponentProps<"div">, "content"> & {
+  /** Classification of the line relative to the old text. */
+  type: DiffType;
+  oldNumber?: number;
+  newNumber?: number;
+  content?: string;
+  /** Render only the start-side gutter (old number, then sign). */
+  showOldNumber?: boolean;
+  /** Render the end-side gutter (new number). */
+  showNewNumber?: boolean;
+};
+
+function DiffLine({
+  type,
+  oldNumber,
+  newNumber,
+  content,
+  showOldNumber = true,
+  showNewNumber = true,
+  className,
+  children,
+  ...props
+}: DiffLineProps) {
+  return (
+    <div
+      data-slot="diff-line"
+      data-diff={type}
+      className={cn(
+        "flex border-s-2 border-transparent",
+        type === "add" && "border-primary bg-primary/10",
+        type === "remove" && "border-destructive bg-destructive/10",
+        className,
+      )}
+      {...props}
+    >
+      {showOldNumber && (
+        <span
+          aria-hidden
+          data-slot="diff-line-old-number"
+          data-line-number={oldNumber}
+          className="w-9 shrink-0 select-none pe-2 text-end text-muted-foreground before:content-[attr(data-line-number)]"
+        />
+      )}
+      {showNewNumber && (
+        <span
+          aria-hidden
+          data-slot="diff-line-new-number"
+          data-line-number={newNumber}
+          className="w-9 shrink-0 select-none pe-2 text-end text-muted-foreground before:content-[attr(data-line-number)]"
+        />
+      )}
+      <span
+        aria-hidden
+        data-slot="diff-line-sign"
+        className={cn(
+          "w-4 shrink-0 select-none text-center",
+          type === "add" && "text-primary",
+          type === "remove" && "text-destructive",
+        )}
+      >
+        {DIFF_SIGN[type]}
+      </span>
+      <span data-slot="diff-line-content" className="flex-1 whitespace-pre pe-4">
+        {children ?? (content === "" ? "​" : content)}
+      </span>
+    </div>
+  );
+}
+
+export type DiffViewerHeaderProps = React.ComponentProps<"div"> & {
+  /** Name of the file or label shown before the old → new pair. */
+  fileName?: string;
+  oldLabel?: string;
+  newLabel?: string;
+};
+
+function DiffViewerHeader({
+  fileName,
+  oldLabel,
+  newLabel,
+  className,
+  children,
+  ...props
+}: DiffViewerHeaderProps) {
+  return (
+    <div
+      data-slot="diff-viewer-header"
+      className={cn(
+        "flex min-h-10 flex-wrap items-center gap-2 border-b border-border px-3 py-1 font-mono text-xs",
+        className,
+      )}
+      {...props}
+    >
+      {children ?? (
+        <>
+          {fileName && (
+            <span data-slot="diff-viewer-filename" className="text-foreground">
+              {fileName}
+            </span>
+          )}
+          {(oldLabel || newLabel) && (
+            <span
+              data-slot="diff-viewer-range"
+              className="flex items-center gap-1.5 text-muted-foreground"
+            >
+              {oldLabel && (
+                <span className="text-destructive">{oldLabel}</span>
+              )}
+              <span aria-hidden>→</span>
+              {newLabel && <span className="text-primary">{newLabel}</span>}
+            </span>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export type DiffViewerProps = React.ComponentProps<"div"> & {
+  /** Original text. Lines are compared against `newText` with a line LCS. */
+  oldText: string;
+  /** Updated text. Lines absent from `oldText` are marked as additions. */
+  newText: string;
+  /** Single column of +/- lines, or old and new side by side. */
+  mode?: "unified" | "split";
+};
+
+function DiffViewer({
+  oldText,
+  newText,
+  mode = "unified",
+  className,
+  children,
+  ...props
+}: DiffViewerProps) {
+  const rows = React.useMemo(
+    () => diffLines(oldText, newText),
+    [oldText, newText],
+  );
+
+  const splitRows = React.useMemo(() => pairForSplit(rows), [rows]);
+
+  return (
+    <div
+      data-slot="diff-viewer"
+      data-mode={mode}
+      className={cn(
+        "overflow-hidden rounded-md border border-border bg-card text-card-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <div
+        data-slot="diff-viewer-body"
+        dir="ltr"
+        className="overflow-x-auto font-mono text-[13px] leading-6"
+      >
+        {mode === "unified" ? (
+          <div data-slot="diff-viewer-unified" className="w-fit min-w-full py-2">
+            {rows.map((row, index) => (
+              <DiffLine
+                key={index}
+                type={row.type}
+                oldNumber={row.oldNumber}
+                newNumber={row.newNumber}
+                content={row.content}
+              />
+            ))}
+          </div>
+        ) : (
+          <div
+            data-slot="diff-viewer-split"
+            className="grid w-fit min-w-full grid-cols-2 py-2"
+          >
+            <div
+              data-slot="diff-viewer-split-old"
+              className="border-e border-border"
+            >
+              {splitRows.map((pair, index) =>
+                pair.old ? (
+                  <DiffLine
+                    key={index}
+                    type={pair.old.type}
+                    oldNumber={pair.old.oldNumber}
+                    content={pair.old.content}
+                    showNewNumber={false}
+                  />
+                ) : (
+                  <DiffLine
+                    key={index}
+                    type="context"
+                    content=""
+                    showNewNumber={false}
+                    className="opacity-0"
+                  />
+                ),
+              )}
+            </div>
+            <div data-slot="diff-viewer-split-new">
+              {splitRows.map((pair, index) =>
+                pair.new ? (
+                  <DiffLine
+                    key={index}
+                    type={pair.new.type}
+                    newNumber={pair.new.newNumber}
+                    content={pair.new.content}
+                    showOldNumber={false}
+                  />
+                ) : (
+                  <DiffLine
+                    key={index}
+                    type="context"
+                    content=""
+                    showOldNumber={false}
+                    className="opacity-0"
+                  />
+                ),
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export { DiffViewer, DiffLine, DiffViewerHeader };

--- a/registry/hirael/ui/discount-builder.tsx
+++ b/registry/hirael/ui/discount-builder.tsx
@@ -1,0 +1,612 @@
+"use client";
+
+import * as React from "react";
+import { Percent, Plus, Tag, Truck, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/registry/hirael/ui/badge";
+import { Button } from "@/registry/hirael/ui/button";
+import { Input } from "@/registry/hirael/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/registry/hirael/ui/select";
+
+export type DiscountType = "percentage" | "fixed" | "free_shipping";
+
+export type DiscountConditionKind =
+  | "min_order"
+  | "collection"
+  | "first_order"
+  | "date_range";
+
+export type DiscountCondition = {
+  id: string;
+  kind: DiscountConditionKind;
+  amount: number;
+  collection: string;
+  start: string;
+  end: string;
+};
+
+export type Discount = {
+  type: DiscountType;
+  value: number;
+  conditions: DiscountCondition[];
+};
+
+const TYPE_OPTIONS: {
+  value: DiscountType;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+}[] = [
+  { value: "percentage", label: "Percentage", icon: Percent },
+  { value: "fixed", label: "Fixed amount", icon: Tag },
+  { value: "free_shipping", label: "Free shipping", icon: Truck },
+];
+
+const CONDITION_OPTIONS: { value: DiscountConditionKind; label: string }[] = [
+  { value: "min_order", label: "Minimum order amount" },
+  { value: "collection", label: "Specific collection" },
+  { value: "first_order", label: "First order only" },
+  { value: "date_range", label: "Date range" },
+];
+
+function conditionLabel(kind: DiscountConditionKind): string {
+  return CONDITION_OPTIONS.find((c) => c.value === kind)?.label ?? kind;
+}
+
+function makeId(seed: number): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `discount-condition-${seed}`;
+}
+
+function emptyCondition(id: string, kind: DiscountConditionKind): DiscountCondition {
+  return { id, kind, amount: 0, collection: "", start: "", end: "" };
+}
+
+function formatMoney(amount: number): string {
+  return Number.isInteger(amount) ? `$${amount}` : `$${amount.toFixed(2)}`;
+}
+
+function conditionSummary(condition: DiscountCondition): string | null {
+  switch (condition.kind) {
+    case "min_order":
+      return condition.amount > 0
+        ? `orders over ${formatMoney(condition.amount)}`
+        : null;
+    case "collection":
+      return condition.collection
+        ? `in ${condition.collection}`
+        : null;
+    case "first_order":
+      return "first order only";
+    case "date_range":
+      if (condition.start && condition.end) {
+        return `from ${condition.start} to ${condition.end}`;
+      }
+      if (condition.start) return `from ${condition.start}`;
+      if (condition.end) return `until ${condition.end}`;
+      return null;
+    default:
+      return null;
+  }
+}
+
+function summarize(discount: Discount): string {
+  let head: string;
+  if (discount.type === "free_shipping") {
+    head = "Free shipping";
+  } else if (discount.type === "percentage") {
+    head = `${discount.value || 0}% off`;
+  } else {
+    head = `${formatMoney(discount.value || 0)} off`;
+  }
+
+  const parts = discount.conditions
+    .map(conditionSummary)
+    .filter((part): part is string => part !== null);
+
+  return parts.length > 0 ? `${head} ${parts.join(", ")}` : head;
+}
+
+type Ctx = {
+  value: Discount;
+  setType: (type: DiscountType) => void;
+  setValue: (value: number) => void;
+  addCondition: () => void;
+  updateCondition: (
+    id: string,
+    patch: Partial<Omit<DiscountCondition, "id">>,
+  ) => void;
+  removeCondition: (id: string) => void;
+};
+
+const DiscountBuilderContext = React.createContext<Ctx | null>(null);
+
+function useDiscountBuilder(): Ctx {
+  const ctx = React.useContext(DiscountBuilderContext);
+  if (!ctx) {
+    throw new Error(
+      "DiscountBuilder compound parts must be used inside <DiscountBuilder>",
+    );
+  }
+  return ctx;
+}
+
+const DEFAULT_DISCOUNT: Discount = {
+  type: "percentage",
+  value: 0,
+  conditions: [],
+};
+
+export type DiscountBuilderProps = Omit<
+  React.ComponentProps<"div">,
+  "onChange" | "defaultValue"
+> & {
+  /** Controlled discount configuration. */
+  value?: Discount;
+  /** Initial discount for an uncontrolled builder. */
+  defaultValue?: Discount;
+  /** Called whenever the discount changes. */
+  onValueChange?: (value: Discount) => void;
+};
+
+function DiscountBuilder({
+  value: valueProp,
+  defaultValue,
+  onValueChange,
+  className,
+  children,
+  ...props
+}: DiscountBuilderProps) {
+  const [internalValue, setInternalValue] = React.useState<Discount>(
+    defaultValue ?? DEFAULT_DISCOUNT,
+  );
+  const value = valueProp ?? internalValue;
+
+  const seedRef = React.useRef(0);
+
+  const setValue = React.useCallback(
+    (next: Discount) => {
+      if (valueProp === undefined) setInternalValue(next);
+      onValueChange?.(next);
+    },
+    [valueProp, onValueChange],
+  );
+
+  const setType = React.useCallback(
+    (type: DiscountType) => {
+      setValue({
+        ...value,
+        type,
+        value: type === "free_shipping" ? 0 : value.value,
+      });
+    },
+    [value, setValue],
+  );
+
+  const setAmount = React.useCallback(
+    (amount: number) => {
+      setValue({ ...value, value: amount });
+    },
+    [value, setValue],
+  );
+
+  const addCondition = React.useCallback(() => {
+    const used = new Set(value.conditions.map((c) => c.kind));
+    const next = CONDITION_OPTIONS.find((option) => !used.has(option.value));
+    if (!next) return;
+    setValue({
+      ...value,
+      conditions: [
+        ...value.conditions,
+        emptyCondition(makeId(seedRef.current++), next.value),
+      ],
+    });
+  }, [value, setValue]);
+
+  const updateCondition = React.useCallback(
+    (id: string, patch: Partial<Omit<DiscountCondition, "id">>) => {
+      setValue({
+        ...value,
+        conditions: value.conditions.map((condition) =>
+          condition.id === id ? { ...condition, ...patch } : condition,
+        ),
+      });
+    },
+    [value, setValue],
+  );
+
+  const removeCondition = React.useCallback(
+    (id: string) => {
+      setValue({
+        ...value,
+        conditions: value.conditions.filter((condition) => condition.id !== id),
+      });
+    },
+    [value, setValue],
+  );
+
+  const ctx = React.useMemo<Ctx>(
+    () => ({
+      value,
+      setType,
+      setValue: setAmount,
+      addCondition,
+      updateCondition,
+      removeCondition,
+    }),
+    [value, setType, setAmount, addCondition, updateCondition, removeCondition],
+  );
+
+  return (
+    <DiscountBuilderContext.Provider value={ctx}>
+      <div
+        data-slot="discount-builder"
+        className={cn("flex w-full flex-col gap-4", className)}
+        {...props}
+      >
+        {children}
+      </div>
+    </DiscountBuilderContext.Provider>
+  );
+}
+
+type DiscountTypeProps = Omit<React.ComponentProps<"div">, "children">;
+
+function DiscountType({ className, ...props }: DiscountTypeProps) {
+  const ctx = useDiscountBuilder();
+  return (
+    <div
+      data-slot="discount-type"
+      role="radiogroup"
+      aria-label="Discount type"
+      className={cn(
+        "grid grid-cols-3 gap-2 rounded-lg border border-input bg-card p-1",
+        className,
+      )}
+      {...props}
+    >
+      {TYPE_OPTIONS.map((option) => {
+        const active = option.value === ctx.value.type;
+        const Icon = option.icon;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            data-slot="discount-type-option"
+            data-state={active ? "active" : "inactive"}
+            onClick={() => ctx.setType(option.value)}
+            className={cn(
+              "flex flex-col items-center justify-center gap-1.5 rounded-md px-2 py-3 text-xs font-medium outline-none transition-colors focus-visible:ring-[3px] focus-visible:ring-ring/50",
+              active
+                ? "bg-primary text-primary-foreground shadow-xs"
+                : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+            )}
+          >
+            <Icon className="size-4" />
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+type DiscountValueProps = Omit<
+  React.ComponentProps<"div">,
+  "children" | "onChange"
+> & {
+  /** Placeholder shown in the empty amount field. */
+  placeholder?: string;
+};
+
+function DiscountValue({
+  className,
+  placeholder = "0",
+  ...props
+}: DiscountValueProps) {
+  const ctx = useDiscountBuilder();
+
+  if (ctx.value.type === "free_shipping") return null;
+
+  const isPercentage = ctx.value.type === "percentage";
+
+  return (
+    <div
+      data-slot="discount-value"
+      className={cn("relative w-full", className)}
+      {...props}
+    >
+      {!isPercentage ? (
+        <span
+          data-slot="discount-value-symbol"
+          className="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3 text-sm text-muted-foreground"
+        >
+          $
+        </span>
+      ) : null}
+      <Input
+        data-slot="discount-value-input"
+        type="number"
+        inputMode="decimal"
+        min={0}
+        max={isPercentage ? 100 : undefined}
+        step={isPercentage ? 1 : "0.01"}
+        value={ctx.value.value === 0 ? "" : ctx.value.value}
+        placeholder={placeholder}
+        aria-label={isPercentage ? "Percentage off" : "Amount off"}
+        onChange={(event) => {
+          const next = Number.parseFloat(event.target.value);
+          ctx.setValue(Number.isFinite(next) ? next : 0);
+        }}
+        className={cn(isPercentage ? "pe-9" : "ps-7")}
+      />
+      {isPercentage ? (
+        <span
+          data-slot="discount-value-symbol"
+          className="pointer-events-none absolute inset-y-0 end-0 flex items-center pe-3 text-sm text-muted-foreground"
+        >
+          <Percent className="size-4" />
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+type DiscountConditionsProps = React.ComponentProps<"div"> & {
+  /** Shown when no conditions have been added. */
+  emptyHint?: React.ReactNode;
+};
+
+function DiscountConditions({
+  className,
+  children,
+  emptyHint = "No conditions. The discount applies to every order.",
+  ...props
+}: DiscountConditionsProps) {
+  const ctx = useDiscountBuilder();
+  const hasChildren = React.Children.count(children) > 0;
+
+  return (
+    <div
+      data-slot="discount-conditions"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    >
+      {hasChildren ? (
+        children
+      ) : ctx.value.conditions.length > 0 ? (
+        ctx.value.conditions.map((condition) => (
+          <DiscountCondition key={condition.id} condition={condition} />
+        ))
+      ) : (
+        <p
+          data-slot="discount-conditions-empty"
+          className="text-sm text-muted-foreground"
+        >
+          {emptyHint}
+        </p>
+      )}
+    </div>
+  );
+}
+
+type DiscountConditionProps = Omit<React.ComponentProps<"div">, "children"> & {
+  /** The condition row this part renders. */
+  condition: DiscountCondition;
+};
+
+function DiscountCondition({
+  condition,
+  className,
+  ...props
+}: DiscountConditionProps) {
+  const ctx = useDiscountBuilder();
+  const used = new Set(
+    ctx.value.conditions
+      .filter((c) => c.id !== condition.id)
+      .map((c) => c.kind),
+  );
+  const available = CONDITION_OPTIONS.filter(
+    (option) => option.value === condition.kind || !used.has(option.value),
+  );
+
+  return (
+    <div
+      data-slot="discount-condition"
+      className={cn(
+        "flex flex-wrap items-center gap-2 rounded-md border border-border bg-background p-2",
+        className,
+      )}
+      {...props}
+    >
+      <Select
+        value={condition.kind}
+        onValueChange={(kind) =>
+          ctx.updateCondition(condition.id, {
+            kind: kind as DiscountConditionKind,
+          })
+        }
+      >
+        <SelectTrigger
+          data-slot="discount-condition-kind"
+          className="w-[12rem]"
+          aria-label="Condition"
+        >
+          <SelectValue placeholder="Condition" />
+        </SelectTrigger>
+        <SelectContent>
+          {available.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {condition.kind === "min_order" ? (
+        <div className="relative min-w-[8rem] flex-1">
+          <span
+            data-slot="discount-condition-symbol"
+            className="pointer-events-none absolute inset-y-0 start-0 flex items-center ps-3 text-sm text-muted-foreground"
+          >
+            $
+          </span>
+          <Input
+            data-slot="discount-condition-amount"
+            type="number"
+            inputMode="decimal"
+            min={0}
+            step="0.01"
+            value={condition.amount === 0 ? "" : condition.amount}
+            placeholder="0"
+            aria-label="Minimum order amount"
+            onChange={(event) => {
+              const next = Number.parseFloat(event.target.value);
+              ctx.updateCondition(condition.id, {
+                amount: Number.isFinite(next) ? next : 0,
+              });
+            }}
+            className="ps-7"
+          />
+        </div>
+      ) : null}
+
+      {condition.kind === "collection" ? (
+        <Input
+          data-slot="discount-condition-collection"
+          value={condition.collection}
+          placeholder="Collection name"
+          aria-label="Collection"
+          onChange={(event) =>
+            ctx.updateCondition(condition.id, {
+              collection: event.target.value,
+            })
+          }
+          className="min-w-[8rem] flex-1"
+        />
+      ) : null}
+
+      {condition.kind === "date_range" ? (
+        <div className="flex min-w-[8rem] flex-1 items-center gap-2">
+          <Input
+            data-slot="discount-condition-start"
+            type="date"
+            value={condition.start}
+            aria-label="Start date"
+            onChange={(event) =>
+              ctx.updateCondition(condition.id, { start: event.target.value })
+            }
+            className="flex-1"
+          />
+          <span className="text-sm text-muted-foreground">to</span>
+          <Input
+            data-slot="discount-condition-end"
+            type="date"
+            value={condition.end}
+            aria-label="End date"
+            onChange={(event) =>
+              ctx.updateCondition(condition.id, { end: event.target.value })
+            }
+            className="flex-1"
+          />
+        </div>
+      ) : null}
+
+      {condition.kind === "first_order" ? (
+        <span
+          data-slot="discount-condition-note"
+          className="flex-1 text-sm text-muted-foreground"
+        >
+          Only the customer&apos;s first order qualifies.
+        </span>
+      ) : null}
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        data-slot="discount-condition-remove"
+        aria-label={`Remove ${conditionLabel(condition.kind)} condition`}
+        onClick={() => ctx.removeCondition(condition.id)}
+        className="ms-auto text-muted-foreground"
+      >
+        <X />
+      </Button>
+    </div>
+  );
+}
+
+type DiscountAddConditionProps = React.ComponentProps<typeof Button>;
+
+function DiscountAddCondition({
+  className,
+  children,
+  onClick,
+  ...props
+}: DiscountAddConditionProps) {
+  const ctx = useDiscountBuilder();
+  const exhausted = ctx.value.conditions.length >= CONDITION_OPTIONS.length;
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      data-slot="discount-add-condition"
+      disabled={exhausted}
+      onClick={(event) => {
+        onClick?.(event);
+        if (event.defaultPrevented) return;
+        ctx.addCondition();
+      }}
+      className={cn("w-fit", className)}
+      {...props}
+    >
+      <Plus />
+      {children ?? "Add condition"}
+    </Button>
+  );
+}
+
+type DiscountSummaryProps = Omit<
+  React.ComponentProps<typeof Badge>,
+  "children"
+>;
+
+function DiscountSummary({ className, ...props }: DiscountSummaryProps) {
+  const ctx = useDiscountBuilder();
+  return (
+    <Badge
+      variant="secondary"
+      data-slot="discount-summary"
+      className={cn(
+        "h-auto max-w-full gap-1.5 px-3 py-1.5 text-sm font-normal whitespace-normal",
+        className,
+      )}
+      {...props}
+    >
+      <Tag className="size-3.5 shrink-0 text-muted-foreground" />
+      <span className="min-w-0">{summarize(ctx.value)}</span>
+    </Badge>
+  );
+}
+
+export {
+  DiscountBuilder,
+  DiscountType,
+  DiscountValue,
+  DiscountConditions,
+  DiscountCondition,
+  DiscountAddCondition,
+  DiscountSummary,
+};

--- a/registry/hirael/ui/feature-flag-manager.tsx
+++ b/registry/hirael/ui/feature-flag-manager.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import * as React from "react";
+import { Flag, Search } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/registry/hirael/ui/badge";
+
+export type FeatureFlag = {
+  id: string;
+  name: string;
+  key: string;
+  description?: string;
+  enabled: boolean;
+  environments?: string[];
+  rollout?: number;
+};
+
+type FeatureFlagManagerContextValue = {
+  flags: FeatureFlag[];
+  query: string;
+  setQuery: (query: string) => void;
+  toggle: (id: string) => void;
+  enabledCount: number;
+  total: number;
+};
+
+const FeatureFlagManagerContext =
+  React.createContext<FeatureFlagManagerContextValue | null>(null);
+
+function useFeatureFlagManager() {
+  const ctx = React.useContext(FeatureFlagManagerContext);
+  if (!ctx) {
+    throw new Error(
+      "FeatureFlagManager compound parts must be used inside <FeatureFlagManager>",
+    );
+  }
+  return ctx;
+}
+
+function matchesQuery(flag: FeatureFlag, query: string) {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return (
+    flag.name.toLowerCase().includes(q) ||
+    flag.key.toLowerCase().includes(q) ||
+    (flag.description?.toLowerCase().includes(q) ?? false)
+  );
+}
+
+export type FeatureFlagManagerProps = Omit<
+  React.ComponentProps<"div">,
+  "defaultValue" | "onChange"
+> & {
+  /** Controlled list of flags. */
+  value?: FeatureFlag[];
+  /** Uncontrolled initial list of flags. */
+  defaultValue?: FeatureFlag[];
+  /** Called with the next list whenever a flag is toggled. */
+  onValueChange?: (value: FeatureFlag[]) => void;
+};
+
+function FeatureFlagManager({
+  value: valueProp,
+  defaultValue,
+  onValueChange,
+  className,
+  children,
+  ...props
+}: FeatureFlagManagerProps) {
+  const [internalValue, setInternalValue] = React.useState<FeatureFlag[]>(
+    defaultValue ?? [],
+  );
+  const flags = valueProp ?? internalValue;
+
+  const setValue = React.useCallback(
+    (next: FeatureFlag[]) => {
+      if (valueProp === undefined) setInternalValue(next);
+      onValueChange?.(next);
+    },
+    [valueProp, onValueChange],
+  );
+
+  const [query, setQuery] = React.useState("");
+
+  const toggle = React.useCallback(
+    (id: string) => {
+      setValue(
+        flags.map((flag) =>
+          flag.id === id ? { ...flag, enabled: !flag.enabled } : flag,
+        ),
+      );
+    },
+    [flags, setValue],
+  );
+
+  const enabledCount = flags.filter((flag) => flag.enabled).length;
+
+  const ctx = React.useMemo<FeatureFlagManagerContextValue>(
+    () => ({
+      flags,
+      query,
+      setQuery,
+      toggle,
+      enabledCount,
+      total: flags.length,
+    }),
+    [flags, query, toggle, enabledCount],
+  );
+
+  return (
+    <FeatureFlagManagerContext.Provider value={ctx}>
+      <div
+        data-slot="feature-flag-manager"
+        className={cn(
+          "flex flex-col overflow-hidden rounded-lg border border-border bg-card text-card-foreground",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </FeatureFlagManagerContext.Provider>
+  );
+}
+
+type FeatureFlagManagerToolbarProps = React.ComponentProps<"div">;
+
+function FeatureFlagManagerToolbar({
+  className,
+  ...props
+}: FeatureFlagManagerToolbarProps) {
+  const { query, setQuery, enabledCount, total } = useFeatureFlagManager();
+
+  return (
+    <div
+      data-slot="feature-flag-manager-toolbar"
+      className={cn(
+        "flex items-center gap-3 border-b border-border px-4 py-3",
+        className,
+      )}
+      {...props}
+    >
+      <div className="relative min-w-0 flex-1">
+        <Search
+          aria-hidden
+          className="pointer-events-none absolute start-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+        />
+        <input
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search flags"
+          aria-label="Search flags"
+          className="h-8 w-full rounded-md border border-border bg-background pe-3 ps-8 text-sm text-foreground transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+        />
+      </div>
+      <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+        {enabledCount} / {total} on
+      </span>
+    </div>
+  );
+}
+
+type FeatureFlagListProps = React.ComponentProps<"ul">;
+
+function FeatureFlagList({ className, children, ...props }: FeatureFlagListProps) {
+  const { flags, query } = useFeatureFlagManager();
+  const visible = flags.filter((flag) => matchesQuery(flag, query));
+
+  return (
+    <ul
+      data-slot="feature-flag-list"
+      className={cn("divide-y divide-border", className)}
+      {...props}
+    >
+      {children ??
+        visible.map((flag) => <FeatureFlagItem key={flag.id} flag={flag} />)}
+    </ul>
+  );
+}
+
+type FeatureFlagItemProps = React.ComponentProps<"li"> & {
+  flag: FeatureFlag;
+};
+
+function FeatureFlagItem({
+  flag,
+  className,
+  children,
+  ...props
+}: FeatureFlagItemProps) {
+  return (
+    <li
+      data-slot="feature-flag-item"
+      data-enabled={flag.enabled ? "" : undefined}
+      className={cn(
+        "flex flex-wrap items-center gap-x-3 gap-y-2 px-4 py-3",
+        className,
+      )}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+              <span className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground">
+                {flag.enabled ? (
+                  <span className="state-dot" aria-hidden />
+                ) : (
+                  <Flag
+                    aria-hidden
+                    className="size-3.5 text-muted-foreground"
+                  />
+                )}
+                {flag.name}
+              </span>
+              <code className="truncate font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+                {flag.key}
+              </code>
+            </div>
+            {flag.description ? (
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                {flag.description}
+              </p>
+            ) : null}
+            {flag.environments?.length || flag.rollout !== undefined ? (
+              <div className="flex flex-wrap items-center gap-1.5 pt-0.5">
+                {flag.environments?.map((env) => (
+                  <Badge
+                    key={env}
+                    variant="secondary"
+                    className="bg-muted font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground"
+                  >
+                    {env}
+                  </Badge>
+                ))}
+                {flag.rollout !== undefined ? (
+                  <span className="font-mono text-[10px] tabular-nums text-muted-foreground">
+                    {flag.rollout}% rollout
+                  </span>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+          <FeatureFlagSwitch flag={flag} className="ms-auto" />
+        </>
+      )}
+    </li>
+  );
+}
+
+type FeatureFlagSwitchProps = Omit<
+  React.ComponentProps<"button">,
+  "role" | "aria-checked" | "onClick"
+> & {
+  flag: FeatureFlag;
+};
+
+function FeatureFlagSwitch({
+  flag,
+  className,
+  ...props
+}: FeatureFlagSwitchProps) {
+  const { toggle } = useFeatureFlagManager();
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={flag.enabled}
+      aria-label={`Toggle ${flag.name}`}
+      data-slot="feature-flag-switch"
+      data-state={flag.enabled ? "checked" : "unchecked"}
+      onClick={() => toggle(flag.id)}
+      className={cn(
+        "inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent p-0.5 transition-colors outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-muted",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        aria-hidden
+        className="pointer-events-none size-4 rounded-full bg-background shadow-sm transition-transform data-[state=checked]:translate-x-4 rtl:data-[state=checked]:-translate-x-4"
+        data-state={flag.enabled ? "checked" : "unchecked"}
+      />
+    </button>
+  );
+}
+
+export {
+  FeatureFlagManager,
+  FeatureFlagManagerToolbar,
+  FeatureFlagList,
+  FeatureFlagItem,
+  FeatureFlagSwitch,
+};

--- a/registry/hirael/ui/file-explorer.tsx
+++ b/registry/hirael/ui/file-explorer.tsx
@@ -1,0 +1,644 @@
+"use client";
+
+import * as React from "react";
+import {
+  ChevronRight,
+  File,
+  Folder,
+  FolderOpen,
+  LayoutGrid,
+  List,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/registry/hirael/ui/breadcrumb";
+import { Button } from "@/registry/hirael/ui/button";
+
+export type FileNode = {
+  name: string;
+  type: "folder" | "file";
+  size?: number;
+  modified?: string;
+  children?: FileNode[];
+};
+
+type FileView = "list" | "grid";
+
+type FileExplorerContextValue = {
+  tree: FileNode;
+  path: string[];
+  current: FileNode;
+  view: FileView;
+  setView: (view: FileView) => void;
+  navigate: (path: string[]) => void;
+  open: (node: FileNode) => void;
+  isOnPath: (path: string[]) => boolean;
+  selected: string | undefined;
+  setSelected: (name: string | undefined) => void;
+};
+
+const FileExplorerContext =
+  React.createContext<FileExplorerContextValue | null>(null);
+
+function useFileExplorer() {
+  const ctx = React.useContext(FileExplorerContext);
+  if (!ctx) {
+    throw new Error("FileExplorer parts must be used within <FileExplorer>");
+  }
+  return ctx;
+}
+
+function nodeAtPath(root: FileNode, path: string[]): FileNode {
+  let node = root;
+  for (const name of path) {
+    const next = node.children?.find(
+      (child) => child.type === "folder" && child.name === name,
+    );
+    if (!next) break;
+    node = next;
+  }
+  return node;
+}
+
+function samePath(a: string[], b: string[]) {
+  return a.length === b.length && a.every((part, index) => part === b[index]);
+}
+
+function startsWithPath(path: string[], prefix: string[]) {
+  return (
+    prefix.length <= path.length &&
+    prefix.every((part, index) => part === path[index])
+  );
+}
+
+function formatSize(bytes: number | undefined) {
+  if (bytes == null) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value < 10 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`;
+}
+
+function folderSummary(node: FileNode) {
+  const count = node.children?.length ?? 0;
+  return count === 1 ? "1 item" : `${count} items`;
+}
+
+export type FileExplorerProps = Omit<
+  React.ComponentProps<"div">,
+  "onChange"
+> & {
+  /** Root folder rendered in the tree and browsed in the main pane. */
+  tree: FileNode;
+  /** Initial folder path, as folder names from the root's children down. */
+  defaultPath?: string[];
+  /** Controlled folder path, as folder names from the root's children down. */
+  path?: string[];
+  /** Called with the new path when the user navigates. */
+  onPathChange?: (path: string[]) => void;
+  defaultView?: FileView;
+};
+
+function FileExplorer({
+  tree,
+  defaultPath,
+  path: pathProp,
+  onPathChange,
+  defaultView = "list",
+  className,
+  children,
+  ...props
+}: FileExplorerProps) {
+  const [internalPath, setInternalPath] = React.useState<string[]>(
+    defaultPath ?? [],
+  );
+  const path = pathProp ?? internalPath;
+  const [view, setView] = React.useState<FileView>(defaultView);
+  const [selected, setSelected] = React.useState<string | undefined>(undefined);
+
+  const navigate = React.useCallback(
+    (next: string[]) => {
+      if (pathProp === undefined) setInternalPath(next);
+      onPathChange?.(next);
+      setSelected(undefined);
+    },
+    [pathProp, onPathChange],
+  );
+
+  const current = React.useMemo(() => nodeAtPath(tree, path), [tree, path]);
+
+  const open = React.useCallback(
+    (node: FileNode) => {
+      if (node.type === "folder") {
+        navigate([...path, node.name]);
+      } else {
+        setSelected(node.name);
+      }
+    },
+    [navigate, path],
+  );
+
+  const isOnPath = React.useCallback(
+    (candidate: string[]) => startsWithPath(path, candidate),
+    [path],
+  );
+
+  const value = React.useMemo<FileExplorerContextValue>(
+    () => ({
+      tree,
+      path,
+      current,
+      view,
+      setView,
+      navigate,
+      open,
+      isOnPath,
+      selected,
+      setSelected,
+    }),
+    [tree, path, current, view, navigate, open, isOnPath, selected],
+  );
+
+  return (
+    <FileExplorerContext.Provider value={value}>
+      <div
+        data-slot="file-explorer"
+        className={cn(
+          "flex min-h-0 w-full overflow-hidden rounded-lg border border-border bg-card text-card-foreground",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </FileExplorerContext.Provider>
+  );
+}
+
+type FileExplorerSidebarProps = React.ComponentProps<"div">;
+
+function FileExplorerSidebar({
+  className,
+  children,
+  ...props
+}: FileExplorerSidebarProps) {
+  return (
+    <div
+      data-slot="file-explorer-sidebar"
+      className={cn(
+        "flex w-56 shrink-0 flex-col overflow-auto border-e border-border bg-background/40 p-2",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+type FileExplorerTreeProps = React.ComponentProps<"div"> & {
+  /** Folder to render. Defaults to the explorer's root tree. */
+  node?: FileNode;
+};
+
+function FileExplorerTree({
+  node,
+  className,
+  ...props
+}: FileExplorerTreeProps) {
+  const { tree } = useFileExplorer();
+  const root = node ?? tree;
+
+  return (
+    <div
+      data-slot="file-explorer-tree"
+      role="tree"
+      className={cn("min-w-0 select-none text-sm", className)}
+      {...props}
+    >
+      {root.children
+        ?.filter((child) => child.type === "folder")
+        .map((child) => (
+          <FileExplorerTreeNode key={child.name} node={child} path={[child.name]} />
+        ))}
+    </div>
+  );
+}
+
+const TREE_INDENT_PER_LEVEL = 14;
+const TREE_INDENT_BASE = 8;
+
+type FileExplorerTreeNodeProps = {
+  node: FileNode;
+  path: string[];
+};
+
+function FileExplorerTreeNode({ node, path }: FileExplorerTreeNodeProps) {
+  const { path: currentPath, isOnPath, navigate } = useFileExplorer();
+  const folders =
+    node.children?.filter((child) => child.type === "folder") ?? [];
+  const hasFolders = folders.length > 0;
+  const onPath = isOnPath(path);
+  const isCurrent = samePath(currentPath, path);
+
+  const [expanded, setExpanded] = React.useState(onPath);
+
+  React.useEffect(() => {
+    if (onPath) setExpanded(true);
+  }, [onPath]);
+
+  const depth = path.length - 1;
+
+  return (
+    <div data-slot="file-explorer-tree-item" role="treeitem" aria-selected={isCurrent}>
+      <button
+        type="button"
+        data-slot="file-explorer-tree-trigger"
+        data-state={expanded ? "open" : "closed"}
+        data-active={isCurrent ? "" : undefined}
+        aria-expanded={hasFolders ? expanded : undefined}
+        onClick={() => {
+          navigate(path);
+          if (hasFolders) setExpanded(true);
+        }}
+        style={{
+          paddingInlineStart:
+            depth * TREE_INDENT_PER_LEVEL + TREE_INDENT_BASE,
+        }}
+        className={cn(
+          "group flex h-7 w-full items-center gap-1.5 rounded-sm pe-2 text-start outline-none transition-colors",
+          "hover:bg-accent focus-visible:bg-accent focus-visible:ring-2 focus-visible:ring-ring",
+          isCurrent
+            ? "bg-accent font-medium text-foreground"
+            : "text-foreground/80",
+        )}
+      >
+        <span
+          role="presentation"
+          onClick={(event) => {
+            if (!hasFolders) return;
+            event.stopPropagation();
+            setExpanded((value) => !value);
+          }}
+          className="flex size-4 shrink-0 items-center justify-center"
+        >
+          <ChevronRight
+            aria-hidden
+            className={cn(
+              "size-3.5 text-muted-foreground transition-transform duration-150",
+              hasFolders
+                ? "group-data-[state=open]:rotate-90 rtl:rotate-180 rtl:group-data-[state=open]:rotate-90"
+                : "invisible",
+            )}
+          />
+        </span>
+        <span className="flex shrink-0 items-center [&_svg]:size-4">
+          <Folder className="text-muted-foreground group-data-[state=open]:hidden" />
+          <FolderOpen className="hidden text-muted-foreground group-data-[state=open]:block" />
+        </span>
+        <span className="min-w-0 truncate">{node.name}</span>
+      </button>
+      {hasFolders && expanded && (
+        <div role="group">
+          {folders.map((child) => (
+            <FileExplorerTreeNode
+              key={child.name}
+              node={child}
+              path={[...path, child.name]}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+type FileExplorerBreadcrumbProps = React.ComponentProps<typeof Breadcrumb> & {
+  /** Label for the root crumb. */
+  rootLabel?: React.ReactNode;
+};
+
+function FileExplorerBreadcrumb({
+  rootLabel = "Home",
+  className,
+  ...props
+}: FileExplorerBreadcrumbProps) {
+  const { tree, path, navigate } = useFileExplorer();
+  const rootName = tree.name || rootLabel;
+
+  const crumbs = [
+    { label: rootName, target: [] as string[] },
+    ...path.map((name, index) => ({
+      label: name,
+      target: path.slice(0, index + 1),
+    })),
+  ];
+
+  return (
+    <Breadcrumb
+      data-slot="file-explorer-breadcrumb"
+      className={cn("min-w-0", className)}
+      {...props}
+    >
+      <BreadcrumbList>
+        {crumbs.map((crumb, index) => {
+          const isLast = index === crumbs.length - 1;
+          return (
+            <React.Fragment key={index}>
+              <BreadcrumbItem className="min-w-0">
+                {isLast ? (
+                  <BreadcrumbPage className="truncate">
+                    {crumb.label}
+                  </BreadcrumbPage>
+                ) : (
+                  <BreadcrumbLink
+                    asChild
+                    className="truncate rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => navigate(crumb.target)}
+                    >
+                      {crumb.label}
+                    </button>
+                  </BreadcrumbLink>
+                )}
+              </BreadcrumbItem>
+              {!isLast && (
+                <BreadcrumbSeparator>
+                  <ChevronRight className="rtl:rotate-180" />
+                </BreadcrumbSeparator>
+              )}
+            </React.Fragment>
+          );
+        })}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}
+
+type FileExplorerToolbarProps = React.ComponentProps<"div">;
+
+function FileExplorerToolbar({
+  className,
+  children,
+  ...props
+}: FileExplorerToolbarProps) {
+  const { view, setView } = useFileExplorer();
+  return (
+    <div
+      data-slot="file-explorer-toolbar"
+      className={cn(
+        "flex items-center gap-2 border-b border-border px-3 py-2",
+        className,
+      )}
+      {...props}
+    >
+      {children ?? <FileExplorerBreadcrumb />}
+      <div
+        role="group"
+        aria-label="View"
+        className="ms-auto flex shrink-0 items-center gap-1"
+      >
+        <Button
+          type="button"
+          variant={view === "list" ? "secondary" : "ghost"}
+          size="icon-sm"
+          aria-label="List view"
+          aria-pressed={view === "list"}
+          onClick={() => setView("list")}
+        >
+          <List />
+        </Button>
+        <Button
+          type="button"
+          variant={view === "grid" ? "secondary" : "ghost"}
+          size="icon-sm"
+          aria-label="Grid view"
+          aria-pressed={view === "grid"}
+          onClick={() => setView("grid")}
+        >
+          <LayoutGrid />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+type FileExplorerListProps = React.ComponentProps<"div"> & {
+  /** Shown when the current folder has no children. */
+  emptyState?: React.ReactNode;
+};
+
+function FileExplorerList({
+  className,
+  emptyState = "Empty folder",
+  children,
+  ...props
+}: FileExplorerListProps) {
+  const { current, view } = useFileExplorer();
+  const entries = current.children ?? [];
+
+  if (children != null) {
+    return (
+      <div
+        data-slot="file-explorer-list"
+        data-view={view}
+        className={cn("min-h-0 flex-1 overflow-auto", className)}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+
+  if (entries.length === 0) {
+    return (
+      <div
+        data-slot="file-explorer-list"
+        data-view={view}
+        className={cn("min-h-0 flex-1 overflow-auto", className)}
+        {...props}
+      >
+        <div
+          data-slot="file-explorer-empty"
+          className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground"
+        >
+          {emptyState}
+        </div>
+      </div>
+    );
+  }
+
+  const sorted = [...entries].sort((a, b) => {
+    if (a.type !== b.type) return a.type === "folder" ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  if (view === "grid") {
+    return (
+      <div
+        data-slot="file-explorer-list"
+        data-view="grid"
+        role="grid"
+        className={cn(
+          "grid min-h-0 flex-1 auto-rows-min grid-cols-[repeat(auto-fill,minmax(7rem,1fr))] gap-2 overflow-auto p-3",
+          className,
+        )}
+        {...props}
+      >
+        {sorted.map((node) => (
+          <FileExplorerItem key={node.name} node={node} />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-slot="file-explorer-list"
+      data-view="list"
+      role="grid"
+      className={cn("min-h-0 flex-1 overflow-auto", className)}
+      {...props}
+    >
+      <div
+        role="row"
+        data-slot="file-explorer-list-header"
+        className="grid grid-cols-[minmax(0,1fr)_5rem_8rem] items-center gap-3 border-b border-border px-3 py-2 text-xs font-medium text-muted-foreground"
+      >
+        <span role="columnheader">Name</span>
+        <span role="columnheader" className="text-end">
+          Size
+        </span>
+        <span role="columnheader" className="text-end">
+          Modified
+        </span>
+      </div>
+      <div role="rowgroup">
+        {sorted.map((node) => (
+          <FileExplorerItem key={node.name} node={node} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+type FileExplorerItemProps = Omit<React.ComponentProps<"button">, "onClick"> & {
+  /** The file or folder this row represents. */
+  node: FileNode;
+};
+
+function FileExplorerItem({
+  node,
+  className,
+  ...props
+}: FileExplorerItemProps) {
+  const { view, open, selected, setSelected } = useFileExplorer();
+  const isFolder = node.type === "folder";
+  const isSelected = selected === node.name;
+
+  const icon = isFolder ? (
+    <Folder className="text-muted-foreground" />
+  ) : (
+    <File className="text-muted-foreground" />
+  );
+
+  const activate = () => {
+    if (isFolder) {
+      open(node);
+    } else {
+      setSelected(node.name);
+    }
+  };
+
+  if (view === "grid") {
+    return (
+      <button
+        type="button"
+        role="gridcell"
+        data-slot="file-explorer-item"
+        data-type={node.type}
+        data-state={isSelected ? "selected" : undefined}
+        aria-current={isSelected ? "true" : undefined}
+        onClick={activate}
+        onDoubleClick={() => isFolder && open(node)}
+        className={cn(
+          "group flex flex-col items-center gap-2 rounded-md p-3 text-center outline-none transition-colors",
+          "hover:bg-accent focus-visible:bg-accent focus-visible:ring-2 focus-visible:ring-ring",
+          isSelected && "bg-accent",
+          className,
+        )}
+        {...props}
+      >
+        <span className="flex size-9 items-center justify-center [&_svg]:size-7">
+          {icon}
+        </span>
+        <span className="w-full truncate text-xs text-foreground">
+          {node.name}
+        </span>
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      role="row"
+      data-slot="file-explorer-item"
+      data-type={node.type}
+      data-state={isSelected ? "selected" : undefined}
+      aria-current={isSelected ? "true" : undefined}
+      onClick={activate}
+      onDoubleClick={() => isFolder && open(node)}
+      className={cn(
+        "grid w-full grid-cols-[minmax(0,1fr)_5rem_8rem] items-center gap-3 px-3 py-2 text-start outline-none transition-colors",
+        "hover:bg-accent focus-visible:bg-accent focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+        isSelected && "bg-accent",
+        className,
+      )}
+      {...props}
+    >
+      <span role="gridcell" className="flex min-w-0 items-center gap-2">
+        <span className="flex shrink-0 items-center [&_svg]:size-4">{icon}</span>
+        <span className="min-w-0 truncate text-sm text-foreground">
+          {node.name}
+        </span>
+      </span>
+      <span
+        role="gridcell"
+        className="truncate text-end text-xs text-muted-foreground"
+      >
+        {isFolder ? folderSummary(node) : formatSize(node.size)}
+      </span>
+      <span
+        role="gridcell"
+        className="truncate text-end text-xs text-muted-foreground"
+      >
+        {node.modified ?? ""}
+      </span>
+    </button>
+  );
+}
+
+export {
+  FileExplorer,
+  FileExplorerSidebar,
+  FileExplorerTree,
+  FileExplorerBreadcrumb,
+  FileExplorerToolbar,
+  FileExplorerList,
+  FileExplorerItem,
+};

--- a/registry/hirael/ui/filter-builder.tsx
+++ b/registry/hirael/ui/filter-builder.tsx
@@ -1,0 +1,363 @@
+"use client";
+
+import * as React from "react";
+import { Filter, Plus, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/registry/hirael/ui/badge";
+import { Button } from "@/registry/hirael/ui/button";
+import { Input } from "@/registry/hirael/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/registry/hirael/ui/select";
+
+export type FilterField = {
+  name: string;
+  label: string;
+  operators?: string[];
+};
+
+export type FilterCondition = {
+  id: string;
+  field: string;
+  operator: string;
+  value: string;
+};
+
+const DEFAULT_OPERATORS = [
+  "is",
+  "is not",
+  "contains",
+  "starts with",
+  "greater than",
+  "less than",
+];
+
+function makeId(seed: number): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `filter-${seed}`;
+}
+
+function fieldLabel(fields: FilterField[], name: string): string {
+  return fields.find((f) => f.name === name)?.label ?? name;
+}
+
+function operatorsFor(fields: FilterField[], name: string): string[] {
+  const operators = fields.find((f) => f.name === name)?.operators;
+  return operators && operators.length > 0 ? operators : DEFAULT_OPERATORS;
+}
+
+type Ctx = {
+  fields: FilterField[];
+  value: FilterCondition[];
+  add: () => void;
+  update: (id: string, patch: Partial<Omit<FilterCondition, "id">>) => void;
+  remove: (id: string) => void;
+  clear: () => void;
+};
+
+const FilterBuilderContext = React.createContext<Ctx | null>(null);
+
+function useFilterBuilder(): Ctx {
+  const ctx = React.useContext(FilterBuilderContext);
+  if (!ctx) {
+    throw new Error(
+      "FilterBuilder compound parts must be used inside <FilterBuilder>",
+    );
+  }
+  return ctx;
+}
+
+export type FilterBuilderProps = Omit<
+  React.ComponentProps<"div">,
+  "onChange" | "defaultValue"
+> & {
+  /** Fields a condition can target. `operators` overrides the default operator list per field. */
+  fields: FilterField[];
+  /** Controlled list of conditions. */
+  value?: FilterCondition[];
+  /** Initial conditions for an uncontrolled builder. */
+  defaultValue?: FilterCondition[];
+  /** Called whenever the condition list changes. */
+  onValueChange?: (value: FilterCondition[]) => void;
+};
+
+function FilterBuilder({
+  fields,
+  value: valueProp,
+  defaultValue,
+  onValueChange,
+  className,
+  children,
+  ...props
+}: FilterBuilderProps) {
+  const [internalValue, setInternalValue] = React.useState<FilterCondition[]>(
+    defaultValue ?? [],
+  );
+  const value = valueProp ?? internalValue;
+
+  const seedRef = React.useRef(0);
+
+  const setValue = React.useCallback(
+    (next: FilterCondition[]) => {
+      if (valueProp === undefined) setInternalValue(next);
+      onValueChange?.(next);
+    },
+    [valueProp, onValueChange],
+  );
+
+  const add = React.useCallback(() => {
+    const field = fields[0]?.name ?? "";
+    const operator = operatorsFor(fields, field)[0] ?? "";
+    const condition: FilterCondition = {
+      id: makeId(seedRef.current++),
+      field,
+      operator,
+      value: "",
+    };
+    setValue([...value, condition]);
+  }, [fields, value, setValue]);
+
+  const update = React.useCallback(
+    (id: string, patch: Partial<Omit<FilterCondition, "id">>) => {
+      setValue(
+        value.map((condition) =>
+          condition.id === id ? { ...condition, ...patch } : condition,
+        ),
+      );
+    },
+    [value, setValue],
+  );
+
+  const remove = React.useCallback(
+    (id: string) => {
+      setValue(value.filter((condition) => condition.id !== id));
+    },
+    [value, setValue],
+  );
+
+  const clear = React.useCallback(() => {
+    setValue([]);
+  }, [setValue]);
+
+  const ctx = React.useMemo<Ctx>(
+    () => ({ fields, value, add, update, remove, clear }),
+    [fields, value, add, update, remove, clear],
+  );
+
+  return (
+    <FilterBuilderContext.Provider value={ctx}>
+      <div
+        data-slot="filter-builder"
+        className={cn("flex w-full flex-col gap-3", className)}
+        {...props}
+      >
+        {children}
+      </div>
+    </FilterBuilderContext.Provider>
+  );
+}
+
+type FilterRowProps = Omit<React.ComponentProps<"div">, "children"> & {
+  condition: FilterCondition;
+};
+
+function FilterRow({ condition, className, ...props }: FilterRowProps) {
+  const ctx = useFilterBuilder();
+  const operators = operatorsFor(ctx.fields, condition.field);
+
+  return (
+    <div
+      data-slot="filter-row"
+      className={cn("flex flex-wrap items-center gap-2", className)}
+      {...props}
+    >
+      <Select
+        value={condition.field}
+        onValueChange={(field) => {
+          const nextOperators = operatorsFor(ctx.fields, field);
+          const operator = nextOperators.includes(condition.operator)
+            ? condition.operator
+            : (nextOperators[0] ?? "");
+          ctx.update(condition.id, { field, operator });
+        }}
+      >
+        <SelectTrigger
+          data-slot="filter-row-field"
+          className="w-[8.5rem]"
+          aria-label="Field"
+        >
+          <SelectValue placeholder="Field" />
+        </SelectTrigger>
+        <SelectContent>
+          {ctx.fields.map((field) => (
+            <SelectItem key={field.name} value={field.name}>
+              {field.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select
+        value={condition.operator}
+        onValueChange={(operator) => ctx.update(condition.id, { operator })}
+      >
+        <SelectTrigger
+          data-slot="filter-row-operator"
+          className="w-[8.5rem]"
+          aria-label="Operator"
+        >
+          <SelectValue placeholder="Operator" />
+        </SelectTrigger>
+        <SelectContent>
+          {operators.map((operator) => (
+            <SelectItem key={operator} value={operator}>
+              {operator}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Input
+        data-slot="filter-row-value"
+        value={condition.value}
+        onChange={(event) =>
+          ctx.update(condition.id, { value: event.target.value })
+        }
+        placeholder="Value"
+        aria-label="Value"
+        className="w-auto min-w-[8rem] flex-1"
+      />
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        data-slot="filter-row-remove"
+        aria-label="Remove filter"
+        onClick={() => ctx.remove(condition.id)}
+        className="text-muted-foreground"
+      >
+        <X />
+      </Button>
+    </div>
+  );
+}
+
+type FilterAddProps = React.ComponentProps<typeof Button>;
+
+function FilterAdd({ className, children, onClick, ...props }: FilterAddProps) {
+  const ctx = useFilterBuilder();
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      data-slot="filter-add"
+      onClick={(event) => {
+        onClick?.(event);
+        if (event.defaultPrevented) return;
+        ctx.add();
+      }}
+      className={cn("w-fit", className)}
+      {...props}
+    >
+      <Plus />
+      {children ?? "Add filter"}
+    </Button>
+  );
+}
+
+type FilterChipProps = Omit<React.ComponentProps<typeof Badge>, "children"> & {
+  condition: FilterCondition;
+};
+
+function FilterChip({ condition, className, ...props }: FilterChipProps) {
+  const ctx = useFilterBuilder();
+  const label = fieldLabel(ctx.fields, condition.field);
+  return (
+    <Badge
+      variant="secondary"
+      data-slot="filter-chip"
+      className={cn("gap-1 pe-1 font-normal", className)}
+      {...props}
+    >
+      <span className="min-w-0 truncate">
+        <span className="font-medium text-foreground">{label}</span>{" "}
+        {condition.operator}
+        {condition.value ? ` ${condition.value}` : ""}
+      </span>
+      <button
+        type="button"
+        tabIndex={-1}
+        aria-label={`Remove ${label} filter`}
+        onClick={() => ctx.remove(condition.id)}
+        className="inline-flex size-3.5 items-center justify-center rounded-[2px] text-secondary-foreground/70 transition-colors hover:bg-secondary-foreground/20 hover:text-secondary-foreground"
+      >
+        <X className="size-2.5" />
+      </button>
+    </Badge>
+  );
+}
+
+type FilterChipsProps = Omit<React.ComponentProps<"div">, "children"> & {
+  /** Shown when no conditions exist. */
+  emptyHint?: React.ReactNode;
+};
+
+function FilterChips({
+  className,
+  emptyHint = "No filters yet.",
+  ...props
+}: FilterChipsProps) {
+  const ctx = useFilterBuilder();
+
+  if (ctx.value.length === 0) {
+    return (
+      <div
+        data-slot="filter-chips"
+        data-empty="true"
+        className={cn("flex items-center text-sm text-muted-foreground", className)}
+        {...props}
+      >
+        {emptyHint}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-slot="filter-chips"
+      className={cn("flex flex-wrap items-center gap-1.5", className)}
+      {...props}
+    >
+      {ctx.value.map((condition) => (
+        <FilterChip key={condition.id} condition={condition} />
+      ))}
+      <Button
+        type="button"
+        variant="ghost"
+        size="xs"
+        data-slot="filter-clear"
+        onClick={ctx.clear}
+        className="ms-1 text-muted-foreground"
+      >
+        Clear all
+      </Button>
+    </div>
+  );
+}
+
+export {
+  FilterBuilder,
+  FilterRow,
+  FilterAdd,
+  FilterChips,
+  FilterChip,
+};

--- a/registry/hirael/ui/inventory-matrix.tsx
+++ b/registry/hirael/ui/inventory-matrix.tsx
@@ -1,0 +1,389 @@
+"use client";
+
+import * as React from "react";
+import { AlertTriangle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Input } from "@/registry/hirael/ui/input";
+
+type Variant = { id: string; label: string };
+
+type Location = { id: string; label: string };
+
+type StockMap = Record<string, Record<string, number>>;
+
+type StockState = "ok" | "low" | "out";
+
+function stockState(qty: number, lowStockThreshold: number): StockState {
+  if (qty <= 0) return "out";
+  if (qty <= lowStockThreshold) return "low";
+  return "ok";
+}
+
+type InventoryMatrixContextValue = {
+  variants: Variant[];
+  locations: Location[];
+  value: StockMap;
+  lowStockThreshold: number;
+  quantity: (variantId: string, locationId: string) => number;
+  setQuantity: (variantId: string, locationId: string, qty: number) => void;
+  rowTotal: (variantId: string) => number;
+  columnTotal: (locationId: string) => number;
+  grandTotal: () => number;
+};
+
+const InventoryMatrixContext =
+  React.createContext<InventoryMatrixContextValue | null>(null);
+
+function useInventoryMatrix() {
+  const ctx = React.useContext(InventoryMatrixContext);
+  if (!ctx) {
+    throw new Error(
+      "InventoryMatrix compound parts must be used inside <InventoryMatrix>",
+    );
+  }
+  return ctx;
+}
+
+export type InventoryMatrixProps = Omit<
+  React.ComponentProps<"div">,
+  "defaultValue" | "onChange"
+> & {
+  /** Rows of the grid. Each variant (size, SKU, …) renders one stock row. */
+  variants: Variant[];
+  /** Columns of the grid. Each location or warehouse renders one stock column. */
+  locations: Location[];
+  /** Controlled stock map of variant id to location id to on-hand quantity. */
+  value?: StockMap;
+  /** Initial stock map for uncontrolled use. */
+  defaultValue?: StockMap;
+  /** Called with the next stock map whenever a cell changes. */
+  onValueChange?: (value: StockMap) => void;
+  /** Quantities at or below this count tint as low stock. Zero or less is out of stock. */
+  lowStockThreshold?: number;
+};
+
+function InventoryMatrix({
+  variants,
+  locations,
+  value: valueProp,
+  defaultValue,
+  onValueChange,
+  lowStockThreshold = 5,
+  className,
+  children,
+  ...props
+}: InventoryMatrixProps) {
+  const [internalValue, setInternalValue] = React.useState<StockMap>(
+    () => defaultValue ?? {},
+  );
+  const value = valueProp ?? internalValue;
+
+  const setValue = React.useCallback(
+    (next: StockMap) => {
+      if (valueProp === undefined) setInternalValue(next);
+      onValueChange?.(next);
+    },
+    [valueProp, onValueChange],
+  );
+
+  const quantity = React.useCallback(
+    (variantId: string, locationId: string) =>
+      value[variantId]?.[locationId] ?? 0,
+    [value],
+  );
+
+  const setQuantity = React.useCallback(
+    (variantId: string, locationId: string, qty: number) => {
+      setValue({
+        ...value,
+        [variantId]: { ...(value[variantId] ?? {}), [locationId]: qty },
+      });
+    },
+    [value, setValue],
+  );
+
+  const rowTotal = React.useCallback(
+    (variantId: string) =>
+      locations.reduce(
+        (sum, location) => sum + quantity(variantId, location.id),
+        0,
+      ),
+    [locations, quantity],
+  );
+
+  const columnTotal = React.useCallback(
+    (locationId: string) =>
+      variants.reduce(
+        (sum, variant) => sum + quantity(variant.id, locationId),
+        0,
+      ),
+    [variants, quantity],
+  );
+
+  const grandTotal = React.useCallback(
+    () =>
+      variants.reduce((sum, variant) => sum + rowTotal(variant.id), 0),
+    [variants, rowTotal],
+  );
+
+  const ctx = React.useMemo<InventoryMatrixContextValue>(
+    () => ({
+      variants,
+      locations,
+      value,
+      lowStockThreshold,
+      quantity,
+      setQuantity,
+      rowTotal,
+      columnTotal,
+      grandTotal,
+    }),
+    [
+      variants,
+      locations,
+      value,
+      lowStockThreshold,
+      quantity,
+      setQuantity,
+      rowTotal,
+      columnTotal,
+      grandTotal,
+    ],
+  );
+
+  return (
+    <InventoryMatrixContext.Provider value={ctx}>
+      <div
+        data-slot="inventory-matrix"
+        className={cn(
+          "relative w-full overflow-x-auto rounded-lg border border-border bg-card text-card-foreground",
+          className,
+        )}
+        {...props}
+      >
+        {children ?? (
+          <table
+            data-slot="inventory-matrix-table"
+            className="w-full border-collapse text-sm"
+          >
+            <InventoryMatrixHeader />
+            <tbody data-slot="inventory-matrix-body">
+              {variants.map((variant) => (
+                <InventoryRow key={variant.id} variant={variant} />
+              ))}
+            </tbody>
+            <InventoryTotals />
+          </table>
+        )}
+      </div>
+    </InventoryMatrixContext.Provider>
+  );
+}
+
+export type InventoryMatrixHeaderProps = React.ComponentProps<"thead">;
+
+function InventoryMatrixHeader({
+  className,
+  ...props
+}: InventoryMatrixHeaderProps) {
+  const { locations } = useInventoryMatrix();
+  return (
+    <thead
+      data-slot="inventory-matrix-header"
+      className={cn("border-b border-border bg-muted/40", className)}
+      {...props}
+    >
+      <tr data-slot="inventory-matrix-header-row">
+        <th
+          scope="col"
+          data-slot="inventory-matrix-corner"
+          className="sticky start-0 z-10 bg-muted/40 px-4 py-3 text-start align-bottom font-medium text-muted-foreground"
+        >
+          Variant
+        </th>
+        {locations.map((location) => (
+          <th
+            key={location.id}
+            scope="col"
+            data-slot="inventory-matrix-location"
+            className="px-3 py-3 text-center align-bottom font-medium text-foreground"
+          >
+            {location.label}
+          </th>
+        ))}
+        <th
+          scope="col"
+          data-slot="inventory-matrix-total-head"
+          className="px-4 py-3 text-end align-bottom font-medium text-muted-foreground"
+        >
+          Total
+        </th>
+      </tr>
+    </thead>
+  );
+}
+
+export type InventoryRowProps = Omit<React.ComponentProps<"tr">, "children"> & {
+  variant: Variant;
+};
+
+function InventoryRow({ variant, className, ...props }: InventoryRowProps) {
+  const { locations, quantity, setQuantity, rowTotal, lowStockThreshold } =
+    useInventoryMatrix();
+  const total = rowTotal(variant.id);
+  return (
+    <tr
+      data-slot="inventory-row"
+      className={cn(
+        "border-b border-border transition-colors hover:bg-accent/40",
+        className,
+      )}
+      {...props}
+    >
+      <th
+        scope="row"
+        data-slot="inventory-row-label"
+        className="sticky start-0 z-10 bg-card px-4 py-2 text-start font-normal text-foreground"
+      >
+        {variant.label}
+      </th>
+      {locations.map((location) => {
+        const qty = quantity(variant.id, location.id);
+        return (
+          <InventoryCell
+            key={location.id}
+            value={qty}
+            state={stockState(qty, lowStockThreshold)}
+            onValueChange={(next) =>
+              setQuantity(variant.id, location.id, next)
+            }
+            aria-label={`Stock for ${variant.label} at ${location.label}`}
+          />
+        );
+      })}
+      <td
+        data-slot="inventory-row-total"
+        className="px-4 py-2 text-end font-medium tabular-nums text-foreground"
+      >
+        {total}
+      </td>
+    </tr>
+  );
+}
+
+export type InventoryCellProps = Omit<
+  React.ComponentProps<"td">,
+  "onChange"
+> & {
+  /** On-hand quantity shown in the cell input. */
+  value: number;
+  /** Stock state derived from the low-stock threshold, driving the cell tint. */
+  state: StockState;
+  /** Called with the parsed quantity when the cell input changes. */
+  onValueChange?: (value: number) => void;
+  /** Accessible name for the cell input, e.g. "Stock for M at Berlin". */
+  "aria-label"?: string;
+  disabled?: boolean;
+};
+
+function InventoryCell({
+  value,
+  state,
+  onValueChange,
+  disabled,
+  className,
+  "aria-label": ariaLabel,
+  ...props
+}: InventoryCellProps) {
+  return (
+    <td
+      data-slot="inventory-cell"
+      data-state={state}
+      className={cn(
+        "px-2 py-1.5 text-center",
+        state === "low" && "bg-warning/10",
+        state === "out" && "bg-destructive/10",
+        className,
+      )}
+      {...props}
+    >
+      <div className="relative">
+        <Input
+          data-slot="inventory-cell-input"
+          type="number"
+          inputMode="numeric"
+          min={0}
+          step={1}
+          value={value}
+          disabled={disabled}
+          aria-label={ariaLabel}
+          onChange={(event) => {
+            const parsed = event.currentTarget.valueAsNumber;
+            onValueChange?.(Number.isNaN(parsed) ? 0 : parsed);
+          }}
+          className={cn(
+            "mx-auto w-20 text-center tabular-nums [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",
+            state === "low" &&
+              "border-warning/40 text-warning focus-visible:border-warning focus-visible:ring-warning/40",
+            state === "out" &&
+              "border-destructive/40 text-destructive focus-visible:border-destructive focus-visible:ring-destructive/40",
+          )}
+        />
+        {state === "low" ? (
+          <AlertTriangle
+            data-slot="inventory-cell-low-icon"
+            className="pointer-events-none absolute end-2 top-1/2 size-3.5 -translate-y-1/2 text-warning"
+            aria-hidden
+          />
+        ) : null}
+      </div>
+    </td>
+  );
+}
+
+export type InventoryTotalsProps = React.ComponentProps<"tfoot">;
+
+function InventoryTotals({ className, ...props }: InventoryTotalsProps) {
+  const { locations, columnTotal, grandTotal } = useInventoryMatrix();
+  return (
+    <tfoot
+      data-slot="inventory-totals"
+      className={cn("border-t border-border bg-muted/40", className)}
+      {...props}
+    >
+      <tr data-slot="inventory-totals-row">
+        <th
+          scope="row"
+          data-slot="inventory-totals-label"
+          className="sticky start-0 z-10 bg-muted/40 px-4 py-2.5 text-start font-medium text-muted-foreground"
+        >
+          Total
+        </th>
+        {locations.map((location) => (
+          <td
+            key={location.id}
+            data-slot="inventory-column-total"
+            className="px-3 py-2.5 text-center font-medium tabular-nums text-foreground"
+          >
+            {columnTotal(location.id)}
+          </td>
+        ))}
+        <td
+          data-slot="inventory-grand-total"
+          className="px-4 py-2.5 text-end font-semibold tabular-nums text-foreground"
+        >
+          {grandTotal()}
+        </td>
+      </tr>
+    </tfoot>
+  );
+}
+
+export {
+  InventoryMatrix,
+  InventoryMatrixHeader,
+  InventoryRow,
+  InventoryCell,
+  InventoryTotals,
+};

--- a/registry/hirael/ui/json-viewer.tsx
+++ b/registry/hirael/ui/json-viewer.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import * as React from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type JsonValueKind =
+  | "object"
+  | "array"
+  | "string"
+  | "number"
+  | "boolean"
+  | "null";
+
+const VALUE_CLASSES: Record<Exclude<JsonValueKind, "object" | "array">, string> =
+  {
+    string: "text-chart-2",
+    number: "text-chart-3",
+    boolean: "text-primary",
+    null: "text-muted-foreground",
+  };
+
+function kindOf(value: unknown): JsonValueKind {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  if (typeof value === "object") return "object";
+  if (typeof value === "string") return "string";
+  if (typeof value === "boolean") return "boolean";
+  return "number";
+}
+
+function isExpandable(value: unknown): value is object {
+  const kind = kindOf(value);
+  return kind === "object" || kind === "array";
+}
+
+function entriesOf(value: object): [string, unknown][] {
+  if (Array.isArray(value)) {
+    return value.map((item, index) => [String(index), item]);
+  }
+  return Object.entries(value);
+}
+
+function formatPrimitive(value: unknown): string {
+  const kind = kindOf(value);
+  if (kind === "string") return JSON.stringify(value);
+  if (kind === "null") return "null";
+  return String(value);
+}
+
+function previewLabel(value: object): string {
+  const count = entriesOf(value).length;
+  if (Array.isArray(value)) {
+    return count === 1 ? "[ 1 item ]" : `[ ${count} items ]`;
+  }
+  return count === 1 ? "{ 1 key }" : `{ ${count} keys }`;
+}
+
+const INDENT_PER_LEVEL = 14;
+
+export type JsonViewerRootProps = React.ComponentProps<"div">;
+
+function JsonViewerRoot({ className, ...props }: JsonViewerRootProps) {
+  return (
+    <div
+      data-slot="json-viewer-root"
+      className={cn(
+        "w-full overflow-x-auto rounded-md border border-border bg-card p-2 font-mono text-[13px] leading-6 text-card-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export type JsonNodeProps = Omit<React.ComponentProps<"div">, "children"> & {
+  /** The JSON value rendered by this node. */
+  value: unknown;
+  /** The object key or array index labeling this node, if any. */
+  nodeKey?: string;
+  /** Render this node's key as a quoted array index rather than a plain key. */
+  isIndex?: boolean;
+  /** Nesting level, used for indentation. */
+  depth?: number;
+  /** Depth up to which expandable nodes start open. */
+  defaultExpandedDepth?: number;
+};
+
+function JsonNode({
+  value,
+  nodeKey,
+  isIndex = false,
+  depth = 0,
+  defaultExpandedDepth = 1,
+  className,
+  ...props
+}: JsonNodeProps) {
+  const expandable = isExpandable(value);
+  const [open, setOpen] = React.useState(
+    () => expandable && depth < defaultExpandedDepth,
+  );
+
+  const indentStyle: React.CSSProperties = {
+    paddingInlineStart: depth * INDENT_PER_LEVEL,
+  };
+
+  const keyLabel =
+    nodeKey === undefined ? null : (
+      <>
+        <span
+          data-slot="json-viewer-key"
+          className={cn(isIndex ? "text-muted-foreground" : "text-foreground")}
+        >
+          {isIndex ? nodeKey : JSON.stringify(nodeKey)}
+        </span>
+        <span data-slot="json-viewer-punctuation" className="text-muted-foreground">
+          :{" "}
+        </span>
+      </>
+    );
+
+  if (!expandable) {
+    const kind = kindOf(value) as Exclude<JsonValueKind, "object" | "array">;
+    return (
+      <div
+        data-slot="json-node"
+        data-kind={kind}
+        style={indentStyle}
+        className={cn("flex items-start py-0.5 ps-[18px]", className)}
+        {...props}
+      >
+        <span className="min-w-0 break-words">
+          {keyLabel}
+          <span data-slot="json-viewer-value" className={VALUE_CLASSES[kind]}>
+            {formatPrimitive(value)}
+          </span>
+        </span>
+      </div>
+    );
+  }
+
+  const entries = entriesOf(value);
+  const empty = entries.length === 0;
+  const isArray = Array.isArray(value);
+  const open$ = open && !empty;
+
+  return (
+    <div
+      data-slot="json-node"
+      data-kind={isArray ? "array" : "object"}
+      data-state={open$ ? "open" : "closed"}
+      className={cn("min-w-fit", className)}
+      {...props}
+    >
+      <button
+        type="button"
+        data-slot="json-node-trigger"
+        aria-expanded={open$}
+        disabled={empty}
+        onClick={() => setOpen((value) => !value)}
+        style={indentStyle}
+        className={cn(
+          "flex w-full items-start gap-1 rounded-sm py-0.5 pe-2 text-start outline-none transition-colors",
+          "hover:bg-accent focus-visible:bg-accent focus-visible:ring-2 focus-visible:ring-ring",
+          "disabled:pointer-events-none",
+        )}
+      >
+        <span className="flex size-[18px] shrink-0 items-center justify-center text-muted-foreground">
+          {empty ? null : open$ ? (
+            <ChevronDown aria-hidden className="size-3.5" />
+          ) : (
+            <ChevronRight aria-hidden className="size-3.5 rtl:rotate-180" />
+          )}
+        </span>
+        <span className="min-w-0 break-words">
+          {keyLabel}
+          {empty ? (
+            <span data-slot="json-viewer-value" className="text-muted-foreground">
+              {isArray ? "[]" : "{}"}
+            </span>
+          ) : open$ ? (
+            <span
+              data-slot="json-viewer-punctuation"
+              className="text-muted-foreground"
+            >
+              {isArray ? "[" : "{"}
+            </span>
+          ) : (
+            <span
+              data-slot="json-viewer-preview"
+              className="text-muted-foreground"
+            >
+              {previewLabel(value)}
+            </span>
+          )}
+        </span>
+      </button>
+
+      {open$ && (
+        <div
+          data-slot="json-node-children"
+          role="group"
+          className="ms-[26px] border-s border-border"
+        >
+          {entries.map(([childKey, childValue]) => (
+            <JsonNode
+              key={childKey}
+              value={childValue}
+              nodeKey={childKey}
+              isIndex={isArray}
+              depth={depth + 1}
+              defaultExpandedDepth={defaultExpandedDepth}
+            />
+          ))}
+          <div
+            data-slot="json-viewer-punctuation"
+            style={indentStyle}
+            className="py-0.5 ps-[18px] text-muted-foreground"
+          >
+            {isArray ? "]" : "}"}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export type JsonViewerProps = Omit<JsonViewerRootProps, "children"> & {
+  /** The value to render as a collapsible JSON tree. */
+  data: unknown;
+  /** Depth up to which nodes start expanded. Defaults to 1. */
+  defaultExpandedDepth?: number;
+  /** Optional label shown as the key of the root node. */
+  rootName?: string;
+};
+
+function JsonViewer({
+  data,
+  defaultExpandedDepth = 1,
+  rootName,
+  ...props
+}: JsonViewerProps) {
+  return (
+    <JsonViewerRoot {...props}>
+      <JsonNode
+        value={data}
+        nodeKey={rootName}
+        defaultExpandedDepth={defaultExpandedDepth}
+      />
+    </JsonViewerRoot>
+  );
+}
+
+export { JsonViewer, JsonViewerRoot, JsonNode };

--- a/registry/hirael/ui/kanban-board.tsx
+++ b/registry/hirael/ui/kanban-board.tsx
@@ -1,0 +1,550 @@
+"use client";
+
+import * as React from "react";
+import { GripVertical, Plus } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/registry/hirael/ui/badge";
+import { Button } from "@/registry/hirael/ui/button";
+
+export type KanbanCardData = {
+  id: string;
+  title: string;
+  [key: string]: unknown;
+};
+
+export type KanbanColumnData = {
+  id: string;
+  title: string;
+  cards: KanbanCardData[];
+};
+
+type DropTarget = {
+  columnId: string;
+  index: number;
+};
+
+type KanbanCtx = {
+  columns: KanbanColumnData[];
+  dragCardId: string | null;
+  dropTarget: DropTarget | null;
+  registerColumn: (id: string) => () => void;
+  columnOrder: () => string[];
+  startDrag: (cardId: string) => void;
+  endDrag: () => void;
+  setDropTarget: (target: DropTarget | null) => void;
+  drop: (columnId: string, index: number) => void;
+  moveCard: (cardId: string, dir: -1 | 1) => void;
+};
+
+const KanbanContext = React.createContext<KanbanCtx | null>(null);
+
+function useKanban() {
+  const ctx = React.useContext(KanbanContext);
+  if (!ctx) {
+    throw new Error("Kanban parts must be used inside <KanbanBoard>");
+  }
+  return ctx;
+}
+
+type ColumnCtx = {
+  columnId: string;
+};
+
+const KanbanColumnContext = React.createContext<ColumnCtx | null>(null);
+
+function useKanbanColumn() {
+  const ctx = React.useContext(KanbanColumnContext);
+  if (!ctx) {
+    throw new Error("Column parts must be used inside <KanbanColumn>");
+  }
+  return ctx;
+}
+
+const CARD_MIME = "application/x-kanban-card";
+
+function locate(columns: KanbanColumnData[], cardId: string) {
+  for (let c = 0; c < columns.length; c += 1) {
+    const index = columns[c].cards.findIndex((card) => card.id === cardId);
+    if (index !== -1) return { columnIndex: c, cardIndex: index };
+  }
+  return null;
+}
+
+function moveCardTo(
+  columns: KanbanColumnData[],
+  cardId: string,
+  toColumnId: string,
+  toIndex: number,
+): KanbanColumnData[] {
+  const from = locate(columns, cardId);
+  if (!from) return columns;
+
+  const card = columns[from.columnIndex].cards[from.cardIndex];
+  const toColumnIndex = columns.findIndex((col) => col.id === toColumnId);
+  if (toColumnIndex === -1) return columns;
+
+  let target = toIndex;
+  if (from.columnIndex === toColumnIndex && from.cardIndex < target) {
+    target -= 1;
+  }
+
+  const next = columns.map((col) => ({ ...col, cards: col.cards.slice() }));
+  next[from.columnIndex].cards.splice(from.cardIndex, 1);
+
+  const clamped = Math.max(0, Math.min(target, next[toColumnIndex].cards.length));
+  if (
+    from.columnIndex === toColumnIndex &&
+    clamped === from.cardIndex &&
+    target === from.cardIndex
+  ) {
+    return columns;
+  }
+  next[toColumnIndex].cards.splice(clamped, 0, card);
+  return next;
+}
+
+export type KanbanBoardProps = Omit<
+  React.ComponentProps<"div">,
+  "defaultValue" | "onChange"
+> & {
+  /** Controlled list of columns with their cards. */
+  value?: KanbanColumnData[];
+  /** Initial columns when uncontrolled. */
+  defaultValue?: KanbanColumnData[];
+  /** Called with the next columns after any move. */
+  onValueChange?: (value: KanbanColumnData[]) => void;
+};
+
+function KanbanBoard({
+  value: valueProp,
+  defaultValue = [],
+  onValueChange,
+  className,
+  children,
+  ...props
+}: KanbanBoardProps) {
+  const [internal, setInternal] = React.useState(defaultValue);
+  const [dragCardId, setDragCardId] = React.useState<string | null>(null);
+  const [dropTarget, setDropTargetState] = React.useState<DropTarget | null>(
+    null,
+  );
+  const [liveText, setLiveText] = React.useState("");
+
+  const columns = valueProp ?? internal;
+  const columnsRef = React.useRef(columns);
+  columnsRef.current = columns;
+
+  const orderRef = React.useRef<string[]>([]);
+
+  const registerColumn = React.useCallback((id: string) => {
+    orderRef.current = [...orderRef.current, id];
+    return () => {
+      orderRef.current = orderRef.current.filter((v) => v !== id);
+    };
+  }, []);
+
+  const columnOrder = React.useCallback(() => orderRef.current, []);
+
+  const commit = React.useCallback(
+    (next: KanbanColumnData[]) => {
+      if (valueProp === undefined) setInternal(next);
+      onValueChange?.(next);
+    },
+    [valueProp, onValueChange],
+  );
+
+  const startDrag = React.useCallback((cardId: string) => {
+    setDragCardId(cardId);
+  }, []);
+
+  const endDrag = React.useCallback(() => {
+    setDragCardId(null);
+    setDropTargetState(null);
+  }, []);
+
+  const setDropTarget = React.useCallback((target: DropTarget | null) => {
+    setDropTargetState(target);
+  }, []);
+
+  const announce = React.useCallback(
+    (cardId: string, columnId: string, next: KanbanColumnData[]) => {
+      const where = locate(next, cardId);
+      const column = next.find((col) => col.id === columnId);
+      if (!where || !column) return;
+      const card = column.cards[where.cardIndex];
+      setLiveText(
+        `Moved ${card?.title ?? cardId} to ${column.title}, position ${
+          where.cardIndex + 1
+        } of ${column.cards.length}.`,
+      );
+    },
+    [],
+  );
+
+  const drop = React.useCallback(
+    (columnId: string, index: number) => {
+      const cardId = dragCardId;
+      endDrag();
+      if (!cardId) return;
+      const next = moveCardTo(columnsRef.current, cardId, columnId, index);
+      if (next === columnsRef.current) return;
+      commit(next);
+      announce(cardId, columnId, next);
+    },
+    [dragCardId, endDrag, commit, announce],
+  );
+
+  const moveCard = React.useCallback(
+    (cardId: string, dir: -1 | 1) => {
+      const current = columnsRef.current;
+      const from = locate(current, cardId);
+      if (!from) return;
+      const order = orderRef.current;
+      const fromOrderIndex = order.indexOf(current[from.columnIndex].id);
+      const toOrderIndex = fromOrderIndex + dir;
+      if (toOrderIndex < 0 || toOrderIndex >= order.length) return;
+      const toColumnId = order[toOrderIndex];
+      const toColumn = current.find((col) => col.id === toColumnId);
+      if (!toColumn) return;
+      const next = moveCardTo(current, cardId, toColumnId, toColumn.cards.length);
+      if (next === current) return;
+      commit(next);
+      announce(cardId, toColumnId, next);
+    },
+    [commit, announce],
+  );
+
+  const ctx = React.useMemo<KanbanCtx>(
+    () => ({
+      columns,
+      dragCardId,
+      dropTarget,
+      registerColumn,
+      columnOrder,
+      startDrag,
+      endDrag,
+      setDropTarget,
+      drop,
+      moveCard,
+    }),
+    [
+      columns,
+      dragCardId,
+      dropTarget,
+      registerColumn,
+      columnOrder,
+      startDrag,
+      endDrag,
+      setDropTarget,
+      drop,
+      moveCard,
+    ],
+  );
+
+  return (
+    <KanbanContext.Provider value={ctx}>
+      <div
+        role="list"
+        data-slot="kanban-board"
+        data-dragging={dragCardId ? "" : undefined}
+        className={cn("flex w-full gap-4 overflow-x-auto pb-2", className)}
+        {...props}
+      >
+        {children}
+        <span data-slot="kanban-live" aria-live="polite" className="sr-only">
+          {liveText}
+        </span>
+      </div>
+    </KanbanContext.Provider>
+  );
+}
+
+export type KanbanColumnProps = React.ComponentProps<"div"> & {
+  /** Unique id matching a column in the root value. */
+  value: string;
+};
+
+function KanbanColumn({
+  value,
+  className,
+  children,
+  ...props
+}: KanbanColumnProps) {
+  const { columns, dragCardId, dropTarget, registerColumn, setDropTarget, drop } =
+    useKanban();
+
+  React.useLayoutEffect(() => registerColumn(value), [value, registerColumn]);
+
+  const column = columns.find((col) => col.id === value);
+  const isActive = dragCardId !== null && dropTarget?.columnId === value;
+
+  const handleDragOver = (e: React.DragEvent) => {
+    if (!dragCardId) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    if (dropTarget?.columnId !== value) {
+      setDropTarget({ columnId: value, index: column?.cards.length ?? 0 });
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    if (!dragCardId) return;
+    e.preventDefault();
+    const fallback = column?.cards.length ?? 0;
+    drop(value, dropTarget?.columnId === value ? dropTarget.index : fallback);
+  };
+
+  return (
+    <KanbanColumnContext.Provider value={{ columnId: value }}>
+      <div
+        role="listitem"
+        data-slot="kanban-column"
+        data-active={isActive ? "" : undefined}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+        className={cn(
+          "flex w-72 shrink-0 flex-col gap-3 rounded-lg border border-border bg-card/40 p-3 transition-colors",
+          isActive && "border-ring bg-accent/40",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </KanbanColumnContext.Provider>
+  );
+}
+
+function KanbanColumnHeader({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div">) {
+  const { columns } = useKanban();
+  const { columnId } = useKanbanColumn();
+  const column = columns.find((col) => col.id === columnId);
+
+  return (
+    <div
+      data-slot="kanban-column-header"
+      className={cn("flex items-center gap-2 px-1", className)}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <h3
+            data-slot="kanban-column-title"
+            className="text-sm font-medium text-foreground"
+          >
+            {column?.title}
+          </h3>
+          <Badge
+            data-slot="kanban-column-count"
+            variant="secondary"
+            className="ms-auto tabular-nums"
+          >
+            {column?.cards.length ?? 0}
+          </Badge>
+        </>
+      )}
+    </div>
+  );
+}
+
+function KanbanCards({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div">) {
+  const { columns, dragCardId, dropTarget } = useKanban();
+  const { columnId } = useKanbanColumn();
+  const column = columns.find((col) => col.id === columnId);
+  const showEndIndicator =
+    dragCardId !== null &&
+    dropTarget?.columnId === columnId &&
+    dropTarget.index >= (column?.cards.length ?? 0);
+
+  return (
+    <div
+      data-slot="kanban-cards"
+      className={cn("flex min-h-16 flex-1 flex-col gap-2", className)}
+      {...props}
+    >
+      {children}
+      {showEndIndicator ? (
+        <div
+          data-slot="kanban-drop-indicator"
+          aria-hidden
+          className="h-0.5 rounded-full bg-ring"
+        />
+      ) : null}
+    </div>
+  );
+}
+
+export type KanbanCardProps = React.ComponentProps<"div"> & {
+  /** Unique id matching a card in this column. */
+  value: string;
+  /** Position of this card within its column, used for the drop indicator. */
+  index: number;
+};
+
+function KanbanCard({
+  value,
+  index,
+  className,
+  children,
+  ...props
+}: KanbanCardProps) {
+  const {
+    columns,
+    dragCardId,
+    dropTarget,
+    startDrag,
+    endDrag,
+    setDropTarget,
+    drop,
+    moveCard,
+    columnOrder,
+  } = useKanban();
+  const { columnId } = useKanbanColumn();
+
+  const card = columns
+    .find((col) => col.id === columnId)
+    ?.cards.find((c) => c.id === value);
+  const isDragging = dragCardId === value;
+  const showIndicator =
+    dragCardId !== null &&
+    dragCardId !== value &&
+    dropTarget?.columnId === columnId &&
+    dropTarget.index === index;
+
+  const order = columnOrder();
+  const columnIndex = order.indexOf(columnId);
+  const canMovePrev = columnIndex > 0;
+  const canMoveNext = columnIndex !== -1 && columnIndex < order.length - 1;
+
+  const handleDragStart = (e: React.DragEvent) => {
+    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.setData(CARD_MIME, value);
+    startDrag(value);
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    if (!dragCardId) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const rect = e.currentTarget.getBoundingClientRect();
+    const after = e.clientY > rect.top + rect.height / 2;
+    const next = after ? index + 1 : index;
+    if (dropTarget?.columnId !== columnId || dropTarget.index !== next) {
+      setDropTarget({ columnId, index: next });
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    if (!dragCardId) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const target = dropTarget?.columnId === columnId ? dropTarget.index : index;
+    drop(columnId, target);
+  };
+
+  return (
+    <>
+      {showIndicator ? (
+        <div
+          data-slot="kanban-drop-indicator"
+          aria-hidden
+          className="h-0.5 rounded-full bg-ring"
+        />
+      ) : null}
+      <div
+        role="group"
+        aria-roledescription="draggable card"
+        aria-label={card?.title}
+        data-slot="kanban-card"
+        data-dragging={isDragging ? "" : undefined}
+        draggable
+        onDragStart={handleDragStart}
+        onDragEnd={endDrag}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+        className={cn(
+          "group/kanban-card flex cursor-grab items-start gap-2 rounded-md border border-border bg-background p-3 text-sm shadow-xs transition-[box-shadow,opacity] outline-none",
+          "focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background",
+          isDragging && "cursor-grabbing opacity-50",
+          className,
+        )}
+        {...props}
+      >
+        <GripVertical
+          aria-hidden
+          className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+        />
+        <div className="min-w-0 flex-1">
+          {children ?? (
+            <span data-slot="kanban-card-title" className="block">
+              {card?.title}
+            </span>
+          )}
+        </div>
+        <div
+          data-slot="kanban-card-actions"
+          className="-me-1 flex shrink-0 items-center gap-0.5"
+        >
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            disabled={!canMovePrev}
+            aria-label={`Move ${card?.title ?? "card"} to previous column`}
+            onClick={() => moveCard(value, -1)}
+          >
+            Prev
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            disabled={!canMoveNext}
+            aria-label={`Move ${card?.title ?? "card"} to next column`}
+            onClick={() => moveCard(value, 1)}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function KanbanAddCard({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"button">) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      data-slot="kanban-add-card"
+      className={cn("justify-start text-muted-foreground", className)}
+      {...props}
+    >
+      <Plus aria-hidden />
+      {children ?? "Add card"}
+    </Button>
+  );
+}
+
+export {
+  KanbanBoard,
+  KanbanColumn,
+  KanbanColumnHeader,
+  KanbanCards,
+  KanbanCard,
+  KanbanAddCard,
+};

--- a/registry/hirael/ui/keyboard-shortcuts.tsx
+++ b/registry/hirael/ui/keyboard-shortcuts.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import * as React from "react";
+import { SearchIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { KbdDisplay, KbdGroup } from "@/registry/hirael/ui/kbd";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/registry/hirael/ui/dialog";
+
+type KeyboardShortcutsContextValue = {
+  query: string;
+  setQuery: (query: string) => void;
+  matches: (haystack: string) => boolean;
+};
+
+const KeyboardShortcutsContext =
+  React.createContext<KeyboardShortcutsContextValue | null>(null);
+
+function useKeyboardShortcuts() {
+  const context = React.useContext(KeyboardShortcutsContext);
+  if (!context) {
+    throw new Error(
+      "KeyboardShortcuts parts must be used within <KeyboardShortcuts>.",
+    );
+  }
+  return context;
+}
+
+function useControllableOpen(
+  open: boolean | undefined,
+  onOpenChange: ((open: boolean) => void) | undefined,
+) {
+  const [uncontrolled, setUncontrolled] = React.useState(false);
+  const isControlled = open !== undefined;
+  const value = isControlled ? open : uncontrolled;
+
+  const setValue = React.useCallback(
+    (next: boolean) => {
+      if (!isControlled) setUncontrolled(next);
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  return [value, setValue] as const;
+}
+
+type KeyboardShortcutsProps = Omit<
+  React.ComponentProps<typeof Dialog>,
+  "open" | "onOpenChange"
+> & {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /**
+   * Key that opens the cheat sheet from anywhere. Pass null to disable
+   * the global hotkey.
+   * @default "?"
+   */
+  hotkey?: string | null;
+};
+
+function KeyboardShortcuts({
+  open,
+  onOpenChange,
+  hotkey = "?",
+  children,
+  ...props
+}: KeyboardShortcutsProps) {
+  const [isOpen, setIsOpen] = useControllableOpen(open, onOpenChange);
+  const [query, setQuery] = React.useState("");
+
+  React.useEffect(() => {
+    if (hotkey == null) return;
+    if (typeof document === "undefined") return;
+
+    const key = hotkey.toLowerCase();
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+
+      const target = event.target as HTMLElement | null;
+      if (
+        target?.isContentEditable ||
+        target?.tagName === "INPUT" ||
+        target?.tagName === "TEXTAREA" ||
+        target?.tagName === "SELECT"
+      ) {
+        return;
+      }
+
+      if (event.key.toLowerCase() === key) {
+        event.preventDefault();
+        setIsOpen(true);
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [hotkey, setIsOpen]);
+
+  const handleOpenChange = React.useCallback(
+    (next: boolean) => {
+      if (!next) setQuery("");
+      setIsOpen(next);
+    },
+    [setIsOpen],
+  );
+
+  const matches = React.useCallback(
+    (haystack: string) => {
+      const term = query.trim().toLowerCase();
+      if (!term) return true;
+      return haystack.toLowerCase().includes(term);
+    },
+    [query],
+  );
+
+  const value = React.useMemo<KeyboardShortcutsContextValue>(
+    () => ({ query, setQuery, matches }),
+    [query, matches],
+  );
+
+  return (
+    <KeyboardShortcutsContext.Provider value={value}>
+      <Dialog
+        data-slot="keyboard-shortcuts"
+        open={isOpen}
+        onOpenChange={handleOpenChange}
+        {...props}
+      >
+        {children}
+      </Dialog>
+    </KeyboardShortcutsContext.Provider>
+  );
+}
+
+function KeyboardShortcutsTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogTrigger>) {
+  return <DialogTrigger data-slot="keyboard-shortcuts-trigger" {...props} />;
+}
+
+type KeyboardShortcutsContentProps = React.ComponentProps<
+  typeof DialogContent
+> & {
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+};
+
+function KeyboardShortcutsContent({
+  className,
+  title = "Keyboard shortcuts",
+  description,
+  children,
+  ...props
+}: KeyboardShortcutsContentProps) {
+  return (
+    <DialogContent
+      data-slot="keyboard-shortcuts-content"
+      className={cn("gap-0 p-0 sm:max-w-lg", className)}
+      {...props}
+    >
+      <DialogHeader
+        data-slot="keyboard-shortcuts-header"
+        className="border-b p-6 pb-4"
+      >
+        <DialogTitle data-slot="keyboard-shortcuts-title">{title}</DialogTitle>
+        {description != null && (
+          <DialogDescription data-slot="keyboard-shortcuts-description">
+            {description}
+          </DialogDescription>
+        )}
+      </DialogHeader>
+      {children}
+    </DialogContent>
+  );
+}
+
+function KeyboardShortcutsSearch({
+  className,
+  placeholder = "Search shortcuts",
+  ...props
+}: Omit<React.ComponentProps<"input">, "value" | "onChange">) {
+  const { query, setQuery } = useKeyboardShortcuts();
+
+  return (
+    <div
+      data-slot="keyboard-shortcuts-search"
+      className="flex items-center gap-2 border-b px-6 py-3"
+    >
+      <SearchIcon className="size-4 shrink-0 text-muted-foreground" />
+      <input
+        data-slot="keyboard-shortcuts-search-input"
+        type="text"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        placeholder={placeholder}
+        className={cn(
+          "w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function KeyboardShortcutsGroup({
+  className,
+  children,
+  heading,
+  ...props
+}: React.ComponentProps<"div"> & {
+  /** Group heading shown above its shortcut rows. */
+  heading?: React.ReactNode;
+}) {
+  const visibleChildren = React.Children.toArray(children).filter(Boolean);
+  if (visibleChildren.length === 0) return null;
+
+  return (
+    <div
+      data-slot="keyboard-shortcuts-group"
+      className={cn("flex flex-col gap-1", className)}
+      {...props}
+    >
+      {heading != null && (
+        <div
+          data-slot="keyboard-shortcuts-group-heading"
+          className="px-2 pb-1 text-xs font-medium text-muted-foreground"
+        >
+          {heading}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}
+
+type KeyboardShortcutProps = React.ComponentProps<"div"> & {
+  /**
+   * Keys in the combo, each rendered as a KbdDisplay inside a KbdGroup.
+   * @example ["⌘", "K"]
+   */
+  keys: string[];
+};
+
+function KeyboardShortcut({
+  className,
+  keys,
+  children,
+  ...props
+}: KeyboardShortcutProps) {
+  const { matches } = useKeyboardShortcuts();
+
+  const description =
+    typeof children === "string" || typeof children === "number"
+      ? String(children)
+      : "";
+
+  if (!matches(`${description} ${keys.join(" ")}`)) return null;
+
+  return (
+    <div
+      data-slot="keyboard-shortcut"
+      className={cn(
+        "flex items-center justify-between gap-4 rounded-md px-2 py-1.5 text-sm text-foreground",
+        className,
+      )}
+      {...props}
+    >
+      <span data-slot="keyboard-shortcut-description" className="text-start">
+        {children}
+      </span>
+      <KbdGroup data-slot="keyboard-shortcut-keys" className="ms-auto shrink-0">
+        {keys.map((key, index) => (
+          <KbdDisplay key={`${key}-${index}`}>{key}</KbdDisplay>
+        ))}
+      </KbdGroup>
+    </div>
+  );
+}
+
+export {
+  KeyboardShortcuts,
+  KeyboardShortcutsTrigger,
+  KeyboardShortcutsContent,
+  KeyboardShortcutsSearch,
+  KeyboardShortcutsGroup,
+  KeyboardShortcut,
+};

--- a/registry/hirael/ui/log-viewer.tsx
+++ b/registry/hirael/ui/log-viewer.tsx
@@ -1,0 +1,455 @@
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Search, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/registry/hirael/ui/button";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@/registry/hirael/ui/input-group";
+
+type LogLevel = "debug" | "info" | "warn" | "error";
+
+const LEVELS: readonly LogLevel[] = ["debug", "info", "warn", "error"];
+
+type LogViewerContextValue = {
+  query: string;
+  setQuery: (query: string) => void;
+  active: Record<LogLevel, boolean>;
+  toggleLevel: (level: LogLevel) => void;
+  count: number;
+  register: (id: string, level: LogLevel, text: string) => void;
+  unregister: (id: string) => void;
+};
+
+const LogViewerContext = React.createContext<LogViewerContextValue | null>(null);
+
+function useLogViewer() {
+  const context = React.useContext(LogViewerContext);
+  if (!context) {
+    throw new Error("LogViewer parts must be used within <LogViewer>.");
+  }
+  return context;
+}
+
+function lineMatches(
+  level: LogLevel,
+  text: string,
+  query: string,
+  active: Record<LogLevel, boolean>,
+) {
+  if (!active[level]) {
+    return false;
+  }
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) {
+    return true;
+  }
+  return text.toLowerCase().includes(trimmed);
+}
+
+type LogViewerProps = React.ComponentProps<"div"> & {
+  /** Show the pulsing tailing indicator and "Live" label in the toolbar. */
+  live?: boolean;
+};
+
+function LogViewer({ live = false, className, children, ...props }: LogViewerProps) {
+  const [query, setQuery] = React.useState("");
+  const [active, setActive] = React.useState<Record<LogLevel, boolean>>({
+    debug: true,
+    info: true,
+    warn: true,
+    error: true,
+  });
+
+  const linesRef = React.useRef(new Map<string, { level: LogLevel; text: string }>());
+  const [count, setCount] = React.useState(0);
+
+  const recount = React.useCallback(() => {
+    let next = 0;
+    for (const { level, text } of linesRef.current.values()) {
+      if (lineMatches(level, text, query, active)) {
+        next += 1;
+      }
+    }
+    setCount(next);
+  }, [query, active]);
+
+  const register = React.useCallback(
+    (id: string, level: LogLevel, text: string) => {
+      linesRef.current.set(id, { level, text });
+      recount();
+    },
+    [recount],
+  );
+
+  const unregister = React.useCallback(
+    (id: string) => {
+      linesRef.current.delete(id);
+      recount();
+    },
+    [recount],
+  );
+
+  const toggleLevel = React.useCallback((level: LogLevel) => {
+    setActive((prev) => ({ ...prev, [level]: !prev[level] }));
+  }, []);
+
+  React.useEffect(() => {
+    recount();
+  }, [recount]);
+
+  const value = React.useMemo<LogViewerContextValue>(
+    () => ({ query, setQuery, active, toggleLevel, count, register, unregister }),
+    [query, active, toggleLevel, count, register, unregister],
+  );
+
+  return (
+    <LogViewerContext.Provider value={value}>
+      <div
+        data-slot="log-viewer"
+        data-live={live || undefined}
+        className={cn(
+          "flex w-full flex-col overflow-hidden rounded-md border border-border bg-card",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </LogViewerContext.Provider>
+  );
+}
+
+type LogViewerToolbarProps = React.ComponentProps<"div">;
+
+function LogViewerToolbar({ className, children, ...props }: LogViewerToolbarProps) {
+  return (
+    <div
+      data-slot="log-viewer-toolbar"
+      className={cn(
+        "flex flex-wrap items-center gap-2 border-b border-border bg-muted/30 px-3 py-2",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+type LogViewerSearchProps = Omit<
+  React.ComponentProps<typeof InputGroupInput>,
+  "value" | "onChange"
+> & {
+  /** Placeholder for the search field. */
+  placeholder?: string;
+};
+
+function LogViewerSearch({
+  className,
+  placeholder = "Search logs",
+  ...props
+}: LogViewerSearchProps) {
+  const { query, setQuery } = useLogViewer();
+
+  return (
+    <InputGroup
+      data-slot="log-viewer-search"
+      className={cn("h-8 min-w-44 flex-1", className)}
+    >
+      <InputGroupAddon>
+        <Search aria-hidden />
+      </InputGroupAddon>
+      <InputGroupInput
+        type="search"
+        aria-label="Search logs"
+        placeholder={placeholder}
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        {...props}
+      />
+      {query ? (
+        <InputGroupAddon align="inline-end">
+          <InputGroupButton
+            size="icon-xs"
+            aria-label="Clear search"
+            onClick={() => setQuery("")}
+          >
+            <X aria-hidden />
+          </InputGroupButton>
+        </InputGroupAddon>
+      ) : null}
+    </InputGroup>
+  );
+}
+
+const LEVEL_LABEL: Record<LogLevel, string> = {
+  debug: "Debug",
+  info: "Info",
+  warn: "Warn",
+  error: "Error",
+};
+
+const levelChipVariants = cva(
+  "h-7 rounded-full px-2.5 font-mono text-[11px] uppercase tracking-[0.08em] data-[on=false]:opacity-50",
+  {
+    variants: {
+      level: {
+        debug: "data-[on=true]:text-muted-foreground",
+        info: "data-[on=true]:text-foreground",
+        warn: "data-[on=true]:text-warning",
+        error: "data-[on=true]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      level: "info",
+    },
+  },
+);
+
+type LogViewerLevelFilterProps = React.ComponentProps<"div"> & {
+  /** Levels to expose as toggle chips. Defaults to all four. */
+  levels?: readonly LogLevel[];
+};
+
+function LogViewerLevelFilter({
+  levels = LEVELS,
+  className,
+  ...props
+}: LogViewerLevelFilterProps) {
+  const { active, toggleLevel } = useLogViewer();
+
+  return (
+    <div
+      data-slot="log-viewer-level-filter"
+      role="group"
+      aria-label="Filter by level"
+      className={cn("flex items-center gap-1", className)}
+      {...props}
+    >
+      {levels.map((level) => {
+        const on = active[level];
+        return (
+          <Button
+            key={level}
+            type="button"
+            variant="ghost"
+            size="sm"
+            role="switch"
+            aria-checked={on}
+            data-level={level}
+            data-on={on}
+            onClick={() => toggleLevel(level)}
+            className={cn(levelChipVariants({ level }))}
+          >
+            {LEVEL_LABEL[level]}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}
+
+type LogViewerCountProps = React.ComponentProps<"span">;
+
+function LogViewerCount({ className, children, ...props }: LogViewerCountProps) {
+  const { count } = useLogViewer();
+
+  return (
+    <span
+      data-slot="log-viewer-count"
+      className={cn(
+        "ms-auto shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {children ?? `${count} ${count === 1 ? "line" : "lines"}`}
+    </span>
+  );
+}
+
+type LogViewerLiveProps = React.ComponentProps<"span"> & {
+  /** Label shown next to the pulsing dot. */
+  label?: string;
+};
+
+function LogViewerLive({
+  className,
+  label = "Live",
+  children,
+  ...props
+}: LogViewerLiveProps) {
+  return (
+    <span
+      data-slot="log-viewer-live"
+      className={cn(
+        "inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.08em] text-muted-foreground",
+        className,
+      )}
+      {...props}
+    >
+      <span className="state-dot" aria-hidden />
+      {children ?? label}
+    </span>
+  );
+}
+
+type LogViewerBodyProps = React.ComponentProps<"div"> & {
+  /** Wrap long lines instead of scrolling them horizontally. */
+  wrap?: boolean;
+};
+
+function LogViewerBody({
+  wrap = false,
+  className,
+  children,
+  ...props
+}: LogViewerBodyProps) {
+  return (
+    <div
+      data-slot="log-viewer-body"
+      data-wrap={wrap || undefined}
+      role="log"
+      aria-live="polite"
+      className={cn(
+        "max-h-80 min-h-0 overflow-auto bg-card py-1.5 font-mono text-[12px] leading-relaxed",
+        wrap ? "[&_[data-slot=log-line]]:whitespace-pre-wrap" : "w-full",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function highlight(text: string, query: string) {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return text;
+  }
+  const lower = text.toLowerCase();
+  const needle = trimmed.toLowerCase();
+  const parts: React.ReactNode[] = [];
+  let cursor = 0;
+  let found = lower.indexOf(needle, cursor);
+  let key = 0;
+
+  while (found !== -1) {
+    if (found > cursor) {
+      parts.push(text.slice(cursor, found));
+    }
+    parts.push(
+      <mark
+        key={key++}
+        data-slot="log-line-match"
+        className="rounded-[2px] bg-primary/20 text-foreground"
+      >
+        {text.slice(found, found + needle.length)}
+      </mark>,
+    );
+    cursor = found + needle.length;
+    found = lower.indexOf(needle, cursor);
+  }
+
+  if (cursor < text.length) {
+    parts.push(text.slice(cursor));
+  }
+
+  return parts;
+}
+
+const logLineVariants = cva("shrink-0", {
+  variants: {
+    level: {
+      debug: "text-muted-foreground",
+      info: "text-muted-foreground",
+      warn: "text-warning",
+      error: "text-destructive",
+    },
+  },
+  defaultVariants: {
+    level: "info",
+  },
+});
+
+type LogLineProps = Omit<React.ComponentProps<"div">, "children"> & {
+  /** Severity of this line. Drives its level tag and message color. */
+  level: LogLevel;
+  /** Timestamp shown before the message, e.g. "12:04:31". */
+  time?: string;
+  children: string;
+};
+
+function LogLine({
+  level,
+  time,
+  className,
+  children,
+  ...props
+}: LogLineProps) {
+  const { query, active, register, unregister } = useLogViewer();
+  const id = React.useId();
+
+  const text = children;
+
+  React.useEffect(() => {
+    register(id, level, text);
+    return () => unregister(id);
+  }, [id, level, text, register, unregister]);
+
+  if (!lineMatches(level, text, query, active)) {
+    return null;
+  }
+
+  return (
+    <div
+      data-slot="log-line"
+      data-level={level}
+      className={cn(
+        "flex items-baseline gap-2.5 px-3 py-0.5 hover:bg-accent/40",
+        className,
+      )}
+      {...props}
+    >
+      {time ? (
+        <time
+          data-slot="log-line-time"
+          className="shrink-0 text-muted-foreground/70 tabular-nums"
+        >
+          {time}
+        </time>
+      ) : null}
+      <span
+        data-slot="log-line-level"
+        className={cn(
+          logLineVariants({ level }),
+          "w-12 uppercase tracking-[0.06em]",
+        )}
+      >
+        {level}
+      </span>
+      <span data-slot="log-line-message" className="min-w-0 text-foreground">
+        {highlight(text, query)}
+      </span>
+    </div>
+  );
+}
+
+export {
+  LogViewer,
+  LogViewerToolbar,
+  LogViewerSearch,
+  LogViewerLevelFilter,
+  LogViewerCount,
+  LogViewerLive,
+  LogViewerBody,
+  LogLine,
+};

--- a/registry/hirael/ui/nested-sortable.tsx
+++ b/registry/hirael/ui/nested-sortable.tsx
@@ -1,0 +1,679 @@
+"use client";
+
+import * as React from "react";
+import { ChevronRight, GripVertical } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/registry/hirael/ui/button";
+
+export type NestedItem = {
+  id: string;
+  label: string;
+  children?: NestedItem[];
+};
+
+type FlatItem = {
+  id: string;
+  label: string;
+  depth: number;
+  childCount: number;
+};
+
+type ItemEntry = {
+  node: HTMLElement;
+};
+
+type NestedSortableCtx = {
+  flat: FlatItem[];
+  dragId: string | null;
+  grabbedId: string | null;
+  dropIndex: number | null;
+  dropDepth: number;
+  registerItem: (id: string, entry: ItemEntry) => () => void;
+  startPress: (e: React.PointerEvent, id: string) => void;
+  handlePointerMove: (e: React.PointerEvent, id: string) => void;
+  handlePointerEnd: (e: React.PointerEvent, id: string, cancel: boolean) => void;
+  handleKeyDown: (e: React.KeyboardEvent, id: string) => void;
+  handleBlur: (id: string) => void;
+};
+
+const NestedSortableContext = React.createContext<NestedSortableCtx | null>(
+  null,
+);
+
+function useNestedSortable() {
+  const ctx = React.useContext(NestedSortableContext);
+  if (!ctx) {
+    throw new Error(
+      "NestedSortable compound parts must be used inside <NestedSortable>",
+    );
+  }
+  return ctx;
+}
+
+type NestedSortableItemCtx = {
+  id: string;
+  depth: number;
+  state: "idle" | "grabbed";
+};
+
+const NestedSortableItemContext =
+  React.createContext<NestedSortableItemCtx | null>(null);
+
+function useNestedSortableItem() {
+  const ctx = React.useContext(NestedSortableItemContext);
+  if (!ctx) {
+    throw new Error(
+      "NestedSortable item parts must be used inside <NestedSortableItem>",
+    );
+  }
+  return ctx;
+}
+
+const DRAG_THRESHOLD = 5;
+const INDENT_PER_LEVEL = 24;
+const INDENT_BASE = 8;
+
+function flatten(items: NestedItem[], depth: number, out: FlatItem[]) {
+  for (const item of items) {
+    const children = item.children ?? [];
+    out.push({
+      id: item.id,
+      label: item.label,
+      depth,
+      childCount: children.length,
+    });
+    if (children.length > 0) flatten(children, depth + 1, out);
+  }
+  return out;
+}
+
+function rebuild(flat: FlatItem[]): NestedItem[] {
+  const root: NestedItem[] = [];
+  const stack: { depth: number; children: NestedItem[] }[] = [
+    { depth: -1, children: root },
+  ];
+  for (const entry of flat) {
+    while (stack.length > 1 && stack[stack.length - 1].depth >= entry.depth) {
+      stack.pop();
+    }
+    const node: NestedItem = { id: entry.id, label: entry.label };
+    stack[stack.length - 1].children.push(node);
+    const children: NestedItem[] = [];
+    node.children = children;
+    stack.push({ depth: entry.depth, children });
+  }
+  return pruneEmpty(root);
+}
+
+function pruneEmpty(items: NestedItem[]): NestedItem[] {
+  return items.map((item) => {
+    const children = item.children ? pruneEmpty(item.children) : [];
+    const node: NestedItem = { id: item.id, label: item.label };
+    if (children.length > 0) node.children = children;
+    return node;
+  });
+}
+
+/** Index just past the moving item's last descendant in the flat list. */
+function branchEnd(flat: FlatItem[], from: number) {
+  const depth = flat[from].depth;
+  let end = from + 1;
+  while (end < flat.length && flat[end].depth > depth) end += 1;
+  return end;
+}
+
+export type NestedSortableProps = Omit<
+  React.ComponentProps<"div">,
+  "defaultValue" | "onChange"
+> & {
+  /** Controlled tree of items. */
+  value?: NestedItem[];
+  /** Initial tree of items when uncontrolled. */
+  defaultValue?: NestedItem[];
+  /** Called with the rebuilt tree after a reorder, indent, or outdent. */
+  onValueChange?: (value: NestedItem[]) => void;
+  /** Deepest nesting level allowed, where the top level is 0. */
+  maxDepth?: number;
+};
+
+function NestedSortable({
+  value: valueProp,
+  defaultValue = [],
+  onValueChange,
+  maxDepth = Infinity,
+  className,
+  children,
+  ...props
+}: NestedSortableProps) {
+  const [internal, setInternal] = React.useState(defaultValue);
+  const [dragId, setDragId] = React.useState<string | null>(null);
+  const [grabbedId, setGrabbedId] = React.useState<string | null>(null);
+  const [dropIndex, setDropIndex] = React.useState<number | null>(null);
+  const [dropDepth, setDropDepth] = React.useState(0);
+  const [liveText, setLiveText] = React.useState("");
+
+  const committed = valueProp ?? internal;
+
+  const flat = React.useMemo(() => flatten(committed, 0, []), [committed]);
+  const flatRef = React.useRef(flat);
+  flatRef.current = flat;
+
+  const itemsRef = React.useRef(new Map<string, ItemEntry>());
+  const pressRef = React.useRef<{ id: string; x: number; y: number } | null>(
+    null,
+  );
+  const rtlRef = React.useRef(false);
+  const listRef = React.useRef<HTMLDivElement | null>(null);
+
+  const registerItem = React.useCallback((id: string, entry: ItemEntry) => {
+    itemsRef.current.set(id, entry);
+    return () => {
+      itemsRef.current.delete(id);
+    };
+  }, []);
+
+  const announce = React.useCallback((text: string) => {
+    setLiveText(text);
+  }, []);
+
+  const labelOf = React.useCallback(
+    (id: string) => flatRef.current.find((f) => f.id === id)?.label ?? id,
+    [],
+  );
+
+  const isRtl = React.useCallback(
+    () =>
+      listRef.current !== null &&
+      getComputedStyle(listRef.current).direction === "rtl",
+    [],
+  );
+
+  const commit = React.useCallback(
+    (next: NestedItem[]) => {
+      if (valueProp === undefined) setInternal(next);
+      onValueChange?.(next);
+    },
+    [valueProp, onValueChange],
+  );
+
+  const cancel = React.useCallback(() => {
+    setDragId(null);
+    setGrabbedId(null);
+    setDropIndex(null);
+    pressRef.current = null;
+  }, []);
+
+  /**
+   * Move the branch rooted at `id` so that, in the flattened list, it lands at
+   * `targetIndex` (an index into the list with the moving branch removed) at
+   * `desiredDepth`. Depth is capped at one past the previous row and at
+   * `maxDepth`. When `clampToNext` is set (pointer drag), it is also floored at
+   * the depth of the row it lands above so that row keeps its parent. Returns
+   * the rebuilt tree and the moving item's final depth.
+   */
+  const computeMove = React.useCallback(
+    (
+      id: string,
+      targetIndex: number,
+      desiredDepth: number,
+      clampToNext: boolean,
+    ) => {
+      const list = flatRef.current;
+      const from = list.findIndex((f) => f.id === id);
+      if (from === -1) return null;
+      const end = branchEnd(list, from);
+      const branch = list.slice(from, end);
+      const rest = [...list.slice(0, from), ...list.slice(end)];
+
+      const at = Math.max(0, Math.min(targetIndex, rest.length));
+      const before = rest[at - 1];
+      const after = rest[at];
+      const maxAllowed = Math.min(before ? before.depth + 1 : 0, maxDepth);
+      const minAllowed = clampToNext && after ? after.depth : 0;
+      const depth = Math.max(minAllowed, Math.min(desiredDepth, maxAllowed));
+
+      const shift = depth - branch[0].depth;
+      const shifted = branch.map((f) => ({ ...f, depth: f.depth + shift }));
+      const merged = [...rest.slice(0, at), ...shifted, ...rest.slice(at)];
+      return { tree: rebuild(merged), depth };
+    },
+    [maxDepth],
+  );
+
+  const startPress = React.useCallback(
+    (e: React.PointerEvent, id: string) => {
+      if (e.button !== 0) return;
+      pressRef.current = { id, x: e.clientX, y: e.clientY };
+      e.currentTarget.setPointerCapture(e.pointerId);
+      rtlRef.current = isRtl();
+    },
+    [isRtl],
+  );
+
+  const handlePointerMove = React.useCallback(
+    (e: React.PointerEvent, id: string) => {
+      const press = pressRef.current;
+      if (!press || press.id !== id) return;
+
+      if (dragId !== id) {
+        const dx = e.clientX - press.x;
+        const dy = e.clientY - press.y;
+        if (Math.hypot(dx, dy) < DRAG_THRESHOLD) return;
+        setDragId(id);
+        setGrabbedId(null);
+      }
+
+      const list = flatRef.current;
+      const from = list.findIndex((f) => f.id === id);
+      if (from === -1) return;
+      const end = branchEnd(list, from);
+
+      let target = list.length;
+      for (let i = 0; i < list.length; i += 1) {
+        if (i >= from && i < end) continue;
+        const entry = itemsRef.current.get(list[i].id);
+        if (!entry) continue;
+        const rect = entry.node.getBoundingClientRect();
+        const mid = (rect.top + rect.bottom) / 2;
+        if (e.clientY < mid) {
+          target = i;
+          break;
+        }
+      }
+      const restIndex = target > from ? target - (end - from) : target;
+
+      const startDelta = rtlRef.current
+        ? press.x - e.clientX
+        : e.clientX - press.x;
+      const desired =
+        list[from].depth + Math.round(startDelta / INDENT_PER_LEVEL);
+
+      const moved = computeMove(id, restIndex, desired, true);
+      if (!moved) return;
+      setDropIndex(target);
+      setDropDepth(moved.depth);
+    },
+    [dragId, computeMove],
+  );
+
+  const handlePointerEnd = React.useCallback(
+    (e: React.PointerEvent, id: string, cancelled: boolean) => {
+      const wasDragging = dragId === id;
+      pressRef.current = null;
+      const target = dropIndex;
+      const depth = dropDepth;
+      setDropIndex(null);
+      if (!wasDragging) return;
+      setDragId(null);
+      if (cancelled || target === null) return;
+      const list = flatRef.current;
+      const from = list.findIndex((f) => f.id === id);
+      const end = branchEnd(list, from);
+      const restIndex = target > from ? target - (end - from) : target;
+      const moved = computeMove(id, restIndex, depth, true);
+      if (!moved) return;
+      commit(moved.tree);
+      announce(`Moved ${labelOf(id)} to level ${moved.depth + 1}`);
+    },
+    [dragId, dropIndex, dropDepth, computeMove, commit, announce, labelOf],
+  );
+
+  const moveVertical = React.useCallback(
+    (id: string, dir: -1 | 1) => {
+      const list = flatRef.current;
+      const from = list.findIndex((f) => f.id === id);
+      if (from === -1) return;
+      const end = branchEnd(list, from);
+      const self = list[from];
+
+      const target =
+        dir === -1 ? from - 1 : end < list.length ? end + 1 : list.length;
+      if (dir === -1 && from === 0) return;
+      if (dir === 1 && end >= list.length) return;
+
+      const restIndex = target > from ? target - (end - from) : target;
+      const moved = computeMove(id, restIndex, self.depth, true);
+      if (!moved) return;
+      commit(moved.tree);
+      const next = flatten(moved.tree, 0, []);
+      const pos = next.findIndex((f) => f.id === id);
+      announce(`Moved ${labelOf(id)} to position ${pos + 1} of ${next.length}`);
+    },
+    [computeMove, commit, announce, labelOf],
+  );
+
+  const reparent = React.useCallback(
+    (id: string, dir: -1 | 1) => {
+      const list = flatRef.current;
+      const from = list.findIndex((f) => f.id === id);
+      if (from === -1) return;
+      const self = list[from];
+      const targetDepth = self.depth + dir;
+      if (targetDepth < 0) return;
+      const moved = computeMove(id, from, targetDepth, false);
+      if (!moved || moved.depth === self.depth) return;
+      commit(moved.tree);
+      const verb = dir === 1 ? "Indented" : "Outdented";
+      announce(`${verb} ${labelOf(id)} to level ${moved.depth + 1}`);
+    },
+    [computeMove, commit, announce, labelOf],
+  );
+
+  const handleKeyDown = React.useCallback(
+    (e: React.KeyboardEvent, id: string) => {
+      const rtl = isRtl();
+
+      if (e.key === " " || e.key === "Enter") {
+        e.preventDefault();
+        if (grabbedId === id) {
+          setGrabbedId(null);
+          announce(`Dropped ${labelOf(id)}`);
+        } else if (grabbedId === null && dragId === null) {
+          setGrabbedId(id);
+          announce(
+            `Grabbed ${labelOf(id)}. Use up and down arrows to move, left and right arrows to outdent and indent, Space to drop, Escape to cancel.`,
+          );
+        }
+        return;
+      }
+
+      if (e.key === "Escape") {
+        if (grabbedId === id) {
+          e.preventDefault();
+          cancel();
+          announce(`Reorder cancelled. ${labelOf(id)} returned to its place.`);
+        }
+        return;
+      }
+
+      if (e.key === "Tab") {
+        if (grabbedId !== id) return;
+        e.preventDefault();
+        reparent(id, e.shiftKey ? -1 : 1);
+        return;
+      }
+
+      if (grabbedId !== id) return;
+
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        moveVertical(id, -1);
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        moveVertical(id, 1);
+        return;
+      }
+      const startKey = rtl ? "ArrowRight" : "ArrowLeft";
+      const endKey = rtl ? "ArrowLeft" : "ArrowRight";
+      if (e.key === endKey) {
+        e.preventDefault();
+        reparent(id, 1);
+        return;
+      }
+      if (e.key === startKey) {
+        e.preventDefault();
+        reparent(id, -1);
+      }
+    },
+    [
+      isRtl,
+      grabbedId,
+      dragId,
+      cancel,
+      reparent,
+      moveVertical,
+      announce,
+      labelOf,
+    ],
+  );
+
+  const handleBlur = React.useCallback(
+    (id: string) => {
+      if (grabbedId === id) cancel();
+    },
+    [grabbedId, cancel],
+  );
+
+  React.useEffect(() => {
+    if (!dragId) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        cancel();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [dragId, cancel]);
+
+  const ctx = React.useMemo<NestedSortableCtx>(
+    () => ({
+      flat,
+      dragId,
+      grabbedId,
+      dropIndex,
+      dropDepth,
+      registerItem,
+      startPress,
+      handlePointerMove,
+      handlePointerEnd,
+      handleKeyDown,
+      handleBlur,
+    }),
+    [
+      flat,
+      dragId,
+      grabbedId,
+      dropIndex,
+      dropDepth,
+      registerItem,
+      startPress,
+      handlePointerMove,
+      handlePointerEnd,
+      handleKeyDown,
+      handleBlur,
+    ],
+  );
+
+  return (
+    <NestedSortableContext.Provider value={ctx}>
+      <div
+        ref={listRef}
+        role="tree"
+        aria-label="Sortable outline"
+        data-slot="nested-sortable"
+        className={cn("relative flex flex-col gap-1", className)}
+        {...props}
+      >
+        {children ??
+          flat.map((item) => (
+            <NestedSortableItem key={item.id} value={item.id}>
+              <NestedSortableHandle />
+              <NestedSortableLabel>{item.label}</NestedSortableLabel>
+            </NestedSortableItem>
+          ))}
+        <span
+          data-slot="nested-sortable-live"
+          aria-live="polite"
+          className="sr-only"
+        >
+          {liveText}
+        </span>
+      </div>
+    </NestedSortableContext.Provider>
+  );
+}
+
+export type NestedSortableItemProps = React.ComponentProps<"div"> & {
+  /** Unique id matching an entry in the root tree. */
+  value: string;
+};
+
+function NestedSortableItem({
+  value,
+  className,
+  style,
+  children,
+  ...props
+}: NestedSortableItemProps) {
+  const {
+    flat,
+    dragId,
+    grabbedId,
+    dropIndex,
+    dropDepth,
+    registerItem,
+    handleKeyDown,
+    handleBlur,
+  } = useNestedSortable();
+
+  const ref = React.useRef<HTMLDivElement | null>(null);
+  const order = flat.findIndex((f) => f.id === value);
+  const depth = order === -1 ? 0 : flat[order].depth;
+
+  React.useLayoutEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    return registerItem(value, { node });
+  }, [value, registerItem]);
+
+  const state: "idle" | "grabbed" =
+    dragId === value || grabbedId === value ? "grabbed" : "idle";
+
+  const showIndicator = dragId !== null && dropIndex === order;
+
+  const itemCtx = React.useMemo<NestedSortableItemCtx>(
+    () => ({ id: value, depth, state }),
+    [value, depth, state],
+  );
+
+  const guides = Array.from({ length: depth }, (_, i) => (
+    <span
+      key={i}
+      aria-hidden
+      data-slot="nested-sortable-guide"
+      className="absolute top-0 bottom-0 w-px bg-border"
+      style={{ insetInlineStart: i * INDENT_PER_LEVEL + INDENT_BASE + 11 }}
+    />
+  ));
+
+  return (
+    <NestedSortableItemContext.Provider value={itemCtx}>
+      <div
+        ref={ref}
+        role="treeitem"
+        aria-level={depth + 1}
+        data-slot="nested-sortable-item"
+        data-state={state}
+        data-depth={depth}
+        aria-roledescription="sortable item"
+        style={{
+          ...style,
+          order: order === -1 ? undefined : order,
+          paddingInlineStart: depth * INDENT_PER_LEVEL + INDENT_BASE,
+        }}
+        className={cn(
+          "group/nested-item relative",
+          state === "grabbed" && "z-10",
+          className,
+        )}
+        {...props}
+      >
+        {guides}
+        {showIndicator && (
+          <span
+            aria-hidden
+            data-slot="nested-sortable-indicator"
+            className="pointer-events-none absolute -top-0.5 end-0 z-20 h-0.5 rounded-full bg-primary"
+            style={{
+              insetInlineStart: dropDepth * INDENT_PER_LEVEL + INDENT_BASE,
+            }}
+          />
+        )}
+        <div
+          data-slot="nested-sortable-row"
+          tabIndex={-1}
+          onKeyDown={(e) => handleKeyDown(e, value)}
+          onBlur={() => handleBlur(value)}
+          className={cn(
+            "relative flex select-none items-center gap-2 rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none transition-[box-shadow,transform,background-color]",
+            "focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background",
+            state === "grabbed" &&
+              "scale-[1.01] border-ring bg-card shadow-lg ring-2 ring-ring/40",
+          )}
+        >
+          {children}
+        </div>
+      </div>
+    </NestedSortableItemContext.Provider>
+  );
+}
+
+function NestedSortableHandle({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { startPress, handlePointerMove, handlePointerEnd, handleKeyDown } =
+    useNestedSortable();
+  const { id, state } = useNestedSortableItem();
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-xs"
+      data-slot="nested-sortable-handle"
+      data-state={state}
+      aria-label="Drag to reorder or nest"
+      aria-pressed={state === "grabbed"}
+      onPointerDown={(e) => startPress(e, id)}
+      onPointerMove={(e) => handlePointerMove(e, id)}
+      onPointerUp={(e) => handlePointerEnd(e, id, false)}
+      onPointerCancel={(e) => handlePointerEnd(e, id, true)}
+      onKeyDown={(e) => handleKeyDown(e, id)}
+      className={cn(
+        "shrink-0 cursor-grab touch-none text-muted-foreground hover:text-foreground",
+        state === "grabbed" && "cursor-grabbing text-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {children ?? <GripVertical aria-hidden />}
+    </Button>
+  );
+}
+
+function NestedSortableLabel({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"span">) {
+  const { depth } = useNestedSortableItem();
+
+  return (
+    <span
+      data-slot="nested-sortable-label"
+      className={cn("flex min-w-0 flex-1 items-center gap-1.5", className)}
+      {...props}
+    >
+      {depth > 0 && (
+        <ChevronRight
+          aria-hidden
+          className="size-3.5 shrink-0 text-muted-foreground rtl:rotate-180"
+        />
+      )}
+      <span className="min-w-0 truncate">{children}</span>
+    </span>
+  );
+}
+
+export {
+  NestedSortable,
+  NestedSortableItem,
+  NestedSortableHandle,
+  NestedSortableLabel,
+};

--- a/registry/hirael/ui/onboarding.tsx
+++ b/registry/hirael/ui/onboarding.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import * as React from "react";
+import { ArrowLeft, ArrowRight, Check } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/registry/hirael/ui/button";
+import { Progress } from "@/registry/hirael/ui/progress";
+
+type OnboardingCtx = {
+  step: number;
+  total: number;
+  isComplete: boolean;
+  registerStep: (value: number) => () => void;
+  goTo: (step: number) => void;
+  back: () => void;
+  next: () => void;
+  skip: () => void;
+  complete: () => void;
+};
+
+const OnboardingContext = React.createContext<OnboardingCtx | null>(null);
+
+function useOnboarding() {
+  const ctx = React.useContext(OnboardingContext);
+  if (!ctx) {
+    throw new Error("Onboarding compound parts must be used inside <Onboarding>");
+  }
+  return ctx;
+}
+
+export type OnboardingProps = Omit<
+  React.ComponentProps<"div">,
+  "onChange"
+> & {
+  /** The active step index, 0-based. Pass with `onStepChange` to control. */
+  step?: number;
+  /** The initial step index for the uncontrolled case, 0-based. */
+  defaultStep?: number;
+  /** Called when the active step changes, with the next 0-based index. */
+  onStepChange?: (step: number) => void;
+  /** Called once when the last step is finished. */
+  onComplete?: () => void;
+};
+
+function Onboarding({
+  step: stepProp,
+  defaultStep = 0,
+  onStepChange,
+  onComplete,
+  className,
+  children,
+  ...props
+}: OnboardingProps) {
+  const [internal, setInternal] = React.useState(defaultStep);
+  const [isComplete, setIsComplete] = React.useState(false);
+  const [registered, setRegistered] = React.useState<number[]>([]);
+  const step = stepProp ?? internal;
+  const total = registered.length;
+
+  const registerStep = React.useCallback((value: number) => {
+    setRegistered((prev) =>
+      prev.includes(value) ? prev : [...prev, value].sort((a, b) => a - b),
+    );
+    return () => {
+      setRegistered((prev) => prev.filter((v) => v !== value));
+    };
+  }, []);
+
+  const goTo = React.useCallback(
+    (next: number) => {
+      if (stepProp === undefined) setInternal(next);
+      onStepChange?.(next);
+    },
+    [stepProp, onStepChange],
+  );
+
+  const complete = React.useCallback(() => {
+    setIsComplete(true);
+    onComplete?.();
+  }, [onComplete]);
+
+  const back = React.useCallback(() => {
+    if (step > 0) goTo(step - 1);
+  }, [step, goTo]);
+
+  const next = React.useCallback(() => {
+    if (step < total - 1) {
+      goTo(step + 1);
+    } else {
+      complete();
+    }
+  }, [step, total, goTo, complete]);
+
+  const skip = next;
+
+  const ctx = React.useMemo<OnboardingCtx>(
+    () => ({
+      step,
+      total,
+      isComplete,
+      registerStep,
+      goTo,
+      back,
+      next,
+      skip,
+      complete,
+    }),
+    [step, total, isComplete, registerStep, goTo, back, next, skip, complete],
+  );
+
+  return (
+    <OnboardingContext.Provider value={ctx}>
+      <div
+        data-slot="onboarding"
+        data-complete={isComplete || undefined}
+        className={cn(
+          "flex w-full flex-col gap-6 rounded-xl border border-border bg-card p-6 text-card-foreground",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </OnboardingContext.Provider>
+  );
+}
+
+export type OnboardingProgressProps = React.ComponentProps<"div"> & {
+  /** Render a continuous bar instead of one dot per step. */
+  variant?: "dots" | "bar";
+};
+
+function OnboardingProgress({
+  variant = "dots",
+  className,
+  ...props
+}: OnboardingProgressProps) {
+  const { step, total, isComplete } = useOnboarding();
+  const safeTotal = Math.max(total, 1);
+  const reached = isComplete ? safeTotal : step + 1;
+  const label = isComplete
+    ? "Done"
+    : `Step ${Math.min(reached, safeTotal)} of ${safeTotal}`;
+
+  return (
+    <div
+      data-slot="onboarding-progress"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <span
+          data-slot="onboarding-progress-label"
+          className="text-xs font-medium tabular-nums text-muted-foreground"
+        >
+          {label}
+        </span>
+        {variant === "dots" && (
+          <div
+            data-slot="onboarding-progress-dots"
+            className="flex items-center gap-1.5"
+          >
+            {Array.from({ length: safeTotal }).map((_, index) => {
+              const state = isComplete
+                ? "completed"
+                : index < step
+                  ? "completed"
+                  : index === step
+                    ? "active"
+                    : "inactive";
+              return (
+                <span
+                  key={index}
+                  data-slot="onboarding-progress-dot"
+                  data-state={state}
+                  aria-hidden
+                  className={cn(
+                    "size-1.5 rounded-full transition-colors",
+                    state === "active" && "bg-primary",
+                    state === "completed" && "bg-primary/50",
+                    state === "inactive" && "bg-border",
+                  )}
+                />
+              );
+            })}
+          </div>
+        )}
+      </div>
+      {variant === "bar" && (
+        <Progress
+          data-slot="onboarding-progress-bar"
+          value={(reached / safeTotal) * 100}
+        />
+      )}
+    </div>
+  );
+}
+
+export type OnboardingStepProps = React.ComponentProps<"div"> & {
+  /** This step's index, 0-based. Renders only while it is the active step. */
+  value: number;
+};
+
+function OnboardingStep({
+  value,
+  className,
+  children,
+  ...props
+}: OnboardingStepProps) {
+  const { step, isComplete, registerStep } = useOnboarding();
+
+  React.useEffect(() => registerStep(value), [registerStep, value]);
+
+  if (isComplete || step !== value) return null;
+
+  return (
+    <div
+      data-slot="onboarding-step"
+      className={cn("flex flex-col gap-1.5", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function OnboardingStepTitle({
+  className,
+  ...props
+}: React.ComponentProps<"h3">) {
+  return (
+    <h3
+      data-slot="onboarding-step-title"
+      className={cn("text-base font-semibold leading-tight", className)}
+      {...props}
+    />
+  );
+}
+
+function OnboardingStepDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="onboarding-step-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function OnboardingStepBody({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="onboarding-step-body"
+      className={cn("mt-2", className)}
+      {...props}
+    />
+  );
+}
+
+function OnboardingComplete({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div">) {
+  const { isComplete } = useOnboarding();
+  if (!isComplete) return null;
+
+  return (
+    <div
+      data-slot="onboarding-complete"
+      className={cn("flex flex-col items-center gap-3 py-4 text-center", className)}
+      {...props}
+    >
+      <span
+        data-slot="onboarding-complete-icon"
+        aria-hidden
+        className="inline-flex size-10 items-center justify-center rounded-full bg-primary text-primary-foreground"
+      >
+        <Check className="size-5" strokeWidth={2.5} />
+      </span>
+      {children}
+    </div>
+  );
+}
+
+export type OnboardingActionsProps = React.ComponentProps<"div"> & {
+  /** Show the Skip button on non-final steps. */
+  showSkip?: boolean;
+  /** Label for the advance button on the last step. */
+  finishLabel?: string;
+};
+
+function OnboardingActions({
+  showSkip = true,
+  finishLabel = "Finish",
+  className,
+  ...props
+}: OnboardingActionsProps) {
+  const { step, total, isComplete, back, next, skip } = useOnboarding();
+
+  if (isComplete) return null;
+
+  const isFirst = step === 0;
+  const isLast = step === total - 1;
+
+  return (
+    <div
+      data-slot="onboarding-actions"
+      className={cn("flex items-center justify-between gap-2", className)}
+      {...props}
+    >
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        data-slot="onboarding-back"
+        onClick={back}
+        disabled={isFirst}
+      >
+        <ArrowLeft className="rtl:rotate-180" />
+        Back
+      </Button>
+      <div className="flex items-center gap-2">
+        {showSkip && !isLast && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            data-slot="onboarding-skip"
+            onClick={skip}
+          >
+            Skip
+          </Button>
+        )}
+        <Button
+          type="button"
+          size="sm"
+          data-slot="onboarding-next"
+          onClick={next}
+        >
+          {isLast ? finishLabel : "Next"}
+          {!isLast && <ArrowRight className="rtl:rotate-180" />}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export {
+  Onboarding,
+  OnboardingProgress,
+  OnboardingStep,
+  OnboardingStepTitle,
+  OnboardingStepDescription,
+  OnboardingStepBody,
+  OnboardingComplete,
+  OnboardingActions,
+};

--- a/registry/hirael/ui/permission-matrix.tsx
+++ b/registry/hirael/ui/permission-matrix.tsx
@@ -1,0 +1,441 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { Checkbox } from "@/registry/hirael/ui/checkbox";
+
+type Role = { id: string; label: string };
+
+type Permission = { id: string; label: string; group?: string };
+
+type GrantState = Record<string, string[]>;
+
+type CheckedState = boolean | "indeterminate";
+
+type PermissionMatrixContextValue = {
+  roles: Role[];
+  permissions: Permission[];
+  value: GrantState;
+  isGranted: (permissionId: string, roleId: string) => boolean;
+  toggleCell: (permissionId: string, roleId: string, granted: boolean) => void;
+  setRow: (permissionId: string, granted: boolean) => void;
+  setColumn: (roleId: string, granted: boolean) => void;
+  rowState: (permissionId: string) => CheckedState;
+  columnState: (roleId: string) => CheckedState;
+};
+
+const PermissionMatrixContext =
+  React.createContext<PermissionMatrixContextValue | null>(null);
+
+function usePermissionMatrix() {
+  const ctx = React.useContext(PermissionMatrixContext);
+  if (!ctx) {
+    throw new Error(
+      "PermissionMatrix compound parts must be used inside <PermissionMatrix>",
+    );
+  }
+  return ctx;
+}
+
+function resolveState(granted: number, total: number): CheckedState {
+  if (total === 0 || granted === 0) return false;
+  if (granted === total) return true;
+  return "indeterminate";
+}
+
+export type PermissionMatrixProps = Omit<
+  React.ComponentProps<"div">,
+  "defaultValue" | "onChange"
+> & {
+  /** Columns of the grid. Each role renders one checkbox column. */
+  roles: Role[];
+  /** Rows of the grid. Group adjacent permissions under a section header with `group`. */
+  permissions: Permission[];
+  /** Controlled grant map of permission id to the role ids that hold it. */
+  value?: GrantState;
+  /** Initial grant map for uncontrolled use. */
+  defaultValue?: GrantState;
+  /** Called with the next grant map whenever a grant changes. */
+  onValueChange?: (value: GrantState) => void;
+  /** Show a master checkbox in each column header that toggles the whole column. */
+  columnToggles?: boolean;
+  /** Show a leading toggle-all checkbox on each permission row. */
+  rowToggles?: boolean;
+};
+
+function PermissionMatrix({
+  roles,
+  permissions,
+  value: valueProp,
+  defaultValue,
+  onValueChange,
+  columnToggles = true,
+  rowToggles = false,
+  className,
+  children,
+  ...props
+}: PermissionMatrixProps) {
+  const [internalValue, setInternalValue] = React.useState<GrantState>(
+    () => defaultValue ?? {},
+  );
+  const value = valueProp ?? internalValue;
+
+  const setValue = React.useCallback(
+    (next: GrantState) => {
+      if (valueProp === undefined) setInternalValue(next);
+      onValueChange?.(next);
+    },
+    [valueProp, onValueChange],
+  );
+
+  const isGranted = React.useCallback(
+    (permissionId: string, roleId: string) =>
+      (value[permissionId] ?? []).includes(roleId),
+    [value],
+  );
+
+  const toggleCell = React.useCallback(
+    (permissionId: string, roleId: string, granted: boolean) => {
+      const current = value[permissionId] ?? [];
+      const next = granted
+        ? current.includes(roleId)
+          ? current
+          : [...current, roleId]
+        : current.filter((id) => id !== roleId);
+      setValue({ ...value, [permissionId]: next });
+    },
+    [value, setValue],
+  );
+
+  const setRow = React.useCallback(
+    (permissionId: string, granted: boolean) => {
+      setValue({
+        ...value,
+        [permissionId]: granted ? roles.map((role) => role.id) : [],
+      });
+    },
+    [value, setValue, roles],
+  );
+
+  const setColumn = React.useCallback(
+    (roleId: string, granted: boolean) => {
+      const next: GrantState = { ...value };
+      for (const permission of permissions) {
+        const current = next[permission.id] ?? [];
+        next[permission.id] = granted
+          ? current.includes(roleId)
+            ? current
+            : [...current, roleId]
+          : current.filter((id) => id !== roleId);
+      }
+      setValue(next);
+    },
+    [value, setValue, permissions],
+  );
+
+  const rowState = React.useCallback(
+    (permissionId: string) => {
+      const granted = roles.reduce(
+        (count, role) => count + (isGranted(permissionId, role.id) ? 1 : 0),
+        0,
+      );
+      return resolveState(granted, roles.length);
+    },
+    [roles, isGranted],
+  );
+
+  const columnState = React.useCallback(
+    (roleId: string) => {
+      const granted = permissions.reduce(
+        (count, permission) =>
+          count + (isGranted(permission.id, roleId) ? 1 : 0),
+        0,
+      );
+      return resolveState(granted, permissions.length);
+    },
+    [permissions, isGranted],
+  );
+
+  const ctx = React.useMemo<PermissionMatrixContextValue>(
+    () => ({
+      roles,
+      permissions,
+      value,
+      isGranted,
+      toggleCell,
+      setRow,
+      setColumn,
+      rowState,
+      columnState,
+    }),
+    [
+      roles,
+      permissions,
+      value,
+      isGranted,
+      toggleCell,
+      setRow,
+      setColumn,
+      rowState,
+      columnState,
+    ],
+  );
+
+  const grouped = React.useMemo(() => {
+    const sections: { group?: string; items: Permission[] }[] = [];
+    for (const permission of permissions) {
+      const last = sections[sections.length - 1];
+      if (last && last.group === permission.group) {
+        last.items.push(permission);
+      } else {
+        sections.push({ group: permission.group, items: [permission] });
+      }
+    }
+    return sections;
+  }, [permissions]);
+
+  return (
+    <PermissionMatrixContext.Provider value={ctx}>
+      <div
+        data-slot="permission-matrix"
+        className={cn(
+          "relative w-full overflow-x-auto rounded-lg border border-border bg-card text-card-foreground",
+          className,
+        )}
+        {...props}
+      >
+        {children ?? (
+          <table
+            data-slot="permission-matrix-table"
+            className="w-full border-collapse text-sm"
+          >
+            <PermissionMatrixHeader
+              columnToggles={columnToggles}
+              rowToggles={rowToggles}
+            />
+            <tbody data-slot="permission-matrix-body">
+              {grouped.map((section, index) => (
+                <React.Fragment key={section.group ?? `section-${index}`}>
+                  {section.group ? (
+                    <PermissionGroupRow rowToggles={rowToggles}>
+                      {section.group}
+                    </PermissionGroupRow>
+                  ) : null}
+                  {section.items.map((permission) => (
+                    <PermissionRow
+                      key={permission.id}
+                      permission={permission}
+                      rowToggles={rowToggles}
+                    />
+                  ))}
+                </React.Fragment>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </PermissionMatrixContext.Provider>
+  );
+}
+
+export type PermissionMatrixHeaderProps = React.ComponentProps<"thead"> & {
+  columnToggles?: boolean;
+  rowToggles?: boolean;
+};
+
+function PermissionMatrixHeader({
+  columnToggles = true,
+  rowToggles = false,
+  className,
+  ...props
+}: PermissionMatrixHeaderProps) {
+  const { roles, setColumn, columnState } = usePermissionMatrix();
+  return (
+    <thead
+      data-slot="permission-matrix-header"
+      className={cn("border-b border-border bg-muted/40", className)}
+      {...props}
+    >
+      <tr data-slot="permission-matrix-header-row">
+        <th
+          scope="col"
+          data-slot="permission-matrix-corner"
+          className="sticky start-0 z-10 bg-muted/40 px-4 py-3 text-start align-bottom font-medium text-muted-foreground"
+        >
+          Permission
+        </th>
+        {rowToggles ? (
+          <th
+            scope="col"
+            data-slot="permission-matrix-row-toggle-head"
+            className="px-3 py-3 text-center align-bottom font-medium text-muted-foreground"
+          >
+            <span className="sr-only">Toggle all roles per permission</span>
+            All
+          </th>
+        ) : null}
+        {roles.map((role) => {
+          const state = columnState(role.id);
+          return (
+            <th
+              key={role.id}
+              scope="col"
+              data-slot="permission-matrix-role"
+              className="px-3 py-3 text-center align-bottom font-medium text-foreground"
+            >
+              <div className="flex flex-col items-center gap-2">
+                <span>{role.label}</span>
+                {columnToggles ? (
+                  <Checkbox
+                    data-slot="permission-matrix-column-toggle"
+                    checked={state}
+                    onCheckedChange={(checked) =>
+                      setColumn(role.id, checked === true)
+                    }
+                    aria-label={`Grant all to ${role.label}`}
+                  />
+                ) : null}
+              </div>
+            </th>
+          );
+        })}
+      </tr>
+    </thead>
+  );
+}
+
+export type PermissionGroupRowProps = React.ComponentProps<"tr"> & {
+  rowToggles?: boolean;
+};
+
+function PermissionGroupRow({
+  rowToggles = false,
+  className,
+  children,
+  ...props
+}: PermissionGroupRowProps) {
+  const { roles } = usePermissionMatrix();
+  return (
+    <tr
+      data-slot="permission-group-row"
+      className={cn("border-b border-border bg-muted/20", className)}
+      {...props}
+    >
+      <th
+        scope="colgroup"
+        colSpan={roles.length + 1 + (rowToggles ? 1 : 0)}
+        className="sticky start-0 bg-muted/20 px-4 py-2 text-start text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground"
+      >
+        {children}
+      </th>
+    </tr>
+  );
+}
+
+export type PermissionRowProps = Omit<
+  React.ComponentProps<"tr">,
+  "children"
+> & {
+  permission: Permission;
+  rowToggles?: boolean;
+};
+
+function PermissionRow({
+  permission,
+  rowToggles = false,
+  className,
+  ...props
+}: PermissionRowProps) {
+  const { roles, isGranted, toggleCell, setRow, rowState } =
+    usePermissionMatrix();
+  const state = rowState(permission.id);
+  return (
+    <tr
+      data-slot="permission-row"
+      className={cn(
+        "border-b border-border last:border-b-0 transition-colors hover:bg-accent/40",
+        className,
+      )}
+      {...props}
+    >
+      <th
+        scope="row"
+        data-slot="permission-label"
+        className="sticky start-0 z-10 bg-card px-4 py-2.5 text-start font-normal text-foreground"
+      >
+        {permission.label}
+      </th>
+      {rowToggles ? (
+        <td
+          data-slot="permission-row-toggle-cell"
+          className="px-3 py-2.5 text-center"
+        >
+          <Checkbox
+            data-slot="permission-row-toggle"
+            checked={state}
+            onCheckedChange={(checked) =>
+              setRow(permission.id, checked === true)
+            }
+            aria-label={`Grant ${permission.label} to all roles`}
+          />
+        </td>
+      ) : null}
+      {roles.map((role) => (
+        <PermissionCell
+          key={role.id}
+          checked={isGranted(permission.id, role.id)}
+          onCheckedChange={(checked) =>
+            toggleCell(permission.id, role.id, checked)
+          }
+          aria-label={`Grant ${permission.label} to ${role.label}`}
+        />
+      ))}
+    </tr>
+  );
+}
+
+export type PermissionCellProps = Omit<
+  React.ComponentProps<"td">,
+  "onChange"
+> & {
+  checked?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+  /** Accessible name for the cell checkbox, e.g. "Grant Edit to Admin". */
+  "aria-label"?: string;
+  disabled?: boolean;
+};
+
+function PermissionCell({
+  checked = false,
+  onCheckedChange,
+  disabled,
+  className,
+  "aria-label": ariaLabel,
+  ...props
+}: PermissionCellProps) {
+  return (
+    <td
+      data-slot="permission-cell"
+      className={cn("px-3 py-2.5 text-center", className)}
+      {...props}
+    >
+      <Checkbox
+        data-slot="permission-cell-checkbox"
+        checked={checked}
+        disabled={disabled}
+        onCheckedChange={(next) => onCheckedChange?.(next === true)}
+        aria-label={ariaLabel}
+        className="mx-auto"
+      />
+    </td>
+  );
+}
+
+export {
+  PermissionMatrix,
+  PermissionMatrixHeader,
+  PermissionGroupRow,
+  PermissionRow,
+  PermissionCell,
+};

--- a/registry/hirael/ui/pricing-rules-builder.tsx
+++ b/registry/hirael/ui/pricing-rules-builder.tsx
@@ -1,0 +1,551 @@
+"use client";
+
+import * as React from "react";
+import { ArrowRight, Plus, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/registry/hirael/ui/badge";
+import { Button } from "@/registry/hirael/ui/button";
+import { Input } from "@/registry/hirael/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/registry/hirael/ui/select";
+
+type PricingField = {
+  name: string;
+  label: string;
+  operators?: string[];
+};
+
+type PricingAction = {
+  name: string;
+  label: string;
+  unit?: string;
+};
+
+type PricingRule = {
+  id: string;
+  field: string;
+  operator: string;
+  value: string;
+  action: string;
+  actionValue: string;
+};
+
+const DEFAULT_FIELDS: PricingField[] = [
+  {
+    name: "quantity",
+    label: "Quantity",
+    operators: [">=", ">", "=", "<", "<="],
+  },
+  {
+    name: "customer-group",
+    label: "Customer group",
+    operators: ["is", "is not"],
+  },
+  {
+    name: "cart-total",
+    label: "Cart total",
+    operators: [">=", ">", "<", "<="],
+  },
+];
+
+const DEFAULT_ACTIONS: PricingAction[] = [
+  { name: "percent-off", label: "Percentage off", unit: "%" },
+  { name: "amount-off", label: "Fixed amount off", unit: "$" },
+  { name: "set-price", label: "Set price", unit: "$" },
+  { name: "price-per-unit", label: "Price per unit", unit: "$" },
+];
+
+const DEFAULT_OPERATORS = [">=", ">", "=", "<", "<="];
+
+function fieldLabel(fields: PricingField[], name: string): string {
+  return fields.find((field) => field.name === name)?.label ?? name;
+}
+
+function operatorsFor(fields: PricingField[], name: string): string[] {
+  const operators = fields.find((field) => field.name === name)?.operators;
+  return operators && operators.length > 0 ? operators : DEFAULT_OPERATORS;
+}
+
+function actionFor(
+  actions: PricingAction[],
+  name: string,
+): PricingAction | undefined {
+  return actions.find((action) => action.name === name);
+}
+
+function shortFieldLabel(fields: PricingField[], name: string): string {
+  const label = fieldLabel(fields, name);
+  if (label === "Quantity") return "Qty";
+  return label;
+}
+
+function summarizeCondition(
+  fields: PricingField[],
+  rule: PricingRule,
+): string {
+  const field = shortFieldLabel(fields, rule.field);
+  const value = rule.value.trim();
+  return [field, rule.operator, value].filter(Boolean).join(" ");
+}
+
+function summarizeAction(
+  actions: PricingAction[],
+  rule: PricingRule,
+): string {
+  const action = actionFor(actions, rule.action);
+  const label = action?.label ?? rule.action;
+  const value = rule.actionValue.trim();
+  const unit = action?.unit ?? "";
+
+  if (!value) return label;
+
+  if (unit === "%") return `${value}% off`;
+  if (action?.name === "amount-off") return `${unit}${value} off`;
+  if (action?.name === "set-price") return `set ${unit}${value}`;
+  if (action?.name === "price-per-unit") return `${unit}${value}/unit`;
+  return `${label} ${value}`;
+}
+
+type PricingRulesContextValue = {
+  fields: PricingField[];
+  actions: PricingAction[];
+  value: PricingRule[];
+  createId: () => string;
+  add: () => void;
+  update: (id: string, patch: Partial<Omit<PricingRule, "id">>) => void;
+  remove: (id: string) => void;
+};
+
+const PricingRulesContext =
+  React.createContext<PricingRulesContextValue | null>(null);
+
+function usePricingRules(): PricingRulesContextValue {
+  const context = React.useContext(PricingRulesContext);
+  if (!context) {
+    throw new Error(
+      "PricingRules compound parts must be used inside <PricingRules>.",
+    );
+  }
+  return context;
+}
+
+function usePricingRule(): PricingRule {
+  const rule = React.useContext(PricingRuleContext);
+  if (!rule) {
+    throw new Error(
+      "PricingRule parts must be used inside <PricingRule>.",
+    );
+  }
+  return rule;
+}
+
+const PricingRuleContext = React.createContext<PricingRule | null>(null);
+
+type PricingRulesProps = Omit<
+  React.ComponentProps<"div">,
+  "onChange" | "defaultValue"
+> & {
+  /** Condition fields a rule can target. `operators` overrides the default operator list per field. */
+  fields?: PricingField[];
+  /** Price actions a rule can apply. `unit` decorates the action value in the summary chip. */
+  actions?: PricingAction[];
+  /** Controlled list of rules. */
+  value?: PricingRule[];
+  /** Initial rules for an uncontrolled builder. */
+  defaultValue?: PricingRule[];
+  /** Called whenever the rule list changes. */
+  onValueChange?: (value: PricingRule[]) => void;
+};
+
+function PricingRules({
+  fields = DEFAULT_FIELDS,
+  actions = DEFAULT_ACTIONS,
+  value: valueProp,
+  defaultValue,
+  onValueChange,
+  className,
+  children,
+  ...props
+}: PricingRulesProps) {
+  const idPrefix = React.useId();
+  const counter = React.useRef(0);
+
+  const createId = React.useCallback(() => {
+    if (
+      typeof crypto !== "undefined" &&
+      typeof crypto.randomUUID === "function"
+    ) {
+      return crypto.randomUUID();
+    }
+    counter.current += 1;
+    return `${idPrefix}rule-${counter.current}`;
+  }, [idPrefix]);
+
+  const [internalValue, setInternalValue] = React.useState<PricingRule[]>(
+    defaultValue ?? [],
+  );
+  const value = valueProp ?? internalValue;
+
+  const setValue = React.useCallback(
+    (next: PricingRule[]) => {
+      if (valueProp === undefined) setInternalValue(next);
+      onValueChange?.(next);
+    },
+    [valueProp, onValueChange],
+  );
+
+  const add = React.useCallback(() => {
+    const field = fields[0]?.name ?? "";
+    const operator = operatorsFor(fields, field)[0] ?? "";
+    const action = actions[0]?.name ?? "";
+    const rule: PricingRule = {
+      id: createId(),
+      field,
+      operator,
+      value: "",
+      action,
+      actionValue: "",
+    };
+    setValue([...value, rule]);
+  }, [actions, createId, fields, setValue, value]);
+
+  const update = React.useCallback(
+    (id: string, patch: Partial<Omit<PricingRule, "id">>) => {
+      setValue(
+        value.map((rule) =>
+          rule.id === id ? { ...rule, ...patch } : rule,
+        ),
+      );
+    },
+    [setValue, value],
+  );
+
+  const remove = React.useCallback(
+    (id: string) => {
+      setValue(value.filter((rule) => rule.id !== id));
+    },
+    [setValue, value],
+  );
+
+  const context = React.useMemo<PricingRulesContextValue>(
+    () => ({ fields, actions, value, createId, add, update, remove }),
+    [fields, actions, value, createId, add, update, remove],
+  );
+
+  return (
+    <PricingRulesContext.Provider value={context}>
+      <div
+        data-slot="pricing-rules"
+        className={cn("flex w-full flex-col gap-3", className)}
+        {...props}
+      >
+        {children}
+      </div>
+    </PricingRulesContext.Provider>
+  );
+}
+
+type PricingRuleProps = React.ComponentProps<"div"> & {
+  /** The rule this row renders. */
+  rule: PricingRule;
+  /** Order in which the rule is evaluated, shown as an ordinal. Rules apply top-down. */
+  index?: number;
+};
+
+function PricingRule({
+  rule,
+  index,
+  className,
+  children,
+  ...props
+}: PricingRuleProps) {
+  const { remove } = usePricingRules();
+
+  return (
+    <PricingRuleContext.Provider value={rule}>
+      <div
+        data-slot="pricing-rule"
+        className={cn(
+          "rounded-md border border-border bg-card/40 p-3",
+          className,
+        )}
+        {...props}
+      >
+        <div
+          data-slot="pricing-rule-header"
+          className="flex flex-wrap items-center gap-2"
+        >
+          {typeof index === "number" ? (
+            <Badge
+              variant="outline"
+              data-slot="pricing-rule-ordinal"
+              className="font-mono text-[0.625rem] tabular-nums"
+              aria-label={`Rule ${index + 1}, evaluated top to bottom`}
+            >
+              {index + 1}
+            </Badge>
+          ) : null}
+          <PricingRuleSummary />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            data-slot="pricing-rule-remove"
+            aria-label="Remove rule"
+            onClick={() => remove(rule.id)}
+            className="ms-auto text-muted-foreground hover:text-destructive"
+          >
+            <X />
+          </Button>
+        </div>
+
+        {children ?? (
+          <div
+            data-slot="pricing-rule-body"
+            className="mt-3 flex flex-col gap-2"
+          >
+            <PricingRuleCondition />
+            <PricingRuleAction />
+          </div>
+        )}
+      </div>
+    </PricingRuleContext.Provider>
+  );
+}
+
+type PricingRuleConditionProps = Omit<
+  React.ComponentProps<"div">,
+  "children"
+> & {
+  /** Label shown before the condition controls. */
+  label?: React.ReactNode;
+};
+
+function PricingRuleCondition({
+  label = "When",
+  className,
+  ...props
+}: PricingRuleConditionProps) {
+  const { fields, update } = usePricingRules();
+  const rule = usePricingRule();
+  const operators = operatorsFor(fields, rule.field);
+
+  return (
+    <div
+      data-slot="pricing-rule-condition"
+      className={cn("flex flex-wrap items-center gap-2", className)}
+      {...props}
+    >
+      <span className="text-xs font-medium text-muted-foreground">{label}</span>
+
+      <Select
+        value={rule.field}
+        onValueChange={(field) => {
+          const nextOperators = operatorsFor(fields, field);
+          const operator = nextOperators.includes(rule.operator)
+            ? rule.operator
+            : (nextOperators[0] ?? "");
+          update(rule.id, { field, operator });
+        }}
+      >
+        <SelectTrigger
+          size="sm"
+          data-slot="pricing-rule-field"
+          className="w-40"
+          aria-label="Condition field"
+        >
+          <SelectValue placeholder="Field" />
+        </SelectTrigger>
+        <SelectContent>
+          {fields.map((field) => (
+            <SelectItem key={field.name} value={field.name}>
+              {field.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select
+        value={rule.operator}
+        onValueChange={(operator) => update(rule.id, { operator })}
+      >
+        <SelectTrigger
+          size="sm"
+          data-slot="pricing-rule-operator"
+          className="w-24"
+          aria-label="Condition operator"
+        >
+          <SelectValue placeholder="Is" />
+        </SelectTrigger>
+        <SelectContent>
+          {operators.map((operator) => (
+            <SelectItem key={operator} value={operator}>
+              {operator}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Input
+        data-slot="pricing-rule-value"
+        className="h-8 w-28 min-w-0 flex-1"
+        value={rule.value}
+        placeholder="Value"
+        aria-label="Condition value"
+        onChange={(event) => update(rule.id, { value: event.target.value })}
+      />
+    </div>
+  );
+}
+
+type PricingRuleActionProps = Omit<React.ComponentProps<"div">, "children"> & {
+  /** Label shown before the action controls. */
+  label?: React.ReactNode;
+};
+
+function PricingRuleAction({
+  label = "then",
+  className,
+  ...props
+}: PricingRuleActionProps) {
+  const { actions, update } = usePricingRules();
+  const rule = usePricingRule();
+  const action = actionFor(actions, rule.action);
+
+  return (
+    <div
+      data-slot="pricing-rule-action"
+      className={cn("flex flex-wrap items-center gap-2", className)}
+      {...props}
+    >
+      <span className="text-xs font-medium text-muted-foreground">{label}</span>
+
+      <Select
+        value={rule.action}
+        onValueChange={(next) => update(rule.id, { action: next })}
+      >
+        <SelectTrigger
+          size="sm"
+          data-slot="pricing-rule-action-type"
+          className="w-44"
+          aria-label="Price action"
+        >
+          <SelectValue placeholder="Action" />
+        </SelectTrigger>
+        <SelectContent>
+          {actions.map((item) => (
+            <SelectItem key={item.name} value={item.name}>
+              {item.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <div className="relative flex min-w-0 flex-1 items-center">
+        {action?.unit ? (
+          <span
+            data-slot="pricing-rule-action-unit"
+            className="pointer-events-none absolute start-3 text-sm text-muted-foreground"
+          >
+            {action.unit}
+          </span>
+        ) : null}
+        <Input
+          data-slot="pricing-rule-action-value"
+          inputMode="decimal"
+          className={cn("h-8 w-28 min-w-0 flex-1", action?.unit && "ps-7")}
+          value={rule.actionValue}
+          placeholder="Amount"
+          aria-label="Action value"
+          onChange={(event) =>
+            update(rule.id, { actionValue: event.target.value })
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+type PricingRuleSummaryProps = Omit<
+  React.ComponentProps<typeof Badge>,
+  "children"
+>;
+
+function PricingRuleSummary({ className, ...props }: PricingRuleSummaryProps) {
+  const { fields, actions } = usePricingRules();
+  const rule = usePricingRule();
+  const condition = summarizeCondition(fields, rule);
+  const result = summarizeAction(actions, rule);
+
+  return (
+    <Badge
+      variant="secondary"
+      data-slot="pricing-rule-summary"
+      className={cn("min-w-0 max-w-full gap-1.5 font-normal", className)}
+      {...props}
+    >
+      <span className="truncate font-medium text-foreground">{condition}</span>
+      <ArrowRight
+        className="size-3 shrink-0 text-muted-foreground rtl:rotate-180"
+        aria-hidden="true"
+      />
+      <span className="truncate">{result}</span>
+    </Badge>
+  );
+}
+
+type PricingRulesAddProps = React.ComponentProps<typeof Button>;
+
+function PricingRulesAdd({
+  className,
+  children,
+  onClick,
+  ...props
+}: PricingRulesAddProps) {
+  const { add } = usePricingRules();
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      data-slot="pricing-rules-add"
+      onClick={(event) => {
+        onClick?.(event);
+        if (event.defaultPrevented) return;
+        add();
+      }}
+      className={cn("w-fit", className)}
+      {...props}
+    >
+      <Plus />
+      {children ?? "Add rule"}
+    </Button>
+  );
+}
+
+export {
+  PricingRules,
+  PricingRule,
+  PricingRuleCondition,
+  PricingRuleAction,
+  PricingRuleSummary,
+  PricingRulesAdd,
+  DEFAULT_FIELDS,
+  DEFAULT_ACTIONS,
+};
+export type {
+  PricingRulesProps,
+  PricingRuleProps,
+  PricingRuleConditionProps,
+  PricingRuleActionProps,
+  PricingRuleSummaryProps,
+  PricingRulesAddProps,
+  PricingField,
+  PricingAction,
+};

--- a/registry/hirael/ui/prompt-editor.tsx
+++ b/registry/hirael/ui/prompt-editor.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const VARIABLE_RE = /\{\{\s*[\w.-]+\s*\}\}/g;
+
+type PromptEditorContextValue = {
+  value: string;
+  setValue: (next: string) => void;
+  disabled?: boolean;
+  fieldRef: React.RefObject<HTMLTextAreaElement | null>;
+  insertVariable: (name: string) => void;
+};
+
+const PromptEditorContext =
+  React.createContext<PromptEditorContextValue | null>(null);
+
+function usePromptEditor(part: string): PromptEditorContextValue {
+  const ctx = React.useContext(PromptEditorContext);
+  if (!ctx) {
+    throw new Error(`${part} must be used within <PromptEditor>.`);
+  }
+  return ctx;
+}
+
+type Segment = { text: string; variable: boolean };
+
+function segmentValue(value: string): Segment[] {
+  const segments: Segment[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  VARIABLE_RE.lastIndex = 0;
+  while ((m = VARIABLE_RE.exec(value)) !== null) {
+    if (m.index > last) {
+      segments.push({ text: value.slice(last, m.index), variable: false });
+    }
+    segments.push({ text: m[0], variable: true });
+    last = m.index + m[0].length;
+  }
+  if (last < value.length) {
+    segments.push({ text: value.slice(last), variable: false });
+  }
+  return segments;
+}
+
+export type PromptEditorProps = Omit<
+  React.ComponentProps<"div">,
+  "defaultValue" | "onChange"
+> & {
+  /** Controlled template text. Use with `onValueChange`. */
+  value?: string;
+  /** Initial template text when uncontrolled. */
+  defaultValue?: string;
+  /** Called with the next template text whenever it changes. */
+  onValueChange?: (value: string) => void;
+  /** Disable the field and variable chips. */
+  disabled?: boolean;
+};
+
+function PromptEditor({
+  value: valueProp,
+  defaultValue,
+  onValueChange,
+  disabled,
+  className,
+  ...props
+}: PromptEditorProps) {
+  const [internalValue, setInternalValue] = React.useState(defaultValue ?? "");
+  const value = valueProp ?? internalValue;
+  const fieldRef = React.useRef<HTMLTextAreaElement | null>(null);
+
+  const setValue = React.useCallback(
+    (next: string) => {
+      if (valueProp === undefined) setInternalValue(next);
+      onValueChange?.(next);
+    },
+    [valueProp, onValueChange],
+  );
+
+  const insertVariable = React.useCallback(
+    (name: string) => {
+      const token = `{{${name}}}`;
+      const ta = fieldRef.current;
+      const start = ta ? ta.selectionStart : value.length;
+      const end = ta ? ta.selectionEnd : value.length;
+      const next = value.slice(0, start) + token + value.slice(end);
+      setValue(next);
+      const caret = start + token.length;
+      requestAnimationFrame(() => {
+        const el = fieldRef.current;
+        if (!el) return;
+        el.focus();
+        el.setSelectionRange(caret, caret);
+      });
+    },
+    [value, setValue],
+  );
+
+  const ctx = React.useMemo<PromptEditorContextValue>(
+    () => ({ value, setValue, disabled, fieldRef, insertVariable }),
+    [value, setValue, disabled, insertVariable],
+  );
+
+  return (
+    <PromptEditorContext.Provider value={ctx}>
+      <div
+        data-slot="prompt-editor"
+        data-disabled={disabled || undefined}
+        className={cn(
+          "flex w-full flex-col rounded-md border border-border bg-card text-card-foreground shadow-xs",
+          "focus-within:border-ring focus-within:ring-1 focus-within:ring-ring",
+          "data-disabled:opacity-60",
+          className,
+        )}
+        {...props}
+      />
+    </PromptEditorContext.Provider>
+  );
+}
+
+export type PromptEditorToolbarProps = React.ComponentProps<"div">;
+
+function PromptEditorToolbar({
+  className,
+  ...props
+}: PromptEditorToolbarProps) {
+  return (
+    <div
+      data-slot="prompt-editor-toolbar"
+      className={cn(
+        "flex flex-wrap items-center gap-1 border-b border-border px-2 py-1.5",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export type PromptEditorFieldProps = Omit<
+  React.ComponentProps<"textarea">,
+  "value" | "defaultValue" | "onChange"
+> & {
+  /** Minimum number of visible text rows. */
+  rows?: number;
+};
+
+function PromptEditorField({
+  className,
+  rows = 6,
+  disabled: disabledProp,
+  onScroll,
+  ...props
+}: PromptEditorFieldProps) {
+  const { value, setValue, disabled, fieldRef } =
+    usePromptEditor("PromptEditorField");
+  const backdropRef = React.useRef<HTMLDivElement | null>(null);
+  const segments = React.useMemo(() => segmentValue(value), [value]);
+
+  const syncScroll = React.useCallback(() => {
+    const ta = fieldRef.current;
+    const backdrop = backdropRef.current;
+    if (!ta || !backdrop) return;
+    backdrop.scrollTop = ta.scrollTop;
+    backdrop.scrollLeft = ta.scrollLeft;
+  }, [fieldRef]);
+
+  React.useLayoutEffect(() => {
+    syncScroll();
+  }, [value, syncScroll]);
+
+  const metrics =
+    "w-full px-3 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words font-mono";
+
+  return (
+    <div data-slot="prompt-editor-field" className="relative w-full">
+      <div
+        ref={backdropRef}
+        aria-hidden
+        data-slot="prompt-editor-highlight"
+        className={cn(
+          metrics,
+          "pointer-events-none absolute inset-0 overflow-hidden text-transparent select-none",
+        )}
+      >
+        {segments.map((seg, i) =>
+          seg.variable ? (
+            <span
+              key={i}
+              data-slot="prompt-editor-token"
+              className="rounded-[3px] bg-primary/15 text-primary box-decoration-clone"
+            >
+              {seg.text}
+            </span>
+          ) : (
+            <span key={i}>{seg.text}</span>
+          ),
+        )}
+        {"​"}
+      </div>
+      <textarea
+        ref={fieldRef}
+        rows={rows}
+        value={value}
+        spellCheck={false}
+        disabled={disabledProp ?? disabled}
+        data-slot="prompt-editor-textarea"
+        onChange={(e) => setValue(e.target.value)}
+        onScroll={(e) => {
+          syncScroll();
+          onScroll?.(e);
+        }}
+        className={cn(
+          metrics,
+          "relative block resize-none bg-transparent text-foreground caret-foreground outline-none",
+          "placeholder:text-muted-foreground",
+          "disabled:cursor-not-allowed",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+export type PromptEditorVariablesProps = React.ComponentProps<"div"> & {
+  /** Heading text shown before the chips. */
+  label?: string;
+};
+
+function PromptEditorVariables({
+  className,
+  label,
+  children,
+  ...props
+}: PromptEditorVariablesProps) {
+  return (
+    <div
+      data-slot="prompt-editor-variables"
+      className={cn(
+        "flex flex-wrap items-center gap-1.5 border-t border-border px-3 py-2",
+        className,
+      )}
+      {...props}
+    >
+      {label ? (
+        <span className="me-1 text-xs text-muted-foreground">{label}</span>
+      ) : null}
+      {children}
+    </div>
+  );
+}
+
+export type PromptEditorVariableProps = Omit<
+  React.ComponentProps<"button">,
+  "value"
+> & {
+  /** Variable name inserted as `{{name}}` at the caret on click. */
+  name: string;
+};
+
+function PromptEditorVariable({
+  className,
+  name,
+  onClick,
+  disabled: disabledProp,
+  children,
+  ...props
+}: PromptEditorVariableProps) {
+  const { disabled, insertVariable } = usePromptEditor("PromptEditorVariable");
+  return (
+    <button
+      type="button"
+      data-slot="prompt-editor-variable"
+      disabled={disabledProp ?? disabled}
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={(e) => {
+        onClick?.(e);
+        if (!e.defaultPrevented) insertVariable(name);
+      }}
+      className={cn(
+        "inline-flex items-center rounded-sm border border-border bg-accent px-2 py-0.5 font-mono text-xs text-accent-foreground transition-colors",
+        "hover:border-primary/40 hover:bg-primary/10 hover:text-primary",
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        "disabled:pointer-events-none disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      {children ?? `{{${name}}}`}
+    </button>
+  );
+}
+
+export type PromptEditorFooterProps = React.ComponentProps<"div"> & {
+  /** Render custom footer content instead of the default counts. */
+  children?: React.ReactNode;
+};
+
+function PromptEditorFooter({
+  className,
+  children,
+  ...props
+}: PromptEditorFooterProps) {
+  const { value } = usePromptEditor("PromptEditorFooter");
+  const chars = value.length;
+  const tokens = Math.ceil(chars / 4);
+  return (
+    <div
+      data-slot="prompt-editor-footer"
+      className={cn(
+        "flex items-center justify-between gap-3 border-t border-border px-3 py-1.5 text-xs text-muted-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <span data-slot="prompt-editor-chars">{chars} chars</span>
+          <span data-slot="prompt-editor-tokens">~{tokens} tokens</span>
+        </>
+      )}
+    </div>
+  );
+}
+
+export {
+  PromptEditor,
+  PromptEditorToolbar,
+  PromptEditorField,
+  PromptEditorVariables,
+  PromptEditorVariable,
+  PromptEditorFooter,
+};

--- a/registry/hirael/ui/query-builder.tsx
+++ b/registry/hirael/ui/query-builder.tsx
@@ -1,0 +1,521 @@
+"use client";
+
+import * as React from "react";
+import { FolderPlus, Plus, Trash2, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/registry/hirael/ui/button";
+import { Input } from "@/registry/hirael/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/registry/hirael/ui/select";
+
+type QueryCombinatorValue = "and" | "or";
+
+type QueryRule = {
+  id: string;
+  field: string;
+  operator: string;
+  value: string;
+};
+
+type QueryGroupNode = {
+  id: string;
+  combinator: QueryCombinatorValue;
+  rules: QueryNode[];
+};
+
+type QueryNode = QueryGroupNode | QueryRule;
+
+type QueryField = {
+  name: string;
+  label: string;
+  operators?: string[];
+};
+
+const DEFAULT_OPERATORS = [
+  "is",
+  "is not",
+  "contains",
+  "before",
+  "after",
+  "greater than",
+  "less than",
+];
+
+function isGroupNode(node: QueryNode): node is QueryGroupNode {
+  return "combinator" in node;
+}
+
+function removeNode(group: QueryGroupNode, id: string): QueryGroupNode {
+  return {
+    ...group,
+    rules: group.rules
+      .filter((rule) => rule.id !== id)
+      .map((rule) => (isGroupNode(rule) ? removeNode(rule, id) : rule)),
+  };
+}
+
+function appendNode(
+  group: QueryGroupNode,
+  parentId: string,
+  child: QueryNode,
+): QueryGroupNode {
+  if (group.id === parentId) {
+    return { ...group, rules: [...group.rules, child] };
+  }
+  return {
+    ...group,
+    rules: group.rules.map((rule) =>
+      isGroupNode(rule) ? appendNode(rule, parentId, child) : rule,
+    ),
+  };
+}
+
+type QueryBuilderContextValue = {
+  fields: QueryField[];
+  rootId: string;
+  createId: () => string;
+  addRule: (parentId: string) => void;
+  addGroup: (parentId: string) => void;
+  removeRule: (id: string) => void;
+  updateRule: (id: string, patch: Partial<Omit<QueryRule, "id">>) => void;
+  setCombinator: (id: string, combinator: QueryCombinatorValue) => void;
+};
+
+const QueryBuilderContext =
+  React.createContext<QueryBuilderContextValue | null>(null);
+
+function useQueryBuilder(): QueryBuilderContextValue {
+  const context = React.useContext(QueryBuilderContext);
+  if (!context) {
+    throw new Error("QueryBuilder parts must be used within <QueryBuilder>.");
+  }
+  return context;
+}
+
+function operatorsForField(
+  fields: QueryField[],
+  fieldName: string,
+): string[] {
+  const field = fields.find((item) => item.name === fieldName);
+  return field?.operators ?? DEFAULT_OPERATORS;
+}
+
+type QueryBuilderProps = Omit<
+  React.ComponentProps<"div">,
+  "defaultValue" | "onChange"
+> & {
+  /** Selectable fields. Each field can carry its own operator list. */
+  fields: QueryField[];
+  /** Controlled root group. */
+  value?: QueryGroupNode;
+  /** Initial root group for uncontrolled use. */
+  defaultValue?: QueryGroupNode;
+  /** Called with the next root group whenever the tree changes. */
+  onValueChange?: (value: QueryGroupNode) => void;
+};
+
+function QueryBuilder({
+  fields,
+  value,
+  defaultValue,
+  onValueChange,
+  className,
+  ...props
+}: QueryBuilderProps) {
+  const idPrefix = React.useId();
+  const counter = React.useRef(0);
+
+  const createId = React.useCallback(() => {
+    if (
+      typeof crypto !== "undefined" &&
+      typeof crypto.randomUUID === "function"
+    ) {
+      return crypto.randomUUID();
+    }
+    counter.current += 1;
+    return `${idPrefix}node-${counter.current}`;
+  }, [idPrefix]);
+
+  const [uncontrolled, setUncontrolled] = React.useState<QueryGroupNode>(
+    () =>
+      defaultValue ?? {
+        id: `${idPrefix}root`,
+        combinator: "and",
+        rules: [],
+      },
+  );
+
+  const isControlled = value !== undefined;
+  const root = isControlled ? value : uncontrolled;
+
+  const commit = React.useCallback(
+    (next: QueryGroupNode) => {
+      if (!isControlled) setUncontrolled(next);
+      onValueChange?.(next);
+    },
+    [isControlled, onValueChange],
+  );
+
+  const addRule = React.useCallback(
+    (parentId: string) => {
+      const fallbackField = fields[0]?.name ?? "";
+      const child: QueryRule = {
+        id: createId(),
+        field: fallbackField,
+        operator: operatorsForField(fields, fallbackField)[0] ?? "",
+        value: "",
+      };
+      commit(appendNode(root, parentId, child));
+    },
+    [commit, createId, fields, root],
+  );
+
+  const addGroup = React.useCallback(
+    (parentId: string) => {
+      const child: QueryGroupNode = {
+        id: createId(),
+        combinator: "and",
+        rules: [],
+      };
+      commit(appendNode(root, parentId, child));
+    },
+    [commit, createId, root],
+  );
+
+  const removeRule = React.useCallback(
+    (id: string) => {
+      commit(removeNode(root, id));
+    },
+    [commit, root],
+  );
+
+  const updateRule = React.useCallback(
+    (id: string, patch: Partial<Omit<QueryRule, "id">>) => {
+      const apply = (group: QueryGroupNode): QueryGroupNode => ({
+        ...group,
+        rules: group.rules.map((rule) => {
+          if (rule.id === id && !isGroupNode(rule)) {
+            return { ...rule, ...patch };
+          }
+          return isGroupNode(rule) ? apply(rule) : rule;
+        }),
+      });
+      commit(apply(root));
+    },
+    [commit, root],
+  );
+
+  const setCombinator = React.useCallback(
+    (id: string, combinator: QueryCombinatorValue) => {
+      const apply = (group: QueryGroupNode): QueryGroupNode => ({
+        ...group,
+        combinator: group.id === id ? combinator : group.combinator,
+        rules: group.rules.map((rule) =>
+          isGroupNode(rule) ? apply(rule) : rule,
+        ),
+      });
+      commit(apply(root));
+    },
+    [commit, root],
+  );
+
+  const context = React.useMemo<QueryBuilderContextValue>(
+    () => ({
+      fields,
+      rootId: root.id,
+      createId,
+      addRule,
+      addGroup,
+      removeRule,
+      updateRule,
+      setCombinator,
+    }),
+    [
+      fields,
+      root.id,
+      createId,
+      addRule,
+      addGroup,
+      removeRule,
+      updateRule,
+      setCombinator,
+    ],
+  );
+
+  return (
+    <QueryBuilderContext.Provider value={context}>
+      <div
+        data-slot="query-builder"
+        className={cn("w-full text-sm text-foreground", className)}
+        {...props}
+      >
+        <QueryGroup node={root} />
+      </div>
+    </QueryBuilderContext.Provider>
+  );
+}
+
+type QueryGroupProps = Omit<React.ComponentProps<"div">, "children"> & {
+  /** The group node this part renders recursively. */
+  node: QueryGroupNode;
+};
+
+function QueryGroup({ node, className, ...props }: QueryGroupProps) {
+  const { rootId, addRule, addGroup, removeRule, setCombinator } =
+    useQueryBuilder();
+  const isRoot = node.id === rootId;
+
+  return (
+    <div
+      data-slot="query-group"
+      data-root={isRoot ? "" : undefined}
+      className={cn(
+        "rounded-md border border-border bg-card/40 p-3",
+        !isRoot && "bg-muted/30",
+        className,
+      )}
+      {...props}
+    >
+      <div
+        data-slot="query-group-header"
+        className="flex flex-wrap items-center gap-2"
+      >
+        <QueryCombinator
+          value={node.combinator}
+          onValueChange={(next) => setCombinator(node.id, next)}
+        />
+        <span className="text-xs text-muted-foreground">
+          Match {node.combinator === "and" ? "all" : "any"} of the following
+        </span>
+        {!isRoot ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className="ms-auto text-muted-foreground hover:text-destructive"
+            onClick={() => removeRule(node.id)}
+            aria-label="Remove group"
+          >
+            <Trash2 />
+          </Button>
+        ) : null}
+      </div>
+
+      <div
+        data-slot="query-group-body"
+        className={cn(
+          "mt-3 flex flex-col gap-2 border-s border-border ps-3",
+          node.rules.length === 0 && "border-dashed",
+        )}
+      >
+        {node.rules.length === 0 ? (
+          <p
+            data-slot="query-empty"
+            className="py-1 text-xs text-muted-foreground"
+          >
+            No rules yet.
+          </p>
+        ) : (
+          node.rules.map((rule) =>
+            isGroupNode(rule) ? (
+              <QueryGroup key={rule.id} node={rule} />
+            ) : (
+              <QueryRule key={rule.id} rule={rule} />
+            ),
+          )
+        )}
+      </div>
+
+      <div
+        data-slot="query-group-actions"
+        className="mt-3 flex flex-wrap gap-2"
+      >
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => addRule(node.id)}
+        >
+          <Plus />
+          Add rule
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => addGroup(node.id)}
+        >
+          <FolderPlus />
+          Add group
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+type QueryCombinatorProps = Omit<
+  React.ComponentProps<"div">,
+  "onChange" | "defaultValue"
+> & {
+  /** The active combinator. */
+  value: QueryCombinatorValue;
+  /** Called when a combinator is selected. */
+  onValueChange: (value: QueryCombinatorValue) => void;
+};
+
+function QueryCombinator({
+  value,
+  onValueChange,
+  className,
+  ...props
+}: QueryCombinatorProps) {
+  const options: QueryCombinatorValue[] = ["and", "or"];
+
+  return (
+    <div
+      data-slot="query-combinator"
+      role="group"
+      aria-label="Combinator"
+      className={cn(
+        "inline-flex items-center rounded-md border border-input p-0.5",
+        className,
+      )}
+      {...props}
+    >
+      {options.map((option) => {
+        const active = option === value;
+        return (
+          <button
+            key={option}
+            type="button"
+            data-slot="query-combinator-option"
+            data-state={active ? "active" : "inactive"}
+            aria-pressed={active}
+            onClick={() => onValueChange(option)}
+            className={cn(
+              "rounded-sm px-2.5 py-1 text-xs font-medium uppercase tracking-[0.06em] outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+              active
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {option}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+type QueryRuleProps = Omit<React.ComponentProps<"div">, "children"> & {
+  /** The rule node this part renders. */
+  rule: QueryRule;
+};
+
+function QueryRule({ rule, className, ...props }: QueryRuleProps) {
+  const { fields, removeRule, updateRule } = useQueryBuilder();
+  const operators = operatorsForField(fields, rule.field);
+
+  return (
+    <div
+      data-slot="query-rule"
+      className={cn(
+        "flex flex-wrap items-center gap-2 rounded-md border border-border bg-background p-2",
+        className,
+      )}
+      {...props}
+    >
+      <Select
+        value={rule.field}
+        onValueChange={(field) => {
+          const nextOperators = operatorsForField(fields, field);
+          const operator = nextOperators.includes(rule.operator)
+            ? rule.operator
+            : (nextOperators[0] ?? "");
+          updateRule(rule.id, { field, operator });
+        }}
+      >
+        <SelectTrigger
+          size="sm"
+          data-slot="query-rule-field"
+          className="w-36"
+          aria-label="Field"
+        >
+          <SelectValue placeholder="Field" />
+        </SelectTrigger>
+        <SelectContent>
+          {fields.map((field) => (
+            <SelectItem key={field.name} value={field.name}>
+              {field.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select
+        value={rule.operator}
+        onValueChange={(operator) => updateRule(rule.id, { operator })}
+      >
+        <SelectTrigger
+          size="sm"
+          data-slot="query-rule-operator"
+          className="w-36"
+          aria-label="Operator"
+        >
+          <SelectValue placeholder="Operator" />
+        </SelectTrigger>
+        <SelectContent>
+          {operators.map((operator) => (
+            <SelectItem key={operator} value={operator}>
+              {operator}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Input
+        data-slot="query-rule-value"
+        className="h-8 w-40 flex-1"
+        value={rule.value}
+        placeholder="Value"
+        aria-label="Value"
+        onChange={(event) => updateRule(rule.id, { value: event.target.value })}
+      />
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        className="ms-auto text-muted-foreground hover:text-destructive"
+        onClick={() => removeRule(rule.id)}
+        aria-label="Remove rule"
+      >
+        <X />
+      </Button>
+    </div>
+  );
+}
+
+export {
+  QueryBuilder,
+  QueryGroup,
+  QueryRule,
+  QueryCombinator,
+  DEFAULT_OPERATORS,
+};
+export type {
+  QueryBuilderProps,
+  QueryGroupProps,
+  QueryRuleProps,
+  QueryCombinatorProps,
+  QueryField,
+  QueryNode,
+  QueryGroupNode,
+  QueryCombinatorValue,
+};

--- a/registry/hirael/ui/rag-citations.tsx
+++ b/registry/hirael/ui/rag-citations.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import * as React from "react";
+import { ExternalLink } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type RagCitationsContextValue = {
+  activeIndex: number | null;
+  setActiveIndex: (index: number | null) => void;
+};
+
+const RagCitationsContext =
+  React.createContext<RagCitationsContextValue | null>(null);
+
+function useRagCitationsContext(component: string) {
+  const ctx = React.useContext(RagCitationsContext);
+  if (!ctx) {
+    throw new Error(`${component} must be used within <RagCitations>.`);
+  }
+  return ctx;
+}
+
+type RagCitationsProps = React.ComponentProps<"div">;
+
+function RagCitations({ className, children, ...props }: RagCitationsProps) {
+  const [activeIndex, setActiveIndex] = React.useState<number | null>(null);
+
+  const value = React.useMemo<RagCitationsContextValue>(
+    () => ({ activeIndex, setActiveIndex }),
+    [activeIndex],
+  );
+
+  return (
+    <RagCitationsContext.Provider value={value}>
+      <div
+        data-slot="rag-citations"
+        className={cn("flex flex-col gap-5", className)}
+        {...props}
+      >
+        {children}
+      </div>
+    </RagCitationsContext.Provider>
+  );
+}
+
+type RagCitationsAnswerProps = React.ComponentProps<"div">;
+
+function RagCitationsAnswer({ className, ...props }: RagCitationsAnswerProps) {
+  return (
+    <div
+      data-slot="rag-citations-answer"
+      className={cn(
+        "text-sm leading-relaxed text-foreground [&_p]:mb-3 [&_p:last-child]:mb-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type RagCitationMarkProps = Omit<React.ComponentProps<"button">, "children"> & {
+  /** Citation number, matching the source card with the same index. */
+  index: number;
+};
+
+function RagCitationMark({
+  index,
+  className,
+  onMouseEnter,
+  onMouseLeave,
+  onFocus,
+  onBlur,
+  ...props
+}: RagCitationMarkProps) {
+  const { activeIndex, setActiveIndex } = useRagCitationsContext(
+    "RagCitationMark",
+  );
+  const isActive = activeIndex === index;
+
+  return (
+    <sup className="ms-0.5 inline-block leading-none">
+      <button
+        type="button"
+        data-slot="rag-citation-mark"
+        data-active={isActive ? "" : undefined}
+        aria-label={`Source ${index}`}
+        className={cn(
+          "inline-flex min-w-4 items-center justify-center rounded-sm border px-1 align-baseline text-[10px] font-medium tabular-nums transition-colors",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cool",
+          isActive
+            ? "border-accent-cool bg-accent-cool/15 text-accent-cool"
+            : "border-border bg-muted text-muted-foreground hover:border-accent-cool/60 hover:text-foreground",
+          className,
+        )}
+        onMouseEnter={(event) => {
+          setActiveIndex(index);
+          onMouseEnter?.(event);
+        }}
+        onMouseLeave={(event) => {
+          setActiveIndex(null);
+          onMouseLeave?.(event);
+        }}
+        onFocus={(event) => {
+          setActiveIndex(index);
+          onFocus?.(event);
+        }}
+        onBlur={(event) => {
+          setActiveIndex(null);
+          onBlur?.(event);
+        }}
+        {...props}
+      >
+        {index}
+      </button>
+    </sup>
+  );
+}
+
+type RagCitationsSourcesProps = React.ComponentProps<"ol">;
+
+function RagCitationsSources({ className, ...props }: RagCitationsSourcesProps) {
+  return (
+    <ol
+      data-slot="rag-citations-sources"
+      className={cn("flex list-none flex-col gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+type RagCitationSourceProps = React.ComponentProps<"li"> & {
+  /** Citation number, matching the inline mark with the same index. */
+  index: number;
+};
+
+function RagCitationSource({
+  index,
+  className,
+  children,
+  onMouseEnter,
+  onMouseLeave,
+  ...props
+}: RagCitationSourceProps) {
+  const { activeIndex, setActiveIndex } = useRagCitationsContext(
+    "RagCitationSource",
+  );
+  const isActive = activeIndex === index;
+
+  return (
+    <li
+      data-slot="rag-citation-source"
+      data-active={isActive ? "" : undefined}
+      className={cn(
+        "group/source flex gap-3 rounded-md border bg-card p-3 transition-colors",
+        isActive
+          ? "border-accent-cool ring-1 ring-accent-cool"
+          : "border-border hover:border-accent-cool/50",
+        className,
+      )}
+      onMouseEnter={(event) => {
+        setActiveIndex(index);
+        onMouseEnter?.(event);
+      }}
+      onMouseLeave={(event) => {
+        setActiveIndex(null);
+        onMouseLeave?.(event);
+      }}
+      {...props}
+    >
+      <span
+        data-slot="rag-citation-source-index"
+        aria-hidden
+        className={cn(
+          "mt-0.5 inline-flex size-5 shrink-0 items-center justify-center rounded-sm border text-[10px] font-medium tabular-nums transition-colors",
+          isActive
+            ? "border-accent-cool bg-accent-cool/15 text-accent-cool"
+            : "border-border bg-muted text-muted-foreground",
+        )}
+      >
+        {index}
+      </span>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">{children}</div>
+    </li>
+  );
+}
+
+type RagCitationSourceTitleProps = React.ComponentProps<"p">;
+
+function RagCitationSourceTitle({
+  className,
+  ...props
+}: RagCitationSourceTitleProps) {
+  return (
+    <p
+      data-slot="rag-citation-source-title"
+      className={cn(
+        "text-sm font-medium leading-snug text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type RagCitationSourceSnippetProps = React.ComponentProps<"p">;
+
+function RagCitationSourceSnippet({
+  className,
+  ...props
+}: RagCitationSourceSnippetProps) {
+  return (
+    <p
+      data-slot="rag-citation-source-snippet"
+      className={cn(
+        "line-clamp-2 text-xs leading-relaxed text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type RagCitationSourceUrlProps = React.ComponentProps<"a">;
+
+function RagCitationSourceUrl({
+  className,
+  children,
+  ...props
+}: RagCitationSourceUrlProps) {
+  return (
+    <a
+      data-slot="rag-citation-source-url"
+      className={cn(
+        "inline-flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cool",
+        className,
+      )}
+      {...props}
+    >
+      <ExternalLink aria-hidden className="size-3 shrink-0" />
+      <span className="truncate">{children}</span>
+    </a>
+  );
+}
+
+type RagCitationScoreProps = React.ComponentProps<"span"> & {
+  /** Relevance score for the source, shown as a small chip. */
+  score: React.ReactNode;
+};
+
+function RagCitationScore({
+  score,
+  className,
+  ...props
+}: RagCitationScoreProps) {
+  return (
+    <span
+      data-slot="rag-citation-score"
+      className={cn(
+        "inline-flex shrink-0 items-center rounded-sm bg-muted px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {score}
+    </span>
+  );
+}
+
+export {
+  RagCitations,
+  RagCitationsAnswer,
+  RagCitationMark,
+  RagCitationsSources,
+  RagCitationSource,
+  RagCitationSourceTitle,
+  RagCitationSourceSnippet,
+  RagCitationSourceUrl,
+  RagCitationScore,
+};

--- a/registry/hirael/ui/release-notes.tsx
+++ b/registry/hirael/ui/release-notes.tsx
@@ -1,0 +1,224 @@
+import * as React from "react";
+import { Sparkles } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/registry/hirael/ui/badge";
+
+type ReleaseNotesProps = React.ComponentProps<"section"> & {
+  /** Version label shown as a badge in the default header, e.g. "v2.0". */
+  version?: React.ReactNode;
+  /** Release date shown beside the version, e.g. "June 18, 2026". */
+  date?: React.ReactNode;
+  /** Release title shown as the heading in the default header. */
+  title?: React.ReactNode;
+};
+
+function ReleaseNotes({
+  version,
+  date,
+  title,
+  className,
+  children,
+  ...props
+}: ReleaseNotesProps) {
+  const hasHeaderProps = version != null || date != null || title != null;
+
+  return (
+    <section
+      data-slot="release-notes"
+      className={cn(
+        "flex flex-col gap-6 rounded-lg border border-border bg-card p-6 text-card-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {hasHeaderProps ? (
+        <ReleaseNotesHeader version={version} date={date} title={title} />
+      ) : null}
+      {children}
+    </section>
+  );
+}
+
+type ReleaseNotesHeaderProps = React.ComponentProps<"header"> & {
+  version?: React.ReactNode;
+  date?: React.ReactNode;
+  title?: React.ReactNode;
+};
+
+function ReleaseNotesHeader({
+  version,
+  date,
+  title,
+  className,
+  children,
+  ...props
+}: ReleaseNotesHeaderProps) {
+  return (
+    <header
+      data-slot="release-notes-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    >
+      {version != null || date != null ? (
+        <div
+          data-slot="release-notes-meta"
+          className="flex items-center gap-2 text-xs text-muted-foreground"
+        >
+          {version != null ? (
+            <Badge data-slot="release-notes-version">{version}</Badge>
+          ) : null}
+          {date != null ? (
+            <span data-slot="release-notes-date">{date}</span>
+          ) : null}
+        </div>
+      ) : null}
+      {title != null ? (
+        <h2
+          data-slot="release-notes-title"
+          className="text-xl font-semibold tracking-tight text-foreground"
+        >
+          {title}
+        </h2>
+      ) : null}
+      {children}
+    </header>
+  );
+}
+
+type ReleaseNotesSummaryProps = React.ComponentProps<"p">;
+
+function ReleaseNotesSummary({ className, ...props }: ReleaseNotesSummaryProps) {
+  return (
+    <p
+      data-slot="release-notes-summary"
+      className={cn("text-sm leading-relaxed text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+type ReleaseNotesHighlightsProps = React.ComponentProps<"ul">;
+
+function ReleaseNotesHighlights({
+  className,
+  ...props
+}: ReleaseNotesHighlightsProps) {
+  return (
+    <ul
+      data-slot="release-notes-highlights"
+      className={cn("flex flex-col gap-4", className)}
+      {...props}
+    />
+  );
+}
+
+type ReleaseNotesHighlightProps = Omit<React.ComponentProps<"li">, "title"> & {
+  /** Optional leading icon. Defaults to a sparkles glyph. */
+  icon?: React.ElementType | React.ReactElement | false;
+  /** Short headline for the highlight. */
+  title: React.ReactNode;
+};
+
+function ReleaseNotesHighlight({
+  icon,
+  title,
+  className,
+  children,
+  ...props
+}: ReleaseNotesHighlightProps) {
+  const renderIcon = () => {
+    if (icon === false) return null;
+    if (React.isValidElement(icon)) return icon;
+    const IconComponent = (icon as React.ElementType | undefined) ?? Sparkles;
+    return <IconComponent className="size-4" aria-hidden />;
+  };
+
+  return (
+    <li
+      data-slot="release-notes-highlight"
+      className={cn("flex items-start gap-3", className)}
+      {...props}
+    >
+      {icon !== false ? (
+        <span
+          data-slot="release-notes-highlight-icon"
+          className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md bg-accent text-primary"
+        >
+          {renderIcon()}
+        </span>
+      ) : null}
+      <div className="flex flex-col gap-0.5">
+        <span
+          data-slot="release-notes-highlight-title"
+          className="text-sm font-medium leading-5 text-foreground"
+        >
+          {title}
+        </span>
+        {children ? (
+          <span
+            data-slot="release-notes-highlight-description"
+            className="text-sm leading-relaxed text-muted-foreground"
+          >
+            {children}
+          </span>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+type ReleaseNotesSectionProps = React.ComponentProps<"div"> & {
+  /** Label shown above the grouped content. */
+  label?: React.ReactNode;
+};
+
+function ReleaseNotesSection({
+  label,
+  className,
+  children,
+  ...props
+}: ReleaseNotesSectionProps) {
+  return (
+    <div
+      data-slot="release-notes-section"
+      className={cn("flex flex-col gap-3", className)}
+      {...props}
+    >
+      {label != null ? (
+        <p
+          data-slot="release-notes-section-label"
+          className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground"
+        >
+          {label}
+        </p>
+      ) : null}
+      {children}
+    </div>
+  );
+}
+
+type ReleaseNotesFooterProps = React.ComponentProps<"div">;
+
+function ReleaseNotesFooter({ className, ...props }: ReleaseNotesFooterProps) {
+  return (
+    <div
+      data-slot="release-notes-footer"
+      className={cn(
+        "flex flex-wrap items-center gap-2 border-t border-border pt-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  ReleaseNotes,
+  ReleaseNotesHeader,
+  ReleaseNotesSummary,
+  ReleaseNotesHighlights,
+  ReleaseNotesHighlight,
+  ReleaseNotesSection,
+  ReleaseNotesFooter,
+};

--- a/registry/hirael/ui/request-builder.tsx
+++ b/registry/hirael/ui/request-builder.tsx
@@ -1,0 +1,536 @@
+"use client";
+
+import * as React from "react";
+import { Plus, Send, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/registry/hirael/ui/button";
+import { Input } from "@/registry/hirael/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/registry/hirael/ui/select";
+import { TabsContent } from "@/registry/hirael/ui/tabs";
+
+type RequestMethodName = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+const METHODS: readonly RequestMethodName[] = [
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+];
+
+type RequestKeyValue = {
+  id: string;
+  name: string;
+  value: string;
+  enabled: boolean;
+};
+
+type RequestBuilderContextValue = {
+  method: RequestMethodName;
+  setMethod: (method: RequestMethodName) => void;
+  url: string;
+  setUrl: (url: string) => void;
+  body: string;
+  setBody: (body: string) => void;
+  createId: () => string;
+};
+
+const RequestBuilderContext =
+  React.createContext<RequestBuilderContextValue | null>(null);
+
+function useRequestBuilder() {
+  const context = React.useContext(RequestBuilderContext);
+  if (!context) {
+    throw new Error("RequestBuilder parts must be used within <RequestBuilder>.");
+  }
+  return context;
+}
+
+type RequestBuilderProps = React.ComponentProps<"div"> & {
+  /** Method selected when the builder first renders. */
+  defaultMethod?: RequestMethodName;
+  /** URL shown in the address input when the builder first renders. */
+  defaultUrl?: string;
+};
+
+function RequestBuilder({
+  defaultMethod = "GET",
+  defaultUrl = "",
+  className,
+  ...props
+}: RequestBuilderProps) {
+  const idPrefix = React.useId();
+  const counter = React.useRef(0);
+
+  const createId = React.useCallback(() => {
+    if (
+      typeof crypto !== "undefined" &&
+      typeof crypto.randomUUID === "function"
+    ) {
+      return crypto.randomUUID();
+    }
+    counter.current += 1;
+    return `${idPrefix}row-${counter.current}`;
+  }, [idPrefix]);
+
+  const [method, setMethod] = React.useState<RequestMethodName>(defaultMethod);
+  const [url, setUrl] = React.useState(defaultUrl);
+  const [body, setBody] = React.useState("");
+
+  const value = React.useMemo<RequestBuilderContextValue>(
+    () => ({ method, setMethod, url, setUrl, body, setBody, createId }),
+    [method, url, body, createId],
+  );
+
+  return (
+    <RequestBuilderContext.Provider value={value}>
+      <div
+        data-slot="request-builder"
+        className={cn(
+          "flex w-full flex-col gap-3 rounded-lg border border-border bg-card text-card-foreground",
+          className,
+        )}
+        {...props}
+      />
+    </RequestBuilderContext.Provider>
+  );
+}
+
+type RequestBarProps = React.ComponentProps<"div">;
+
+function RequestBar({ className, ...props }: RequestBarProps) {
+  return (
+    <div
+      data-slot="request-bar"
+      className={cn(
+        "flex flex-wrap items-center gap-2 border-b border-border p-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type RequestMethodProps = Omit<
+  React.ComponentProps<typeof SelectTrigger>,
+  "value" | "defaultValue" | "onValueChange"
+>;
+
+function RequestMethod({ className, ...props }: RequestMethodProps) {
+  const { method, setMethod } = useRequestBuilder();
+  return (
+    <Select
+      value={method}
+      onValueChange={(next) => setMethod(next as RequestMethodName)}
+    >
+      <SelectTrigger
+        data-slot="request-method"
+        aria-label="Request method"
+        className={cn("w-28 font-mono text-xs tracking-[0.08em]", className)}
+        {...props}
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {METHODS.map((name) => (
+          <SelectItem
+            key={name}
+            value={name}
+            className="font-mono text-xs tracking-[0.08em]"
+          >
+            {name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+type RequestUrlProps = Omit<
+  React.ComponentProps<typeof Input>,
+  "value" | "defaultValue" | "onChange"
+>;
+
+function RequestUrl({ className, ...props }: RequestUrlProps) {
+  const { url, setUrl } = useRequestBuilder();
+  return (
+    <Input
+      data-slot="request-url"
+      type="text"
+      inputMode="url"
+      autoComplete="off"
+      autoCorrect="off"
+      spellCheck={false}
+      aria-label="Request URL"
+      placeholder="https://api.example.com/v1/users"
+      value={url}
+      onChange={(event) => setUrl(event.target.value)}
+      className={cn("min-w-48 flex-1 font-mono text-xs", className)}
+      {...props}
+    />
+  );
+}
+
+type RequestSendProps = React.ComponentProps<typeof Button> & {
+  /** Show a busy state and disable the control while a request is in flight. */
+  pending?: boolean;
+};
+
+function RequestSend({
+  pending = false,
+  disabled,
+  className,
+  children,
+  ...props
+}: RequestSendProps) {
+  return (
+    <Button
+      type="button"
+      data-slot="request-send"
+      data-pending={pending ? "" : undefined}
+      disabled={disabled ?? pending}
+      className={cn(className)}
+      {...props}
+    >
+      <Send className={cn(pending && "animate-pulse")} aria-hidden />
+      {children ?? (pending ? "Sending" : "Send")}
+    </Button>
+  );
+}
+
+type RequestSectionProps = React.ComponentProps<typeof TabsContent>;
+
+function RequestSection({ className, ...props }: RequestSectionProps) {
+  return (
+    <TabsContent
+      data-slot="request-section"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+type RequestKeyValuesProps = Omit<
+  React.ComponentProps<"div">,
+  "onChange"
+> & {
+  /** The rows to render. Each needs a stable `id`. */
+  rows: RequestKeyValue[];
+  /** Called with the next rows whenever a value, toggle, add, or remove fires. */
+  onChange: (rows: RequestKeyValue[]) => void;
+  /** Label for the add-row button. */
+  addLabel?: string;
+  /** Placeholder for the key field. */
+  namePlaceholder?: string;
+  /** Placeholder for the value field. */
+  valuePlaceholder?: string;
+};
+
+function RequestKeyValues({
+  rows,
+  onChange,
+  addLabel = "Add row",
+  namePlaceholder = "Key",
+  valuePlaceholder = "Value",
+  className,
+  ...props
+}: RequestKeyValuesProps) {
+  const { createId } = useRequestBuilder();
+
+  const update = React.useCallback(
+    (id: string, patch: Partial<RequestKeyValue>) => {
+      onChange(rows.map((row) => (row.id === id ? { ...row, ...patch } : row)));
+    },
+    [onChange, rows],
+  );
+
+  const remove = React.useCallback(
+    (id: string) => {
+      onChange(rows.filter((row) => row.id !== id));
+    },
+    [onChange, rows],
+  );
+
+  const add = React.useCallback(() => {
+    onChange([
+      ...rows,
+      { id: createId(), name: "", value: "", enabled: true },
+    ]);
+  }, [createId, onChange, rows]);
+
+  return (
+    <div
+      data-slot="request-key-values"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    >
+      {rows.length === 0 ? (
+        <p
+          data-slot="request-key-values-empty"
+          className="px-1 py-2 text-xs text-muted-foreground"
+        >
+          No rows yet.
+        </p>
+      ) : (
+        rows.map((row) => (
+          <RequestKeyValueRow
+            key={row.id}
+            row={row}
+            namePlaceholder={namePlaceholder}
+            valuePlaceholder={valuePlaceholder}
+            onNameChange={(name) => update(row.id, { name })}
+            onValueChange={(value) => update(row.id, { value })}
+            onEnabledChange={(enabled) => update(row.id, { enabled })}
+            onRemove={() => remove(row.id)}
+          />
+        ))
+      )}
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={add}
+        className="self-start text-muted-foreground"
+      >
+        <Plus aria-hidden />
+        {addLabel}
+      </Button>
+    </div>
+  );
+}
+
+type RequestKeyValueRowProps = Omit<React.ComponentProps<"div">, "onChange"> & {
+  /** The row this control edits. */
+  row: RequestKeyValue;
+  onNameChange: (name: string) => void;
+  onValueChange: (value: string) => void;
+  onEnabledChange: (enabled: boolean) => void;
+  onRemove: () => void;
+  namePlaceholder?: string;
+  valuePlaceholder?: string;
+};
+
+function RequestKeyValueRow({
+  row,
+  onNameChange,
+  onValueChange,
+  onEnabledChange,
+  onRemove,
+  namePlaceholder = "Key",
+  valuePlaceholder = "Value",
+  className,
+  ...props
+}: RequestKeyValueRowProps) {
+  return (
+    <div
+      data-slot="request-key-value-row"
+      data-enabled={row.enabled ? "" : undefined}
+      className={cn(
+        "flex items-center gap-2 data-[enabled]:opacity-100",
+        !row.enabled && "opacity-60",
+        className,
+      )}
+      {...props}
+    >
+      <input
+        type="checkbox"
+        data-slot="request-key-value-toggle"
+        checked={row.enabled}
+        onChange={(event) => onEnabledChange(event.target.checked)}
+        aria-label={
+          row.name ? `Enable ${row.name}` : "Enable row"
+        }
+        className="size-4 shrink-0 rounded-sm border border-input bg-transparent accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+      />
+      <Input
+        type="text"
+        data-slot="request-key-value-name"
+        value={row.name}
+        onChange={(event) => onNameChange(event.target.value)}
+        placeholder={namePlaceholder}
+        autoComplete="off"
+        spellCheck={false}
+        className="h-8 flex-1 font-mono text-xs"
+      />
+      <Input
+        type="text"
+        data-slot="request-key-value-value"
+        value={row.value}
+        onChange={(event) => onValueChange(event.target.value)}
+        placeholder={valuePlaceholder}
+        autoComplete="off"
+        spellCheck={false}
+        className="h-8 flex-1 font-mono text-xs"
+      />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        onClick={onRemove}
+        aria-label={row.name ? `Remove ${row.name}` : "Remove row"}
+        className="shrink-0 text-muted-foreground"
+      >
+        <X aria-hidden />
+      </Button>
+    </div>
+  );
+}
+
+type RequestBodyProps = Omit<
+  React.ComponentProps<"textarea">,
+  "value" | "defaultValue" | "onChange"
+>;
+
+function RequestBody({ className, rows = 6, ...props }: RequestBodyProps) {
+  const { body, setBody } = useRequestBuilder();
+  return (
+    <textarea
+      data-slot="request-body"
+      value={body}
+      onChange={(event) => setBody(event.target.value)}
+      rows={rows}
+      spellCheck={false}
+      placeholder={'{\n  "key": "value"\n}'}
+      aria-label="Request body"
+      className={cn(
+        "w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs leading-relaxed text-foreground shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type RequestResponseProps = React.ComponentProps<"div"> & {
+  /** Response time, formatted by the caller (for example "142 ms"). */
+  time?: React.ReactNode;
+  /** Response size, formatted by the caller (for example "1.2 KB"). */
+  size?: React.ReactNode;
+};
+
+function RequestResponse({
+  time,
+  size,
+  className,
+  children,
+  ...props
+}: RequestResponseProps) {
+  const hasMeta = time != null || size != null;
+  return (
+    <div
+      data-slot="request-response"
+      className={cn(
+        "flex flex-col gap-2 border-t border-border p-3",
+        className,
+      )}
+      {...props}
+    >
+      {hasMeta ? (
+        <div
+          data-slot="request-response-meta"
+          className="flex flex-wrap items-center gap-x-4 gap-y-1 font-mono text-[11px] text-muted-foreground"
+        >
+          {children}
+          <span className="ms-auto flex items-center gap-x-4">
+            {time != null ? (
+              <span data-slot="request-response-time">{time}</span>
+            ) : null}
+            {size != null ? (
+              <span data-slot="request-response-size">{size}</span>
+            ) : null}
+          </span>
+        </div>
+      ) : (
+        children
+      )}
+    </div>
+  );
+}
+
+type RequestStatusProps = React.ComponentProps<"span"> & {
+  /** HTTP status code. 2xx/3xx read as success, 4xx/5xx as error. */
+  status: number;
+};
+
+const STATUS_TEXT: Record<number, string> = {
+  200: "OK",
+  201: "Created",
+  202: "Accepted",
+  204: "No Content",
+  301: "Moved Permanently",
+  302: "Found",
+  304: "Not Modified",
+  400: "Bad Request",
+  401: "Unauthorized",
+  403: "Forbidden",
+  404: "Not Found",
+  409: "Conflict",
+  422: "Unprocessable Entity",
+  429: "Too Many Requests",
+  500: "Internal Server Error",
+  502: "Bad Gateway",
+  503: "Service Unavailable",
+};
+
+function RequestStatus({ status, className, children, ...props }: RequestStatusProps) {
+  const isError = status >= 400;
+  const label = STATUS_TEXT[status];
+  return (
+    <span
+      data-slot="request-status"
+      data-tone={isError ? "error" : "success"}
+      className={cn(
+        "inline-flex shrink-0 items-center rounded-sm border px-1.5 py-0.5 font-mono text-[11px] leading-none",
+        isError
+          ? "border-destructive/30 text-destructive"
+          : "border-primary/30 text-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {children ?? (
+        <>
+          {status}
+          {label ? <span className="ms-1.5 opacity-70">{label}</span> : null}
+        </>
+      )}
+    </span>
+  );
+}
+
+function RequestBodyPre({ className, ...props }: React.ComponentProps<"pre">) {
+  return (
+    <pre
+      data-slot="request-response-body"
+      className={cn(
+        "overflow-x-auto rounded-md border border-border bg-muted/30 p-3 font-mono text-xs leading-relaxed text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  RequestBuilder,
+  RequestBar,
+  RequestMethod,
+  RequestUrl,
+  RequestSend,
+  RequestSection,
+  RequestKeyValues,
+  RequestKeyValueRow,
+  RequestBody,
+  RequestBodyPre,
+  RequestResponse,
+  RequestStatus,
+  type RequestKeyValue,
+  type RequestMethodName,
+};

--- a/registry/hirael/ui/review-queue.tsx
+++ b/registry/hirael/ui/review-queue.tsx
@@ -1,0 +1,378 @@
+"use client";
+
+import * as React from "react";
+import { Check, Inbox, SkipForward, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/registry/hirael/ui/badge";
+import { Button } from "@/registry/hirael/ui/button";
+import { KbdDisplay, KbdGroup } from "@/registry/hirael/ui/kbd";
+
+type ReviewDecision = "approve" | "reject" | "skip";
+
+type ReviewQueueItemData = {
+  id: string;
+};
+
+type ReviewQueueContextValue = {
+  total: number;
+  index: number;
+  remaining: number;
+  current: ReviewQueueItemData | null;
+  isDone: boolean;
+  decide: (decision: ReviewDecision) => void;
+};
+
+const ReviewQueueContext =
+  React.createContext<ReviewQueueContextValue | null>(null);
+
+function useReviewQueue() {
+  const ctx = React.useContext(ReviewQueueContext);
+  if (!ctx) {
+    throw new Error("Review queue parts must be used inside <ReviewQueue>");
+  }
+  return ctx;
+}
+
+type ReviewQueueProps<TItem extends ReviewQueueItemData> =
+  React.ComponentProps<"div"> & {
+    /** The items waiting for a decision, in queue order. */
+    items: readonly TItem[];
+    /** Called when the focused item is approved, rejected, or skipped. */
+    onDecision?: (id: string, decision: ReviewDecision) => void;
+  };
+
+function ReviewQueue<TItem extends ReviewQueueItemData>({
+  items,
+  onDecision,
+  className,
+  children,
+  onKeyDown,
+  ...props
+}: ReviewQueueProps<TItem>) {
+  const [index, setIndex] = React.useState(0);
+
+  const total = items.length;
+  const isDone = index >= total;
+  const current = isDone ? null : items[index];
+
+  const decide = React.useCallback(
+    (decision: ReviewDecision) => {
+      setIndex((prev) => {
+        if (prev >= items.length) return prev;
+        onDecision?.(items[prev].id, decision);
+        return prev + 1;
+      });
+    },
+    [items, onDecision],
+  );
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      onKeyDown?.(event);
+      if (event.defaultPrevented || isDone) return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+
+      const target = event.target as HTMLElement;
+      if (
+        target.isContentEditable ||
+        target.closest("input, textarea, select")
+      ) {
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+      if (key === "a") {
+        event.preventDefault();
+        decide("approve");
+      } else if (key === "r") {
+        event.preventDefault();
+        decide("reject");
+      } else if (
+        key === "s" ||
+        key === "j" ||
+        key === "k" ||
+        key === "arrowright" ||
+        key === "arrowleft"
+      ) {
+        event.preventDefault();
+        decide("skip");
+      }
+    },
+    [decide, isDone, onKeyDown],
+  );
+
+  const value = React.useMemo<ReviewQueueContextValue>(
+    () => ({
+      total,
+      index: Math.min(index, total),
+      remaining: Math.max(total - index, 0),
+      current,
+      isDone,
+      decide,
+    }),
+    [total, index, current, isDone, decide],
+  );
+
+  return (
+    <ReviewQueueContext.Provider value={value}>
+      <div
+        data-slot="review-queue"
+        role="group"
+        aria-label="Review queue"
+        tabIndex={isDone ? -1 : 0}
+        onKeyDown={handleKeyDown}
+        className={cn(
+          "flex w-full flex-col gap-4 rounded-xl border border-border bg-card p-4 text-card-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </ReviewQueueContext.Provider>
+  );
+}
+
+type ReviewQueueItemProps<TItem extends ReviewQueueItemData> = Omit<
+  React.ComponentProps<"div">,
+  "children"
+> & {
+  /** Render the focused item. Not called while the queue is empty. */
+  children: (item: TItem) => React.ReactNode;
+};
+
+function ReviewQueueItem<TItem extends ReviewQueueItemData>({
+  className,
+  children,
+  ...props
+}: ReviewQueueItemProps<TItem>) {
+  const { current } = useReviewQueue();
+
+  if (!current) return null;
+
+  return (
+    <div
+      data-slot="review-queue-item"
+      className={cn(
+        "flex flex-col gap-3 rounded-lg border border-border bg-background p-4",
+        className,
+      )}
+      {...props}
+    >
+      {children(current as TItem)}
+    </div>
+  );
+}
+
+type ReviewQueueProgressProps = Omit<React.ComponentProps<"div">, "children"> & {
+  /** Render custom progress copy. Receives the 1-based position and total. */
+  children?: (position: number, total: number) => React.ReactNode;
+};
+
+function ReviewQueueProgress({
+  className,
+  children,
+  ...props
+}: ReviewQueueProgressProps) {
+  const { index, total } = useReviewQueue();
+  const position = Math.min(index + 1, total);
+  const pct = total === 0 ? 0 : Math.round((index / total) * 100);
+
+  return (
+    <div
+      data-slot="review-queue-progress"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    >
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span data-slot="review-queue-progress-label">
+          {children ? (
+            children(position, total)
+          ) : (
+            <>
+              Item {position} of {total}
+            </>
+          )}
+        </span>
+        <span
+          data-slot="review-queue-progress-value"
+          className="font-mono tabular-nums"
+        >
+          {pct}%
+        </span>
+      </div>
+      <div
+        data-slot="review-queue-progress-track"
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={total}
+        aria-valuenow={index}
+        className="h-1.5 overflow-hidden rounded-full bg-muted"
+      >
+        <div
+          data-slot="review-queue-progress-fill"
+          className="h-full rounded-full bg-primary transition-[width] duration-300 ease-out"
+          style={{ inlineSize: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+type ReviewQueueActionsProps = Omit<React.ComponentProps<"div">, "children"> & {
+  /** Label for the approve button. Defaults to "Approve". */
+  approveLabel?: React.ReactNode;
+  /** Label for the reject button. Defaults to "Reject". */
+  rejectLabel?: React.ReactNode;
+  /** Label for the skip button. Defaults to "Skip". */
+  skipLabel?: React.ReactNode;
+};
+
+function ReviewQueueActions({
+  approveLabel = "Approve",
+  rejectLabel = "Reject",
+  skipLabel = "Skip",
+  className,
+  ...props
+}: ReviewQueueActionsProps) {
+  const { decide, isDone } = useReviewQueue();
+
+  return (
+    <div
+      data-slot="review-queue-actions"
+      role="group"
+      aria-label="Review actions"
+      className={cn("flex flex-wrap items-center gap-2", className)}
+      {...props}
+    >
+      <Button
+        data-slot="review-queue-approve"
+        type="button"
+        variant="default"
+        aria-keyshortcuts="A"
+        onClick={() => decide("approve")}
+        disabled={isDone}
+        className="flex-1"
+      >
+        <Check aria-hidden />
+        {approveLabel}
+        <KbdDisplay className="ms-auto bg-primary-foreground/15 text-primary-foreground">
+          A
+        </KbdDisplay>
+      </Button>
+      <Button
+        data-slot="review-queue-reject"
+        type="button"
+        variant="destructive"
+        aria-keyshortcuts="R"
+        onClick={() => decide("reject")}
+        disabled={isDone}
+        className="flex-1"
+      >
+        <X aria-hidden />
+        {rejectLabel}
+        <KbdDisplay className="ms-auto bg-white/15 text-white">R</KbdDisplay>
+      </Button>
+      <Button
+        data-slot="review-queue-skip"
+        type="button"
+        variant="outline"
+        aria-keyshortcuts="S"
+        onClick={() => decide("skip")}
+        disabled={isDone}
+      >
+        <SkipForward aria-hidden className="rtl:rotate-180" />
+        {skipLabel}
+        <KbdGroup className="ms-1">
+          <KbdDisplay>S</KbdDisplay>
+        </KbdGroup>
+      </Button>
+    </div>
+  );
+}
+
+type ReviewQueueEmptyProps = React.ComponentProps<"div"> & {
+  /** Hide the empty state while items remain. Defaults to true. */
+  whenDone?: boolean;
+};
+
+function ReviewQueueEmpty({
+  whenDone = true,
+  className,
+  children,
+  ...props
+}: ReviewQueueEmptyProps) {
+  const { isDone, total } = useReviewQueue();
+
+  if (whenDone && !isDone) return null;
+
+  return (
+    <div
+      data-slot="review-queue-empty"
+      role="status"
+      className={cn(
+        "flex flex-col items-center gap-3 rounded-lg border border-dashed border-border bg-background px-6 py-12 text-center",
+        className,
+      )}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <span
+            aria-hidden
+            data-slot="review-queue-empty-icon"
+            className="inline-flex size-10 items-center justify-center rounded-full bg-muted text-muted-foreground [&_svg]:size-5"
+          >
+            <Inbox />
+          </span>
+          <div className="flex flex-col gap-1">
+            <p className="text-sm font-medium text-foreground">Queue cleared</p>
+            <p className="text-sm text-muted-foreground">
+              {total === 0
+                ? "Nothing to review right now."
+                : `You reviewed all ${total} items.`}
+            </p>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+type ReviewQueueRemainingProps = Omit<
+  React.ComponentProps<typeof Badge>,
+  "children"
+> & {
+  /** Render custom copy. Receives the number of items still to review. */
+  children?: (remaining: number) => React.ReactNode;
+};
+
+function ReviewQueueRemaining({
+  className,
+  children,
+  variant = "secondary",
+  ...props
+}: ReviewQueueRemainingProps) {
+  const { remaining } = useReviewQueue();
+
+  return (
+    <Badge
+      data-slot="review-queue-remaining"
+      variant={variant}
+      className={cn("tabular-nums", className)}
+      {...props}
+    >
+      {children ? children(remaining) : `${remaining} left`}
+    </Badge>
+  );
+}
+
+export {
+  ReviewQueue,
+  ReviewQueueItem,
+  ReviewQueueProgress,
+  ReviewQueueActions,
+  ReviewQueueEmpty,
+  ReviewQueueRemaining,
+};

--- a/registry/hirael/ui/role-manager.tsx
+++ b/registry/hirael/ui/role-manager.tsx
@@ -1,0 +1,547 @@
+"use client";
+
+import * as React from "react";
+import { Plus, Copy, Trash2, Shield, Users } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/registry/hirael/ui/badge";
+import { Button } from "@/registry/hirael/ui/button";
+import { Checkbox } from "@/registry/hirael/ui/checkbox";
+
+export type Role = {
+  id: string;
+  name: string;
+  description?: string;
+  members?: number;
+  system?: boolean;
+  permissions: string[];
+};
+
+type Permission = { id: string; label: string; group?: string };
+
+type RoleManagerContextValue = {
+  roles: Role[];
+  permissions: Permission[];
+  selectedId: string | null;
+  selectedRole: Role | null;
+  select: (id: string) => void;
+  addRole: () => void;
+  duplicateRole: (id: string) => void;
+  deleteRole: (id: string) => void;
+  togglePermission: (roleId: string, permissionId: string, on: boolean) => void;
+  baseId: string;
+};
+
+const RoleManagerContext =
+  React.createContext<RoleManagerContextValue | null>(null);
+
+function useRoleManager() {
+  const ctx = React.useContext(RoleManagerContext);
+  if (!ctx) {
+    throw new Error(
+      "RoleManager compound parts must be used inside <RoleManager>",
+    );
+  }
+  return ctx;
+}
+
+export type RoleManagerProps = Omit<
+  React.ComponentProps<"div">,
+  "onChange"
+> & {
+  /** Roles to administer. The first part holds the name, member count, and a System badge for built-in roles. */
+  roles: Role[];
+  /** Permissions offered in the detail checklist. Adjacent items sharing `group` render under one section header. */
+  permissions: Permission[];
+  /** Id of the role selected on first render. Falls back to the first role. */
+  defaultSelectedId?: string;
+  /** Called with the full role set whenever a role is added, duplicated, deleted, or its permissions change. */
+  onChange?: (roles: Role[]) => void;
+};
+
+function RoleManager({
+  roles: rolesProp,
+  permissions,
+  defaultSelectedId,
+  onChange,
+  className,
+  children,
+  ...props
+}: RoleManagerProps) {
+  const reactId = React.useId();
+  const counter = React.useRef(0);
+  const [roles, setRoles] = React.useState<Role[]>(rolesProp);
+  const [selectedId, setSelectedId] = React.useState<string | null>(
+    () => defaultSelectedId ?? rolesProp[0]?.id ?? null,
+  );
+
+  const commit = React.useCallback(
+    (next: Role[]) => {
+      setRoles(next);
+      onChange?.(next);
+    },
+    [onChange],
+  );
+
+  const select = React.useCallback((id: string) => {
+    setSelectedId(id);
+  }, []);
+
+  const makeId = React.useCallback(() => {
+    counter.current += 1;
+    return `${reactId}-role-${counter.current}`;
+  }, [reactId]);
+
+  const addRole = React.useCallback(() => {
+    const role: Role = {
+      id: makeId(),
+      name: "New role",
+      description: "",
+      members: 0,
+      permissions: [],
+    };
+    commit([...roles, role]);
+    setSelectedId(role.id);
+  }, [roles, commit, makeId]);
+
+  const duplicateRole = React.useCallback(
+    (id: string) => {
+      const source = roles.find((role) => role.id === id);
+      if (!source) return;
+      const copy: Role = {
+        ...source,
+        id: makeId(),
+        name: `${source.name} copy`,
+        members: 0,
+        system: false,
+        permissions: [...source.permissions],
+      };
+      const index = roles.findIndex((role) => role.id === id);
+      const next = [...roles];
+      next.splice(index + 1, 0, copy);
+      commit(next);
+      setSelectedId(copy.id);
+    },
+    [roles, commit, makeId],
+  );
+
+  const deleteRole = React.useCallback(
+    (id: string) => {
+      const target = roles.find((role) => role.id === id);
+      if (!target || target.system) return;
+      const index = roles.findIndex((role) => role.id === id);
+      const next = roles.filter((role) => role.id !== id);
+      commit(next);
+      setSelectedId((current) => {
+        if (current !== id) return current;
+        const fallback = next[index] ?? next[index - 1] ?? next[0];
+        return fallback?.id ?? null;
+      });
+    },
+    [roles, commit],
+  );
+
+  const togglePermission = React.useCallback(
+    (roleId: string, permissionId: string, on: boolean) => {
+      commit(
+        roles.map((role) => {
+          if (role.id !== roleId || role.system) return role;
+          const has = role.permissions.includes(permissionId);
+          if (on === has) return role;
+          return {
+            ...role,
+            permissions: on
+              ? [...role.permissions, permissionId]
+              : role.permissions.filter((id) => id !== permissionId),
+          };
+        }),
+      );
+    },
+    [roles, commit],
+  );
+
+  const selectedRole =
+    roles.find((role) => role.id === selectedId) ?? null;
+
+  const ctx = React.useMemo<RoleManagerContextValue>(
+    () => ({
+      roles,
+      permissions,
+      selectedId,
+      selectedRole,
+      select,
+      addRole,
+      duplicateRole,
+      deleteRole,
+      togglePermission,
+      baseId: reactId,
+    }),
+    [
+      roles,
+      permissions,
+      selectedId,
+      selectedRole,
+      select,
+      addRole,
+      duplicateRole,
+      deleteRole,
+      togglePermission,
+      reactId,
+    ],
+  );
+
+  return (
+    <RoleManagerContext.Provider value={ctx}>
+      <div
+        data-slot="role-manager"
+        className={cn(
+          "flex w-full flex-col overflow-hidden rounded-lg border border-border bg-card text-card-foreground sm:flex-row sm:divide-x sm:divide-border rtl:sm:divide-x-reverse",
+          className,
+        )}
+        {...props}
+      >
+        {children ?? (
+          <>
+            <div
+              data-slot="role-manager-aside"
+              className="flex w-full flex-col border-b border-border sm:w-64 sm:shrink-0 sm:border-b-0"
+            >
+              <RoleManagerToolbar />
+              <RoleList />
+            </div>
+            <RoleManagerDetail />
+          </>
+        )}
+      </div>
+    </RoleManagerContext.Provider>
+  );
+}
+
+export type RoleManagerToolbarProps = React.ComponentProps<"div">;
+
+function RoleManagerToolbar({
+  className,
+  children,
+  ...props
+}: RoleManagerToolbarProps) {
+  const { roles, addRole } = useRoleManager();
+  return (
+    <div
+      data-slot="role-manager-toolbar"
+      className={cn(
+        "flex items-center justify-between gap-2 border-b border-border px-3 py-2.5",
+        className,
+      )}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <span
+            data-slot="role-manager-toolbar-title"
+            className="text-sm font-medium text-foreground"
+          >
+            Roles
+            <span className="ms-1.5 text-muted-foreground tabular-nums">
+              {roles.length}
+            </span>
+          </span>
+          <Button
+            data-slot="role-manager-add"
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={addRole}
+          >
+            <Plus />
+            New
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}
+
+export type RoleListProps = React.ComponentProps<"ul">;
+
+function RoleList({ className, children, ...props }: RoleListProps) {
+  const { roles } = useRoleManager();
+  return (
+    <ul
+      data-slot="role-list"
+      className={cn("flex-1 overflow-y-auto p-1.5", className)}
+      {...props}
+    >
+      {children ??
+        roles.map((role) => <RoleItem key={role.id} role={role} />)}
+    </ul>
+  );
+}
+
+export type RoleItemProps = Omit<
+  React.ComponentProps<"li">,
+  "children" | "role"
+> & {
+  role: Role;
+};
+
+function RoleItem({ role, className, ...props }: RoleItemProps) {
+  const { selectedId, select } = useRoleManager();
+  const active = selectedId === role.id;
+  return (
+    <li data-slot="role-item" {...props}>
+      <button
+        type="button"
+        data-slot="role-item-trigger"
+        data-active={active || undefined}
+        aria-pressed={active}
+        onClick={() => select(role.id)}
+        className={cn(
+          "flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-start transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
+          active
+            ? "bg-accent text-accent-foreground"
+            : "text-foreground hover:bg-accent/50",
+          className,
+        )}
+      >
+        <Shield
+          aria-hidden
+          className={cn(
+            "size-4 shrink-0",
+            active ? "text-primary" : "text-muted-foreground",
+          )}
+        />
+        <span className="flex min-w-0 flex-1 flex-col">
+          <span
+            data-slot="role-item-name"
+            className="truncate text-sm font-medium"
+          >
+            {role.name}
+          </span>
+          <span
+            data-slot="role-item-meta"
+            className="flex items-center gap-1 text-xs text-muted-foreground"
+          >
+            <Users aria-hidden className="size-3" />
+            <span className="tabular-nums">{role.members ?? 0}</span>
+          </span>
+        </span>
+        {role.system ? (
+          <Badge
+            data-slot="role-item-system"
+            variant="secondary"
+            className="shrink-0"
+          >
+            System
+          </Badge>
+        ) : null}
+      </button>
+    </li>
+  );
+}
+
+export type RoleManagerDetailProps = React.ComponentProps<"div">;
+
+function RoleManagerDetail({
+  className,
+  children,
+  ...props
+}: RoleManagerDetailProps) {
+  const { selectedRole } = useRoleManager();
+  return (
+    <div
+      data-slot="role-manager-detail"
+      className={cn("flex min-w-0 flex-1 flex-col", className)}
+      {...props}
+    >
+      {children ??
+        (selectedRole ? (
+          <>
+            <div
+              data-slot="role-manager-detail-header"
+              className="flex items-start justify-between gap-3 border-b border-border px-5 py-4"
+            >
+              <div className="flex min-w-0 flex-col gap-1">
+                <div className="flex items-center gap-2">
+                  <h3
+                    data-slot="role-manager-detail-name"
+                    className="truncate text-base font-semibold text-foreground"
+                  >
+                    {selectedRole.name}
+                  </h3>
+                  {selectedRole.system ? (
+                    <Badge
+                      data-slot="role-manager-detail-system"
+                      variant="secondary"
+                    >
+                      System
+                    </Badge>
+                  ) : null}
+                </div>
+                {selectedRole.description ? (
+                  <p
+                    data-slot="role-manager-detail-description"
+                    className="text-sm text-muted-foreground"
+                  >
+                    {selectedRole.description}
+                  </p>
+                ) : null}
+              </div>
+              <RoleManagerDetailActions />
+            </div>
+            <RolePermissions />
+          </>
+        ) : (
+          <div
+            data-slot="role-manager-empty"
+            className="flex flex-1 items-center justify-center p-8 text-sm text-muted-foreground"
+          >
+            No role selected
+          </div>
+        ))}
+    </div>
+  );
+}
+
+export type RoleManagerDetailActionsProps = React.ComponentProps<"div">;
+
+function RoleManagerDetailActions({
+  className,
+  children,
+  ...props
+}: RoleManagerDetailActionsProps) {
+  const { selectedRole, duplicateRole, deleteRole } = useRoleManager();
+  if (!selectedRole) return null;
+  return (
+    <div
+      data-slot="role-manager-detail-actions"
+      className={cn("flex shrink-0 items-center gap-1", className)}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <Button
+            data-slot="role-manager-duplicate"
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => duplicateRole(selectedRole.id)}
+            aria-label={`Duplicate ${selectedRole.name}`}
+          >
+            <Copy />
+          </Button>
+          <Button
+            data-slot="role-manager-delete"
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => deleteRole(selectedRole.id)}
+            disabled={selectedRole.system}
+            aria-label={`Delete ${selectedRole.name}`}
+          >
+            <Trash2 />
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}
+
+export type RolePermissionsProps = React.ComponentProps<"div">;
+
+function RolePermissions({ className, ...props }: RolePermissionsProps) {
+  const { selectedRole, permissions, togglePermission, baseId } =
+    useRoleManager();
+
+  const grouped = React.useMemo(() => {
+    const sections: { group?: string; items: Permission[] }[] = [];
+    for (const permission of permissions) {
+      const last = sections[sections.length - 1];
+      if (last && last.group === permission.group) {
+        last.items.push(permission);
+      } else {
+        sections.push({ group: permission.group, items: [permission] });
+      }
+    }
+    return sections;
+  }, [permissions]);
+
+  if (!selectedRole) return null;
+  const readOnly = selectedRole.system === true;
+
+  return (
+    <div
+      data-slot="role-permissions"
+      className={cn("flex-1 overflow-y-auto p-5", className)}
+      {...props}
+    >
+      {readOnly ? (
+        <p
+          data-slot="role-permissions-readonly"
+          className="mb-4 text-xs text-muted-foreground"
+        >
+          System role. Permissions are read-only.
+        </p>
+      ) : null}
+      <div className="flex flex-col gap-5">
+        {grouped.map((section, index) => (
+          <div
+            key={section.group ?? `section-${index}`}
+            data-slot="role-permissions-group"
+            className="flex flex-col gap-2"
+          >
+            {section.group ? (
+              <p
+                data-slot="role-permissions-group-label"
+                className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground"
+              >
+                {section.group}
+              </p>
+            ) : null}
+            {section.items.map((permission) => {
+              const checkboxId = `${baseId}-${selectedRole.id}-${permission.id}`;
+              const checked = selectedRole.permissions.includes(permission.id);
+              return (
+                <label
+                  key={permission.id}
+                  data-slot="role-permission-item"
+                  htmlFor={checkboxId}
+                  className={cn(
+                    "flex items-center gap-2.5 text-sm text-foreground",
+                    readOnly && "cursor-not-allowed opacity-70",
+                  )}
+                >
+                  <Checkbox
+                    data-slot="role-permission-checkbox"
+                    id={checkboxId}
+                    checked={checked}
+                    disabled={readOnly}
+                    onCheckedChange={(next) =>
+                      togglePermission(
+                        selectedRole.id,
+                        permission.id,
+                        next === true,
+                      )
+                    }
+                  />
+                  <span data-slot="role-permission-label">
+                    {permission.label}
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export {
+  RoleManager,
+  RoleManagerToolbar,
+  RoleList,
+  RoleItem,
+  RoleManagerDetail,
+  RoleManagerDetailActions,
+  RolePermissions,
+};

--- a/registry/hirael/ui/shipment-tracker.tsx
+++ b/registry/hirael/ui/shipment-tracker.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import {
+  Check,
+  Clock,
+  MapPin,
+  Truck,
+  type LucideIcon,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type ShipmentOrientation = "horizontal" | "vertical";
+
+type ShipmentStatus = "complete" | "current" | "upcoming";
+
+const ShipmentOrientationContext =
+  React.createContext<ShipmentOrientation>("horizontal");
+
+function useShipmentOrientation() {
+  return React.useContext(ShipmentOrientationContext);
+}
+
+type ShipmentTrackerProps = React.ComponentProps<"div"> & {
+  /** Lays the stage stepper out along the inline axis or stacked vertically. Defaults to `horizontal`. */
+  orientation?: ShipmentOrientation;
+};
+
+function ShipmentTracker({
+  orientation = "horizontal",
+  className,
+  ...props
+}: ShipmentTrackerProps) {
+  return (
+    <ShipmentOrientationContext.Provider value={orientation}>
+      <div
+        data-slot="shipment-tracker"
+        data-orientation={orientation}
+        className={cn("flex w-full flex-col gap-6", className)}
+        {...props}
+      />
+    </ShipmentOrientationContext.Provider>
+  );
+}
+
+function ShipmentStages({ className, ...props }: React.ComponentProps<"ol">) {
+  const orientation = useShipmentOrientation();
+  return (
+    <ol
+      data-slot="shipment-stages"
+      data-orientation={orientation}
+      className={cn(
+        "flex",
+        orientation === "horizontal" ? "flex-row" : "flex-col",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const shipmentStageVariants = cva("group/stage relative flex", {
+  variants: {
+    orientation: {
+      horizontal: cn(
+        "min-w-0 flex-1 flex-col items-center gap-2 pt-7 text-center",
+        "before:absolute before:top-[11px] before:h-px before:bg-border",
+        "before:start-1/2 before:end-[-50%]",
+        "last:before:hidden",
+      ),
+      vertical: cn(
+        "items-start gap-3 pb-6 ps-9 last:pb-0",
+        "before:absolute before:start-[11px] before:top-7 before:bottom-0 before:w-px before:bg-border",
+        "last:before:hidden",
+      ),
+    },
+    status: {
+      complete: "before:bg-success/40",
+      current: "before:bg-border",
+      upcoming: "before:bg-border",
+    },
+  },
+  defaultVariants: {
+    orientation: "horizontal",
+    status: "upcoming",
+  },
+});
+
+const shipmentMarkerVariants = cva(
+  cn(
+    "z-10 inline-flex size-[22px] shrink-0 items-center justify-center rounded-full border bg-background [&_svg]:size-3",
+  ),
+  {
+    variants: {
+      orientation: {
+        horizontal: "absolute top-0",
+        vertical: "absolute start-0 top-0",
+      },
+      status: {
+        complete: "border-success/40 text-success",
+        current:
+          "border-accent-cool text-accent-cool shadow-[0_0_10px_1px_var(--accent-cool-glow)]",
+        upcoming: "border-border text-muted-foreground",
+      },
+    },
+    defaultVariants: {
+      orientation: "horizontal",
+      status: "upcoming",
+    },
+  },
+);
+
+const stageIcons: Record<ShipmentStatus, LucideIcon> = {
+  complete: Check,
+  current: Truck,
+  upcoming: Clock,
+};
+
+type ShipmentStageProps = Omit<React.ComponentProps<"li">, "title"> &
+  VariantProps<typeof shipmentStageVariants> & {
+    /** Progress of this stage. `current` reads as live (accent-cool, pulsing). */
+    status?: ShipmentStatus;
+    /** Short stage name, e.g. "Out for delivery". */
+    label?: React.ReactNode;
+    /** When the stage was reached. Omit for stages not yet hit. */
+    time?: React.ReactNode;
+    /** Replaces the default stage icon. */
+    icon?: React.ReactNode;
+  };
+
+function ShipmentStage({
+  status = "upcoming",
+  label,
+  time,
+  icon,
+  className,
+  children,
+  ...props
+}: ShipmentStageProps) {
+  const orientation = useShipmentOrientation();
+  const Icon = stageIcons[status];
+
+  return (
+    <li
+      data-slot="shipment-stage"
+      data-status={status}
+      data-orientation={orientation}
+      className={cn(
+        shipmentStageVariants({ orientation, status }),
+        className,
+      )}
+      {...props}
+    >
+      <span
+        data-slot="shipment-stage-marker"
+        data-status={status}
+        className={shipmentMarkerVariants({ orientation, status })}
+      >
+        {icon ?? <Icon aria-hidden />}
+        {status === "current" ? (
+          <span aria-hidden className="state-dot absolute -end-0.5 -top-0.5" />
+        ) : null}
+      </span>
+      <div
+        data-slot="shipment-stage-content"
+        className={cn(
+          "flex min-w-0 flex-col gap-0.5",
+          orientation === "horizontal" ? "items-center" : "items-start",
+        )}
+      >
+        {label != null ? (
+          <span
+            data-slot="shipment-stage-label"
+            className={cn(
+              "text-sm font-medium leading-snug",
+              status === "upcoming"
+                ? "text-muted-foreground"
+                : "text-foreground",
+            )}
+          >
+            {label}
+          </span>
+        ) : null}
+        {time != null ? (
+          <time
+            data-slot="shipment-stage-time"
+            className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground"
+          >
+            {time}
+          </time>
+        ) : null}
+        {children}
+      </div>
+    </li>
+  );
+}
+
+function ShipmentEvents({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="shipment-events"
+      className={cn("flex flex-col", className)}
+      {...props}
+    />
+  );
+}
+
+type ShipmentEventProps = React.ComponentProps<"li"> & {
+  /** When the event happened. */
+  time?: React.ReactNode;
+  /** Where the event happened. */
+  location?: React.ReactNode;
+  /** What happened. */
+  description?: React.ReactNode;
+  /** Replaces the default location marker icon. */
+  icon?: React.ReactNode;
+};
+
+function ShipmentEvent({
+  time,
+  location,
+  description,
+  icon,
+  className,
+  children,
+  ...props
+}: ShipmentEventProps) {
+  return (
+    <li
+      data-slot="shipment-event"
+      className={cn(
+        "group relative flex gap-3 pb-5 ps-9 last:pb-0",
+        "before:absolute before:start-[11px] before:top-7 before:bottom-0 before:w-px before:bg-border",
+        "last:before:hidden",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        data-slot="shipment-event-marker"
+        aria-hidden
+        className="absolute start-0 top-0 z-10 inline-flex size-[22px] shrink-0 items-center justify-center rounded-full border border-border bg-background text-muted-foreground [&_svg]:size-3"
+      >
+        {icon ?? <MapPin />}
+      </span>
+      <div
+        data-slot="shipment-event-content"
+        className="flex min-w-0 flex-1 flex-col gap-1"
+      >
+        <div
+          data-slot="shipment-event-meta"
+          className="flex flex-wrap items-center gap-x-2 gap-y-0.5 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground"
+        >
+          {time != null ? (
+            <time data-slot="shipment-event-time">{time}</time>
+          ) : null}
+          {location != null ? (
+            <span data-slot="shipment-event-location" className="text-foreground">
+              {location}
+            </span>
+          ) : null}
+        </div>
+        {description != null ? (
+          <p
+            data-slot="shipment-event-description"
+            className="text-[13px] leading-relaxed text-foreground"
+          >
+            {description}
+          </p>
+        ) : null}
+        {children}
+      </div>
+    </li>
+  );
+}
+
+export {
+  ShipmentTracker,
+  ShipmentStages,
+  ShipmentStage,
+  ShipmentEvents,
+  ShipmentEvent,
+};

--- a/registry/hirael/ui/spotlight-search.tsx
+++ b/registry/hirael/ui/spotlight-search.tsx
@@ -1,0 +1,653 @@
+"use client";
+
+import * as React from "react";
+import { ArrowDown, ArrowUp, CornerDownLeft, Search } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "@/registry/hirael/ui/dialog";
+import { Kbd, KbdGroup } from "@/registry/hirael/ui/kbd";
+
+type RegisteredItem = {
+  id: string;
+  value: string;
+  text: string;
+  onSelect?: () => void;
+};
+
+type SpotlightContextValue = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  query: string;
+  setQuery: (query: string) => void;
+  inputId: string;
+  listId: string;
+  activeId: string | null;
+  setActiveId: (id: string | null) => void;
+  matches: (value: string, text: string) => boolean;
+  register: (item: RegisteredItem) => () => void;
+  getItems: () => RegisteredItem[];
+  select: (item: RegisteredItem) => void;
+  version: number;
+  keyHandlerRef: React.RefObject<
+    ((event: React.KeyboardEvent) => void) | null
+  >;
+};
+
+const SpotlightContext = React.createContext<SpotlightContextValue | null>(
+  null,
+);
+
+function useSpotlight() {
+  const ctx = React.useContext(SpotlightContext);
+  if (!ctx) {
+    throw new Error(
+      "SpotlightSearch parts must be used inside <SpotlightSearch>",
+    );
+  }
+  return ctx;
+}
+
+type SpotlightGroupContextValue = {
+  reportVisible: (id: string, visible: boolean) => void;
+};
+
+const SpotlightGroupContext =
+  React.createContext<SpotlightGroupContextValue | null>(null);
+
+export type SpotlightSearchProps = React.ComponentProps<typeof Dialog> & {
+  /** Keyboard shortcut letter that opens the overlay with Ctrl/Cmd held, e.g. "k". Pass null to disable. */
+  shortcut?: string | null;
+};
+
+function SpotlightSearch({
+  open: openProp,
+  defaultOpen = false,
+  onOpenChange,
+  shortcut = "k",
+  children,
+  ...props
+}: SpotlightSearchProps) {
+  const [internalOpen, setInternalOpen] = React.useState(defaultOpen);
+  const open = openProp ?? internalOpen;
+
+  const [query, setQuery] = React.useState("");
+  const [activeId, setActiveId] = React.useState<string | null>(null);
+
+  const setOpen = React.useCallback(
+    (next: boolean) => {
+      if (openProp === undefined) setInternalOpen(next);
+      if (!next) setQuery("");
+      onOpenChange?.(next);
+    },
+    [openProp, onOpenChange],
+  );
+
+  const reactId = React.useId();
+  const inputId = `${reactId}-input`;
+  const listId = `${reactId}-list`;
+
+  const itemsRef = React.useRef<Map<string, RegisteredItem>>(new Map());
+  const orderRef = React.useRef<string[]>([]);
+  const keyHandlerRef = React.useRef<
+    ((event: React.KeyboardEvent) => void) | null
+  >(null);
+  const [version, setVersion] = React.useState(0);
+
+  const register = React.useCallback((item: RegisteredItem) => {
+    itemsRef.current.set(item.id, item);
+    if (!orderRef.current.includes(item.id)) {
+      orderRef.current.push(item.id);
+    }
+    setVersion((v) => v + 1);
+    return () => {
+      itemsRef.current.delete(item.id);
+      orderRef.current = orderRef.current.filter((id) => id !== item.id);
+      setVersion((v) => v + 1);
+    };
+  }, []);
+
+  const getItems = React.useCallback(
+    () =>
+      orderRef.current
+        .map((id) => itemsRef.current.get(id))
+        .filter((item): item is RegisteredItem => item !== undefined),
+    [],
+  );
+
+  const matches = React.useCallback((value: string, text: string) => {
+    const q = query.trim().toLowerCase();
+    if (q === "") return true;
+    return value.toLowerCase().includes(q) || text.toLowerCase().includes(q);
+  }, [query]);
+
+  const select = React.useCallback(
+    (item: RegisteredItem) => {
+      item.onSelect?.();
+      setOpen(false);
+    },
+    [setOpen],
+  );
+
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !shortcut) return;
+    const key = shortcut.toLowerCase();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() === key && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        setOpen(!open);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [shortcut, open, setOpen]);
+
+  const value = React.useMemo<SpotlightContextValue>(
+    () => ({
+      open,
+      setOpen,
+      query,
+      setQuery,
+      inputId,
+      listId,
+      activeId,
+      setActiveId,
+      matches,
+      register,
+      getItems,
+      select,
+      version,
+      keyHandlerRef,
+    }),
+    [
+      open,
+      setOpen,
+      query,
+      inputId,
+      listId,
+      activeId,
+      matches,
+      register,
+      getItems,
+      select,
+      version,
+    ],
+  );
+
+  return (
+    <SpotlightContext.Provider value={value}>
+      <Dialog open={open} onOpenChange={setOpen} {...props}>
+        {children}
+      </Dialog>
+    </SpotlightContext.Provider>
+  );
+}
+
+function SpotlightSearchTrigger(
+  props: React.ComponentProps<typeof DialogTrigger>,
+) {
+  return <DialogTrigger data-slot="spotlight-search-trigger" {...props} />;
+}
+
+export type SpotlightSearchInputProps = Omit<
+  React.ComponentProps<"input">,
+  "value" | "onChange"
+> & {
+  /** Label announced to assistive tech for the search field. */
+  label?: string;
+};
+
+function SpotlightSearchInput({
+  className,
+  label = "Search",
+  placeholder = "Search",
+  onKeyDown,
+  ...props
+}: SpotlightSearchInputProps) {
+  const { query, setQuery, inputId, listId, activeId, keyHandlerRef } =
+    useSpotlight();
+
+  return (
+    <div
+      data-slot="spotlight-search-input-wrapper"
+      className="flex items-center gap-3 border-b border-border px-5"
+    >
+      <Search
+        data-slot="spotlight-search-icon"
+        className="size-5 shrink-0 text-muted-foreground"
+        aria-hidden="true"
+      />
+      <input
+        id={inputId}
+        data-slot="spotlight-search-input"
+        type="text"
+        role="combobox"
+        aria-expanded
+        aria-controls={listId}
+        aria-activedescendant={activeId ?? undefined}
+        aria-label={label}
+        autoComplete="off"
+        autoCorrect="off"
+        spellCheck={false}
+        placeholder={placeholder}
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        onKeyDown={(event) => {
+          onKeyDown?.(event);
+          if (!event.defaultPrevented) keyHandlerRef.current?.(event);
+        }}
+        className={cn(
+          "h-14 w-full bg-transparent text-lg text-foreground outline-none placeholder:text-muted-foreground",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function SpotlightSearchResults({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div">) {
+  const {
+    listId,
+    activeId,
+    setActiveId,
+    getItems,
+    matches,
+    select,
+    version,
+    keyHandlerRef,
+  } = useSpotlight();
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  const visible = React.useCallback(
+    () => getItems().filter((item) => matches(item.value, item.text)),
+    [getItems, matches],
+  );
+
+  React.useEffect(() => {
+    const items = visible();
+    if (items.length === 0) {
+      if (activeId !== null) setActiveId(null);
+      return;
+    }
+    if (!activeId || !items.some((item) => item.id === activeId)) {
+      setActiveId(items[0].id);
+    }
+  }, [activeId, setActiveId, visible, version]);
+
+  React.useEffect(() => {
+    if (!activeId || !ref.current) return;
+    const el = ref.current.querySelector<HTMLElement>(
+      `[data-item-id="${CSS.escape(activeId)}"]`,
+    );
+    el?.scrollIntoView({ block: "nearest" });
+  }, [activeId]);
+
+  const navKeyDown = React.useCallback(
+    (event: React.KeyboardEvent) => {
+      const items = visible();
+      const move = (delta: number) => {
+        if (items.length === 0) return;
+        const current = items.findIndex((item) => item.id === activeId);
+        const base = current === -1 ? (delta > 0 ? -1 : 0) : current;
+        const next = (base + delta + items.length) % items.length;
+        setActiveId(items[next].id);
+      };
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault();
+          move(1);
+          break;
+        case "ArrowUp":
+          event.preventDefault();
+          move(-1);
+          break;
+        case "Enter": {
+          event.preventDefault();
+          const item = items.find((entry) => entry.id === activeId);
+          if (item) select(item);
+          break;
+        }
+      }
+    },
+    [visible, activeId, setActiveId, select],
+  );
+
+  React.useEffect(() => {
+    keyHandlerRef.current = navKeyDown;
+    return () => {
+      if (keyHandlerRef.current === navKeyDown) keyHandlerRef.current = null;
+    };
+  }, [navKeyDown, keyHandlerRef]);
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    navKeyDown(event);
+    if (event.defaultPrevented) return;
+    const items = visible();
+    switch (event.key) {
+      case "Home":
+        event.preventDefault();
+        if (items.length > 0) setActiveId(items[0].id);
+        break;
+      case "End":
+        event.preventDefault();
+        if (items.length > 0) setActiveId(items[items.length - 1].id);
+        break;
+    }
+  }
+
+  return (
+    <div
+      ref={ref}
+      id={listId}
+      data-slot="spotlight-search-results"
+      role="listbox"
+      aria-label="Search results"
+      onKeyDown={handleKeyDown}
+      className={cn(
+        "max-h-80 overflow-y-auto overscroll-contain p-2",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function SpotlightSearchGroup({
+  className,
+  heading,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & { heading?: React.ReactNode }) {
+  const [visibleIds, setVisibleIds] = React.useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const reportVisible = React.useCallback((id: string, visible: boolean) => {
+    setVisibleIds((prev) => {
+      const has = prev.has(id);
+      if (visible === has) return prev;
+      const next = new Set(prev);
+      if (visible) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  }, []);
+
+  const contextValue = React.useMemo<SpotlightGroupContextValue>(
+    () => ({ reportVisible }),
+    [reportVisible],
+  );
+
+  const hidden = visibleIds.size === 0;
+
+  return (
+    <SpotlightGroupContext.Provider value={contextValue}>
+      <div
+        data-slot="spotlight-search-group"
+        role="group"
+        hidden={hidden}
+        className={cn(hidden && "hidden", "py-1", className)}
+        {...props}
+      >
+        {heading != null ? (
+          <div
+            data-slot="spotlight-search-group-heading"
+            className="px-3 pb-1.5 pt-2 text-start font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground"
+          >
+            {heading}
+          </div>
+        ) : null}
+        {children}
+      </div>
+    </SpotlightGroupContext.Provider>
+  );
+}
+
+export type SpotlightSearchItemProps = Omit<
+  React.ComponentProps<"div">,
+  "onSelect"
+> & {
+  /** Text matched against the query, alongside the title and description. */
+  value: string;
+  /** Leading icon or thumbnail rendered at the start of the row. */
+  icon?: React.ReactNode;
+  /** Secondary line shown under the title. */
+  description?: React.ReactNode;
+  /** End-aligned category tag or meta shown opposite the title. */
+  meta?: React.ReactNode;
+  /** Called when the row is chosen by click or Enter. */
+  onSelect?: () => void;
+};
+
+function SpotlightSearchItem({
+  className,
+  value,
+  icon,
+  description,
+  meta,
+  onSelect,
+  children,
+  ...props
+}: SpotlightSearchItemProps) {
+  const { register, matches, activeId, setActiveId, select } = useSpotlight();
+  const group = React.useContext(SpotlightGroupContext);
+  const id = React.useId();
+
+  const text = React.useMemo(() => {
+    const parts: string[] = [];
+    if (typeof children === "string") parts.push(children);
+    if (typeof description === "string") parts.push(description);
+    return parts.join(" ");
+  }, [children, description]);
+
+  const onSelectRef = React.useRef(onSelect);
+  React.useEffect(() => {
+    onSelectRef.current = onSelect;
+  });
+
+  React.useEffect(
+    () =>
+      register({
+        id,
+        value,
+        text,
+        onSelect: () => onSelectRef.current?.(),
+      }),
+    [id, value, text, register],
+  );
+
+  const visible = matches(value, text);
+
+  React.useEffect(() => {
+    group?.reportVisible(id, visible);
+    return () => group?.reportVisible(id, false);
+  }, [group, id, visible]);
+
+  if (!visible) return null;
+
+  const active = activeId === id;
+
+  return (
+    <div
+      id={id}
+      data-item-id={id}
+      data-slot="spotlight-search-item"
+      data-active={active || undefined}
+      role="option"
+      aria-selected={active}
+      onPointerMove={() => {
+        if (!active) setActiveId(id);
+      }}
+      onClick={() =>
+        select({ id, value, text, onSelect: () => onSelectRef.current?.() })
+      }
+      className={cn(
+        "flex cursor-pointer items-center gap-3 rounded-md px-3 py-2.5 outline-none",
+        "data-[active]:bg-accent data-[active]:text-accent-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {icon != null ? (
+        <span
+          data-slot="spotlight-search-item-icon"
+          className="flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border bg-card text-muted-foreground [&_img]:size-full [&_img]:object-cover [&_svg:not([class*='size-'])]:size-4"
+        >
+          {icon}
+        </span>
+      ) : null}
+      <span
+        data-slot="spotlight-search-item-body"
+        className="flex min-w-0 flex-1 flex-col gap-0.5 text-start"
+      >
+        <span
+          data-slot="spotlight-search-item-title"
+          className="truncate text-sm font-medium text-foreground"
+        >
+          {children}
+        </span>
+        {description != null ? (
+          <span
+            data-slot="spotlight-search-item-description"
+            className="truncate text-xs text-muted-foreground"
+          >
+            {description}
+          </span>
+        ) : null}
+      </span>
+      {meta != null ? (
+        <span
+          data-slot="spotlight-search-item-meta"
+          className="ms-auto shrink-0 rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground"
+        >
+          {meta}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function SpotlightSearchEmpty({
+  className,
+  children = "No results",
+  ...props
+}: React.ComponentProps<"div">) {
+  const { getItems, matches } = useSpotlight();
+  const hasVisible = getItems().some((item) => matches(item.value, item.text));
+  if (hasVisible) return null;
+
+  return (
+    <div
+      data-slot="spotlight-search-empty"
+      role="status"
+      className={cn(
+        "px-3 py-10 text-center text-sm text-muted-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function SpotlightSearchFooter({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="spotlight-search-footer"
+      className={cn(
+        "flex items-center gap-4 border-t border-border px-5 py-2.5 text-xs text-muted-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <span className="inline-flex items-center gap-1.5">
+            <KbdGroup>
+              <Kbd
+                aria-label="Up arrow"
+                className="h-5 min-w-5 px-1 text-[11px]"
+              >
+                <ArrowUp className="size-3" />
+              </Kbd>
+              <Kbd
+                aria-label="Down arrow"
+                className="h-5 min-w-5 px-1 text-[11px]"
+              >
+                <ArrowDown className="size-3" />
+              </Kbd>
+            </KbdGroup>
+            to navigate
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <Kbd
+              aria-label="Enter"
+              className="h-5 min-w-5 px-1 text-[11px]"
+            >
+              <CornerDownLeft className="size-3" />
+            </Kbd>
+            to open
+          </span>
+        </>
+      )}
+    </div>
+  );
+}
+
+export type SpotlightSearchContentProps = React.ComponentProps<
+  typeof DialogContent
+> & {
+  /** Accessible title for the dialog; visually hidden. */
+  title?: string;
+};
+
+function SpotlightSearchContent({
+  className,
+  children,
+  title = "Search",
+  ...props
+}: SpotlightSearchContentProps) {
+  return (
+    <DialogContent
+      data-slot="spotlight-search-content"
+      showCloseButton={false}
+      aria-describedby={undefined}
+      className={cn(
+        "glass-panel-strong top-[18%] translate-y-0 gap-0 overflow-hidden p-0 sm:max-w-xl",
+        className,
+      )}
+      {...props}
+    >
+      <DialogTitle className="sr-only">{title}</DialogTitle>
+      {children}
+    </DialogContent>
+  );
+}
+
+export {
+  SpotlightSearch,
+  SpotlightSearchTrigger,
+  SpotlightSearchContent,
+  SpotlightSearchInput,
+  SpotlightSearchResults,
+  SpotlightSearchGroup,
+  SpotlightSearchItem,
+  SpotlightSearchEmpty,
+  SpotlightSearchFooter,
+};

--- a/registry/hirael/ui/terminal.tsx
+++ b/registry/hirael/ui/terminal.tsx
@@ -1,0 +1,352 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+type TerminalEntry = {
+  id: string
+  node: React.ReactNode
+}
+
+type TerminalContextValue = {
+  entries: TerminalEntry[]
+  pushLine: (node: React.ReactNode) => void
+  clear: () => void
+  history: string[]
+  pushHistory: (command: string) => void
+}
+
+const TerminalContext = React.createContext<TerminalContextValue | null>(null)
+
+function useTerminal() {
+  const context = React.useContext(TerminalContext)
+  if (!context) {
+    throw new Error("Terminal parts must be used within <Terminal>.")
+  }
+  return context
+}
+
+type TerminalProps = React.ComponentProps<"div">
+
+function Terminal({ className, children, ...props }: TerminalProps) {
+  const [entries, setEntries] = React.useState<TerminalEntry[]>([])
+  const [history, setHistory] = React.useState<string[]>([])
+  const counter = React.useRef(0)
+
+  const pushLine = React.useCallback((node: React.ReactNode) => {
+    counter.current += 1
+    setEntries((prev) => [...prev, { id: `line-${counter.current}`, node }])
+  }, [])
+
+  const clear = React.useCallback(() => {
+    setEntries([])
+  }, [])
+
+  const pushHistory = React.useCallback((command: string) => {
+    setHistory((prev) => [...prev, command])
+  }, [])
+
+  const value = React.useMemo<TerminalContextValue>(
+    () => ({ entries, pushLine, clear, history, pushHistory }),
+    [entries, pushLine, clear, history, pushHistory],
+  )
+
+  return (
+    <TerminalContext.Provider value={value}>
+      <div
+        data-slot="terminal"
+        className={cn(
+          "flex w-full flex-col overflow-hidden rounded-md border border-border bg-card text-card-foreground",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </TerminalContext.Provider>
+  )
+}
+
+type TerminalHeaderProps = React.ComponentProps<"div"> & {
+  /** Title shown beside the window dots. */
+  title?: string
+}
+
+function TerminalHeader({
+  title,
+  className,
+  children,
+  ...props
+}: TerminalHeaderProps) {
+  return (
+    <div
+      data-slot="terminal-header"
+      className={cn(
+        "flex h-9 shrink-0 items-center gap-2 border-b border-border bg-muted/40 ps-3 pe-3",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        data-slot="terminal-dots"
+        aria-hidden
+        className="flex items-center gap-1.5"
+      >
+        <span className="size-3 rounded-full bg-muted-foreground/40" />
+        <span className="size-3 rounded-full bg-muted-foreground/40" />
+        <span className="size-3 rounded-full bg-muted-foreground/40" />
+      </span>
+      {title ? (
+        <span
+          data-slot="terminal-title"
+          className="ms-1 truncate font-mono text-xs text-muted-foreground"
+        >
+          {title}
+        </span>
+      ) : null}
+      {children}
+    </div>
+  )
+}
+
+type TerminalBodyProps = React.ComponentProps<"div">
+
+function TerminalBody({ className, children, ...props }: TerminalBodyProps) {
+  const { entries } = useTerminal()
+  const ref = React.useRef<HTMLDivElement>(null)
+
+  React.useEffect(() => {
+    const node = ref.current
+    if (!node) return
+    node.scrollTop = node.scrollHeight
+  }, [entries])
+
+  const seeded: React.ReactNode[] = []
+  const trailing: React.ReactNode[] = []
+  React.Children.forEach(children, (child) => {
+    if (React.isValidElement(child) && child.type === TerminalInput) {
+      trailing.push(child)
+    } else {
+      seeded.push(child)
+    }
+  })
+
+  return (
+    <div
+      ref={ref}
+      data-slot="terminal-body"
+      dir="ltr"
+      className={cn(
+        "max-h-80 min-h-0 flex-1 space-y-1 overflow-auto bg-card px-3 py-2.5 font-mono text-[13px] leading-relaxed text-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {seeded}
+      {entries.map((entry) => (
+        <React.Fragment key={entry.id}>{entry.node}</React.Fragment>
+      ))}
+      {trailing}
+    </div>
+  )
+}
+
+type TerminalLineProps = React.ComponentProps<"div">
+
+function TerminalLine({ className, ...props }: TerminalLineProps) {
+  return (
+    <div
+      data-slot="terminal-line"
+      className={cn("flex items-baseline gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+type TerminalPromptProps = React.ComponentProps<"span"> & {
+  /** Prompt symbol or user@host:path label. Defaults to "$". */
+  symbol?: React.ReactNode
+}
+
+function TerminalPrompt({
+  symbol = "$",
+  className,
+  children,
+  ...props
+}: TerminalPromptProps) {
+  return (
+    <span
+      data-slot="terminal-prompt"
+      aria-hidden
+      className={cn("shrink-0 select-none font-medium text-primary", className)}
+      {...props}
+    >
+      {children ?? symbol}
+    </span>
+  )
+}
+
+type TerminalOutputTone = "default" | "error" | "muted"
+
+const OUTPUT_TONE: Record<TerminalOutputTone, string> = {
+  default: "text-foreground",
+  error: "text-destructive",
+  muted: "text-muted-foreground",
+}
+
+type TerminalOutputProps = React.ComponentProps<"div"> & {
+  /** Color treatment for the output text. */
+  tone?: TerminalOutputTone
+}
+
+function TerminalOutput({
+  tone = "default",
+  className,
+  ...props
+}: TerminalOutputProps) {
+  return (
+    <div
+      data-slot="terminal-output"
+      data-tone={tone}
+      className={cn(
+        "whitespace-pre-wrap break-words",
+        OUTPUT_TONE[tone],
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+type TerminalInputProps = Omit<
+  React.ComponentProps<"input">,
+  "value" | "onChange" | "prefix"
+> & {
+  /** Prompt symbol shown before the editable line. Defaults to "$". */
+  prompt?: React.ReactNode
+  /**
+   * Runs the entered command and returns the output to append below it.
+   * Return a string or node to echo as output, or nothing to echo only the
+   * command. The component handles the echo, Up/Down history, and clearing
+   * the field.
+   */
+  onCommand?: (input: string) => React.ReactNode | string | void
+}
+
+function TerminalInput({
+  prompt = "$",
+  onCommand,
+  className,
+  disabled,
+  onKeyDown,
+  ...props
+}: TerminalInputProps) {
+  const { pushLine, history, pushHistory } = useTerminal()
+  const [value, setValue] = React.useState("")
+  const [cursor, setCursor] = React.useState<number | null>(null)
+  const inputRef = React.useRef<HTMLInputElement>(null)
+
+  const run = () => {
+    const command = value
+    pushLine(
+      <TerminalLine data-slot="terminal-echo">
+        <TerminalPrompt symbol={prompt} />
+        <span className="min-w-0 flex-1 break-words">{command}</span>
+      </TerminalLine>,
+    )
+
+    if (command.trim()) {
+      pushHistory(command)
+    }
+
+    const output = onCommand?.(command)
+    if (output != null && output !== "") {
+      pushLine(<TerminalOutput>{output}</TerminalOutput>)
+    }
+
+    setValue("")
+    setCursor(null)
+  }
+
+  const recall = (next: number | null) => {
+    if (history.length === 0) return
+    setCursor(next)
+    setValue(next == null ? "" : (history[next] ?? ""))
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    onKeyDown?.(event)
+    if (event.defaultPrevented) return
+
+    if (event.key === "Enter") {
+      event.preventDefault()
+      run()
+      return
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault()
+      const next = cursor == null ? history.length - 1 : Math.max(0, cursor - 1)
+      recall(next)
+      return
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault()
+      if (cursor == null) return
+      const next = cursor + 1
+      recall(next >= history.length ? null : next)
+    }
+  }
+
+  return (
+    <TerminalLine
+      data-slot="terminal-input"
+      className={cn("group relative", className)}
+      onClick={() => inputRef.current?.focus()}
+    >
+      <TerminalPrompt symbol={prompt} />
+      <span className="relative min-w-0 flex-1">
+        <input
+          ref={inputRef}
+          data-slot="terminal-input-field"
+          type="text"
+          value={value}
+          disabled={disabled}
+          spellCheck={false}
+          autoCapitalize="off"
+          autoCorrect="off"
+          autoComplete="off"
+          aria-label="Terminal input"
+          onChange={(event) => {
+            setValue(event.target.value)
+            setCursor(null)
+          }}
+          onKeyDown={handleKeyDown}
+          className="w-full bg-transparent font-mono text-[13px] text-foreground caret-transparent outline-none placeholder:text-muted-foreground disabled:opacity-50"
+          {...props}
+        />
+        {!disabled ? (
+          <span
+            aria-hidden
+            data-slot="terminal-caret"
+            style={{ insetInlineStart: `${value.length}ch` }}
+            className="pointer-events-none absolute top-1/2 h-[1.1em] w-[2px] -translate-y-1/2 animate-caret-blink bg-foreground opacity-0 duration-1000 group-focus-within:opacity-100 motion-reduce:animate-none motion-reduce:group-focus-within:opacity-100"
+          />
+        ) : null}
+      </span>
+    </TerminalLine>
+  )
+}
+
+export {
+  Terminal,
+  TerminalHeader,
+  TerminalBody,
+  TerminalLine,
+  TerminalPrompt,
+  TerminalOutput,
+  TerminalInput,
+  useTerminal,
+}

--- a/registry/hirael/ui/upload-manager.tsx
+++ b/registry/hirael/ui/upload-manager.tsx
@@ -1,0 +1,549 @@
+"use client";
+
+import * as React from "react";
+import {
+  Check,
+  CircleAlert,
+  File as FileIcon,
+  RotateCw,
+  Upload,
+  X,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/registry/hirael/ui/button";
+import { Progress } from "@/registry/hirael/ui/progress";
+
+export type UploadStatus = "queued" | "uploading" | "done" | "error";
+
+export type UploadItem = {
+  id: string;
+  name: string;
+  size: number;
+  progress: number;
+  status: UploadStatus;
+};
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"] as const;
+  let i = 0;
+  let n = bytes;
+  while (n >= 1024 && i < units.length - 1) {
+    n /= 1024;
+    i++;
+  }
+  const fixed = i === 0 ? n.toFixed(0) : n.toFixed(1);
+  return `${fixed} ${units[i]}`;
+}
+
+const STATUS_LABEL: Record<UploadStatus, string> = {
+  queued: "Queued",
+  uploading: "Uploading",
+  done: "Done",
+  error: "Failed",
+};
+
+type Ctx = {
+  items: UploadItem[];
+  setItems: (next: UploadItem[]) => void;
+  removeItem: (id: string) => void;
+  nextId: () => string;
+};
+
+const UploadManagerContext = React.createContext<Ctx | null>(null);
+
+function useUploadManager() {
+  const ctx = React.useContext(UploadManagerContext);
+  if (!ctx) {
+    throw new Error(
+      "UploadManager compound parts must be used inside <UploadManager>",
+    );
+  }
+  return ctx;
+}
+
+export type UploadManagerProps = Omit<
+  React.ComponentProps<"div">,
+  "defaultValue"
+> & {
+  /** Controlled queue of upload items. */
+  value?: UploadItem[];
+  /** Initial queue when uncontrolled. */
+  defaultValue?: UploadItem[];
+  /** Called whenever the queue changes (add, remove, or progress update). */
+  onValueChange?: (items: UploadItem[]) => void;
+};
+
+function UploadManager({
+  value: valueProp,
+  defaultValue,
+  onValueChange,
+  className,
+  children,
+  ...props
+}: UploadManagerProps) {
+  const reactId = React.useId();
+  const seedRef = React.useRef(0);
+
+  const [internalItems, setInternalItems] = React.useState<UploadItem[]>(
+    defaultValue ?? [],
+  );
+  const items = valueProp ?? internalItems;
+
+  const setItems = React.useCallback(
+    (next: UploadItem[]) => {
+      if (valueProp === undefined) setInternalItems(next);
+      onValueChange?.(next);
+    },
+    [valueProp, onValueChange],
+  );
+
+  const itemsRef = React.useRef(items);
+  itemsRef.current = items;
+
+  const removeItem = React.useCallback(
+    (id: string) => {
+      setItems(itemsRef.current.filter((item) => item.id !== id));
+    },
+    [setItems],
+  );
+
+  const nextId = React.useCallback(
+    () => `${reactId}-upload-${seedRef.current++}`,
+    [reactId],
+  );
+
+  const ctx = React.useMemo<Ctx>(
+    () => ({ items, setItems, removeItem, nextId }),
+    [items, setItems, removeItem, nextId],
+  );
+
+  return (
+    <UploadManagerContext.Provider value={ctx}>
+      <div
+        data-slot="upload-manager"
+        className={cn(
+          "flex w-full flex-col gap-3 rounded-lg border border-border bg-card p-3 text-card-foreground",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </UploadManagerContext.Provider>
+  );
+}
+
+export type UploadDropzoneProps = Omit<
+  React.ComponentProps<"div">,
+  "onDrop" | "onDragEnter" | "onDragLeave" | "onDragOver" | "children"
+> & {
+  /** Restrict the native file picker, e.g. "image/*,.pdf". */
+  accept?: string;
+  /** Allow selecting more than one file at a time. */
+  multiple?: boolean;
+  disabled?: boolean;
+  /** Called with the selected or dropped files so the queue can append them. */
+  onAdd?: (files: File[]) => void;
+  headline?: string;
+  subline?: React.ReactNode;
+  children?: React.ReactNode;
+};
+
+function UploadDropzone({
+  accept,
+  multiple = true,
+  disabled,
+  onAdd,
+  headline = "Drop files here, or click to browse",
+  subline,
+  className,
+  children,
+  ...props
+}: UploadDropzoneProps) {
+  const { nextId, setItems, items } = useUploadManager();
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const [isDragging, setIsDragging] = React.useState(false);
+  const dragCounter = React.useRef(0);
+
+  const itemsRef = React.useRef(items);
+  itemsRef.current = items;
+
+  const add = React.useCallback(
+    (incoming: FileList | File[]) => {
+      if (disabled) return;
+      const list = Array.from(incoming);
+      if (list.length === 0) return;
+      onAdd?.(list);
+      const appended: UploadItem[] = list.map((file) => ({
+        id: nextId(),
+        name: file.name,
+        size: file.size,
+        progress: 0,
+        status: "queued",
+      }));
+      setItems([...itemsRef.current, ...appended]);
+    },
+    [disabled, nextId, onAdd, setItems],
+  );
+
+  const openPicker = () => {
+    if (disabled) return;
+    inputRef.current?.click();
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled || undefined}
+      data-slot="upload-dropzone"
+      data-dragging={isDragging || undefined}
+      onClick={openPicker}
+      onKeyDown={(e) => {
+        if (disabled) return;
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          openPicker();
+        }
+      }}
+      onDragEnter={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (disabled) return;
+        dragCounter.current += 1;
+        if (dragCounter.current === 1) setIsDragging(true);
+      }}
+      onDragLeave={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (disabled) return;
+        dragCounter.current -= 1;
+        if (dragCounter.current <= 0) {
+          dragCounter.current = 0;
+          setIsDragging(false);
+        }
+      }}
+      onDragOver={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+      onDrop={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        dragCounter.current = 0;
+        setIsDragging(false);
+        if (disabled) return;
+        const dropped = e.dataTransfer.files;
+        if (dropped && dropped.length > 0) add(dropped);
+      }}
+      className={cn(
+        "flex min-w-0 flex-col items-center justify-center gap-1.5 rounded-md border border-dashed border-border bg-background px-4 py-6 text-center outline-none transition-colors",
+        "hover:border-foreground/30 hover:bg-muted/50",
+        "focus-visible:ring-2 focus-visible:ring-ring",
+        isDragging && "border-foreground/30 bg-muted/50",
+        disabled && "cursor-not-allowed opacity-60",
+        className,
+      )}
+      {...props}
+    >
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        multiple={multiple}
+        disabled={disabled}
+        className="sr-only"
+        onChange={(e) => {
+          const list = e.target.files;
+          if (list && list.length > 0) add(list);
+          e.target.value = "";
+        }}
+      />
+      {children ?? (
+        <>
+          <Upload className="size-5 text-muted-foreground" aria-hidden />
+          <p className="text-sm text-foreground">{headline}</p>
+          {subline ? (
+            <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+              {subline}
+            </p>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}
+
+type UploadListProps = React.ComponentProps<"ul"> & {
+  /** Shown when the queue is empty. Hides the list entirely if omitted. */
+  empty?: React.ReactNode;
+};
+
+function UploadList({ className, empty, children, ...props }: UploadListProps) {
+  const { items } = useUploadManager();
+  if (items.length === 0) {
+    if (empty === undefined) return null;
+    return (
+      <div
+        data-slot="upload-list-empty"
+        className="rounded-md border border-dashed border-border px-3 py-6 text-center text-sm text-muted-foreground"
+      >
+        {empty}
+      </div>
+    );
+  }
+  return (
+    <ul
+      data-slot="upload-list"
+      className={cn("flex min-w-0 flex-col gap-1.5", className)}
+      {...props}
+    >
+      {children}
+    </ul>
+  );
+}
+
+export type UploadItemRowProps = Omit<
+  React.ComponentProps<"li">,
+  "children"
+> & {
+  /** The queue entry to render. */
+  item: UploadItem;
+  /** Called when the user cancels an in-flight upload. */
+  onCancel?: (id: string) => void;
+  /** Called when the user retries a failed upload. */
+  onRetry?: (id: string) => void;
+  /** Called when the user removes the entry. Falls back to the root's remove. */
+  onRemove?: (id: string) => void;
+};
+
+function UploadItem({
+  item,
+  onCancel,
+  onRetry,
+  onRemove,
+  className,
+  ...props
+}: UploadItemRowProps) {
+  const { removeItem } = useUploadManager();
+  const isUploading = item.status === "uploading";
+  const isError = item.status === "error";
+  const isDone = item.status === "done";
+
+  const handleRemove = () => {
+    if (onRemove) onRemove(item.id);
+    else removeItem(item.id);
+  };
+
+  return (
+    <li
+      data-slot="upload-item"
+      data-status={item.status}
+      className={cn(
+        "flex min-w-0 items-start gap-3 rounded-md border border-border bg-background px-3 py-2.5",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        data-slot="upload-item-icon"
+        className="mt-0.5 inline-flex size-8 shrink-0 items-center justify-center rounded-md border border-border bg-muted text-muted-foreground [&_svg]:size-4"
+      >
+        {isError ? (
+          <CircleAlert className="text-destructive" aria-hidden />
+        ) : isDone ? (
+          <Check className="text-foreground" aria-hidden />
+        ) : (
+          <FileIcon aria-hidden />
+        )}
+      </span>
+
+      <div data-slot="upload-item-main" className="flex min-w-0 flex-1 flex-col gap-1.5">
+        <div className="flex min-w-0 items-center gap-2">
+          <span
+            data-slot="upload-item-name"
+            className="min-w-0 flex-1 truncate text-sm text-foreground"
+            title={item.name}
+          >
+            {item.name}
+          </span>
+          <span
+            data-slot="upload-item-size"
+            className="shrink-0 font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground"
+          >
+            {formatBytes(item.size)}
+          </span>
+        </div>
+
+        {isError ? (
+          <p
+            data-slot="upload-item-status"
+            className="text-xs text-destructive"
+          >
+            {STATUS_LABEL.error}
+          </p>
+        ) : (
+          <div className="flex items-center gap-2">
+            <Progress
+              data-slot="upload-item-progress"
+              value={item.progress}
+              className="h-1.5 flex-1"
+            />
+            <span
+              data-slot="upload-item-status"
+              className={cn(
+                "inline-flex shrink-0 items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.08em]",
+                isUploading ? "text-foreground" : "text-muted-foreground",
+              )}
+            >
+              {isUploading ? (
+                <span className="state-dot" aria-hidden />
+              ) : null}
+              {isDone
+                ? STATUS_LABEL.done
+                : isUploading
+                  ? `${Math.round(item.progress)}%`
+                  : STATUS_LABEL.queued}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div
+        data-slot="upload-item-actions"
+        className="flex shrink-0 items-center gap-1"
+      >
+        {isUploading ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`Cancel upload of ${item.name}`}
+            onClick={() => onCancel?.(item.id)}
+          >
+            <X aria-hidden />
+          </Button>
+        ) : isError ? (
+          <>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label={`Retry upload of ${item.name}`}
+              onClick={() => onRetry?.(item.id)}
+            >
+              <RotateCw aria-hidden />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label={`Remove ${item.name}`}
+              onClick={handleRemove}
+            >
+              <X aria-hidden />
+            </Button>
+          </>
+        ) : (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`Remove ${item.name}`}
+            onClick={handleRemove}
+          >
+            <X aria-hidden />
+          </Button>
+        )}
+      </div>
+    </li>
+  );
+}
+
+type UploadSummaryProps = Omit<React.ComponentProps<"div">, "children"> & {
+  children?: (summary: {
+    total: number;
+    done: number;
+    uploading: number;
+    error: number;
+    queued: number;
+    progress: number;
+  }) => React.ReactNode;
+};
+
+function UploadSummary({ className, children, ...props }: UploadSummaryProps) {
+  const { items } = useUploadManager();
+
+  const summary = React.useMemo(() => {
+    const total = items.length;
+    let done = 0;
+    let uploading = 0;
+    let error = 0;
+    let queued = 0;
+    let progressSum = 0;
+    for (const item of items) {
+      progressSum += item.status === "done" ? 100 : item.progress;
+      if (item.status === "done") done++;
+      else if (item.status === "uploading") uploading++;
+      else if (item.status === "error") error++;
+      else queued++;
+    }
+    const progress = total === 0 ? 0 : progressSum / total;
+    return { total, done, uploading, error, queued, progress };
+  }, [items]);
+
+  if (summary.total === 0) return null;
+
+  if (children) {
+    return (
+      <div data-slot="upload-summary" className={className} {...props}>
+        {children(summary)}
+      </div>
+    );
+  }
+
+  const parts: string[] = [];
+  if (summary.uploading > 0) parts.push(`${summary.uploading} uploading`);
+  if (summary.queued > 0) parts.push(`${summary.queued} queued`);
+  if (summary.done > 0) parts.push(`${summary.done} done`);
+  if (summary.error > 0) parts.push(`${summary.error} failed`);
+
+  return (
+    <div
+      data-slot="upload-summary"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span
+          data-slot="upload-summary-counts"
+          className="text-sm font-medium text-foreground"
+        >
+          {summary.done} of {summary.total} uploaded
+        </span>
+        <span
+          data-slot="upload-summary-detail"
+          className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground"
+        >
+          {parts.length > 0 ? parts.join(" · ") : "Ready"}
+        </span>
+      </div>
+      <Progress
+        data-slot="upload-summary-progress"
+        value={summary.progress}
+        className="h-1.5"
+      />
+    </div>
+  );
+}
+
+export {
+  UploadManager,
+  UploadDropzone,
+  UploadList,
+  UploadItem,
+  UploadSummary,
+  useUploadManager,
+};

--- a/registry/hirael/ui/variant-editor.tsx
+++ b/registry/hirael/ui/variant-editor.tsx
@@ -1,0 +1,586 @@
+"use client";
+
+import * as React from "react";
+import { Plus, Trash2, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/registry/hirael/ui/badge";
+import { Button } from "@/registry/hirael/ui/button";
+import { Input } from "@/registry/hirael/ui/input";
+
+export type VariantOption = {
+  id: string;
+  name: string;
+  values: string[];
+};
+
+export type VariantRow = {
+  id: string;
+  options: Record<string, string>;
+  price: string;
+  sku: string;
+  stock: string;
+};
+
+function comboKey(options: Record<string, string>): string {
+  return Object.keys(options)
+    .sort()
+    .map((name) => `${name}=${options[name]}`)
+    .join("");
+}
+
+function cartesian(
+  axes: VariantOption[],
+): Array<Record<string, string>> {
+  const usable = axes.filter(
+    (axis) => axis.name.trim() !== "" && axis.values.length > 0,
+  );
+  if (usable.length === 0) return [];
+  return usable.reduce<Array<Record<string, string>>>(
+    (acc, axis) =>
+      acc.flatMap((combo) =>
+        axis.values.map((value) => ({ ...combo, [axis.name]: value })),
+      ),
+    [{}],
+  );
+}
+
+type VariantEditorContextValue = {
+  options: VariantOption[];
+  rows: VariantRow[];
+  createId: () => string;
+  addOption: () => void;
+  removeOption: (id: string) => void;
+  renameOption: (id: string, name: string) => void;
+  addValue: (id: string, value: string) => void;
+  removeValue: (id: string, index: number) => void;
+  updateRow: (
+    id: string,
+    patch: Partial<Pick<VariantRow, "price" | "sku" | "stock">>,
+  ) => void;
+};
+
+const VariantEditorContext =
+  React.createContext<VariantEditorContextValue | null>(null);
+
+function useVariantEditor(): VariantEditorContextValue {
+  const context = React.useContext(VariantEditorContext);
+  if (!context) {
+    throw new Error(
+      "VariantEditor compound parts must be used inside <VariantEditor>",
+    );
+  }
+  return context;
+}
+
+type VariantEditorState = {
+  options: VariantOption[];
+  rows: VariantRow[];
+};
+
+export type VariantEditorProps = Omit<
+  React.ComponentProps<"div">,
+  "defaultValue" | "onChange"
+> & {
+  /** Controlled options and generated rows. */
+  value?: VariantEditorState;
+  /** Initial options and rows for an uncontrolled editor. */
+  defaultValue?: VariantEditorState;
+  /** Called whenever the options or any row changes. */
+  onValueChange?: (value: VariantEditorState) => void;
+};
+
+function VariantEditor({
+  value: valueProp,
+  defaultValue,
+  onValueChange,
+  className,
+  children,
+  ...props
+}: VariantEditorProps) {
+  const idPrefix = React.useId();
+  const counter = React.useRef(0);
+
+  const createId = React.useCallback(() => {
+    if (
+      typeof crypto !== "undefined" &&
+      typeof crypto.randomUUID === "function"
+    ) {
+      return crypto.randomUUID();
+    }
+    counter.current += 1;
+    return `${idPrefix}item-${counter.current}`;
+  }, [idPrefix]);
+
+  const [internal, setInternal] = React.useState<VariantEditorState>(
+    () => defaultValue ?? { options: [], rows: [] },
+  );
+
+  const isControlled = valueProp !== undefined;
+  const state = isControlled ? valueProp : internal;
+
+  const commitOptions = React.useCallback(
+    (nextOptions: VariantOption[]) => {
+      const combos = cartesian(nextOptions);
+      const existing = new Map(
+        state.rows.map((row) => [comboKey(row.options), row]),
+      );
+      const nextRows = combos.map((options) => {
+        const key = comboKey(options);
+        const prev = existing.get(key);
+        return prev
+          ? { ...prev, options }
+          : {
+              id: createId(),
+              options,
+              price: "",
+              sku: "",
+              stock: "",
+            };
+      });
+      const next: VariantEditorState = {
+        options: nextOptions,
+        rows: nextRows,
+      };
+      if (!isControlled) setInternal(next);
+      onValueChange?.(next);
+    },
+    [state.rows, createId, isControlled, onValueChange],
+  );
+
+  const commitRows = React.useCallback(
+    (nextRows: VariantRow[]) => {
+      const next: VariantEditorState = {
+        options: state.options,
+        rows: nextRows,
+      };
+      if (!isControlled) setInternal(next);
+      onValueChange?.(next);
+    },
+    [state.options, isControlled, onValueChange],
+  );
+
+  const addOption = React.useCallback(() => {
+    commitOptions([
+      ...state.options,
+      { id: createId(), name: "", values: [] },
+    ]);
+  }, [state.options, createId, commitOptions]);
+
+  const removeOption = React.useCallback(
+    (id: string) => {
+      commitOptions(state.options.filter((option) => option.id !== id));
+    },
+    [state.options, commitOptions],
+  );
+
+  const renameOption = React.useCallback(
+    (id: string, name: string) => {
+      commitOptions(
+        state.options.map((option) =>
+          option.id === id ? { ...option, name } : option,
+        ),
+      );
+    },
+    [state.options, commitOptions],
+  );
+
+  const addValue = React.useCallback(
+    (id: string, value: string) => {
+      const trimmed = value.trim();
+      if (!trimmed) return;
+      commitOptions(
+        state.options.map((option) =>
+          option.id === id && !option.values.includes(trimmed)
+            ? { ...option, values: [...option.values, trimmed] }
+            : option,
+        ),
+      );
+    },
+    [state.options, commitOptions],
+  );
+
+  const removeValue = React.useCallback(
+    (id: string, index: number) => {
+      commitOptions(
+        state.options.map((option) =>
+          option.id === id
+            ? {
+                ...option,
+                values: option.values.filter((_, i) => i !== index),
+              }
+            : option,
+        ),
+      );
+    },
+    [state.options, commitOptions],
+  );
+
+  const updateRow = React.useCallback(
+    (
+      id: string,
+      patch: Partial<Pick<VariantRow, "price" | "sku" | "stock">>,
+    ) => {
+      commitRows(
+        state.rows.map((row) =>
+          row.id === id ? { ...row, ...patch } : row,
+        ),
+      );
+    },
+    [state.rows, commitRows],
+  );
+
+  const context = React.useMemo<VariantEditorContextValue>(
+    () => ({
+      options: state.options,
+      rows: state.rows,
+      createId,
+      addOption,
+      removeOption,
+      renameOption,
+      addValue,
+      removeValue,
+      updateRow,
+    }),
+    [
+      state.options,
+      state.rows,
+      createId,
+      addOption,
+      removeOption,
+      renameOption,
+      addValue,
+      removeValue,
+      updateRow,
+    ],
+  );
+
+  return (
+    <VariantEditorContext.Provider value={context}>
+      <div
+        data-slot="variant-editor"
+        className={cn("flex w-full flex-col gap-6", className)}
+        {...props}
+      >
+        {children}
+      </div>
+    </VariantEditorContext.Provider>
+  );
+}
+
+type VariantOptionsProps = Omit<React.ComponentProps<"div">, "children"> & {
+  /** Override the add-axis control label. */
+  addLabel?: React.ReactNode;
+};
+
+function VariantOptions({
+  className,
+  addLabel = "Add option",
+  ...props
+}: VariantOptionsProps) {
+  const ctx = useVariantEditor();
+  return (
+    <div
+      data-slot="variant-options"
+      className={cn("flex flex-col gap-3", className)}
+      {...props}
+    >
+      {ctx.options.map((option) => (
+        <VariantOptionRow key={option.id} option={option} />
+      ))}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        data-slot="variant-options-add"
+        onClick={ctx.addOption}
+        className="w-fit"
+      >
+        <Plus />
+        {addLabel}
+      </Button>
+    </div>
+  );
+}
+
+type VariantOptionProps = Omit<React.ComponentProps<"div">, "children"> & {
+  option: VariantOption;
+};
+
+function VariantOptionRow({ option, className, ...props }: VariantOptionProps) {
+  const ctx = useVariantEditor();
+  return (
+    <div
+      data-slot="variant-option"
+      className={cn(
+        "flex flex-col gap-2 rounded-md border border-border bg-card p-3 sm:flex-row sm:items-start",
+        className,
+      )}
+      {...props}
+    >
+      <Input
+        data-slot="variant-option-name"
+        value={option.name}
+        onChange={(event) => ctx.renameOption(option.id, event.target.value)}
+        placeholder="Option name"
+        aria-label="Option name"
+        className="sm:w-40"
+      />
+      <VariantValues option={option} className="flex-1" />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        data-slot="variant-option-remove"
+        aria-label={`Remove ${option.name || "option"}`}
+        onClick={() => ctx.removeOption(option.id)}
+        className="text-muted-foreground"
+      >
+        <Trash2 />
+      </Button>
+    </div>
+  );
+}
+
+type VariantValuesProps = Omit<React.ComponentProps<"div">, "children"> & {
+  option: VariantOption;
+};
+
+function VariantValues({ option, className, ...props }: VariantValuesProps) {
+  const ctx = useVariantEditor();
+  const [draft, setDraft] = React.useState("");
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+
+  const commit = () => {
+    if (!draft.trim()) return;
+    ctx.addValue(option.id, draft);
+    setDraft("");
+  };
+
+  return (
+    <div
+      data-slot="variant-values"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          event.preventDefault();
+          inputRef.current?.focus();
+        }
+      }}
+      className={cn(
+        "flex min-h-9 flex-wrap items-center gap-1 rounded-sm border border-input bg-transparent px-1.5 py-1 transition-colors focus-within:border-ring",
+        className,
+      )}
+      {...props}
+    >
+      {option.values.map((value, index) => (
+        <Badge
+          key={`${value}-${index}`}
+          variant="secondary"
+          data-slot="variant-value"
+          className="gap-1 pe-1 font-normal"
+        >
+          <span className="min-w-0 truncate">{value}</span>
+          <button
+            type="button"
+            tabIndex={-1}
+            aria-label={`Remove ${value}`}
+            onClick={() => ctx.removeValue(option.id, index)}
+            className="inline-flex size-3.5 items-center justify-center rounded-[2px] text-secondary-foreground/70 transition-colors hover:bg-secondary-foreground/20 hover:text-secondary-foreground"
+          >
+            <X className="size-2.5" />
+          </button>
+        </Badge>
+      ))}
+      <input
+        ref={inputRef}
+        type="text"
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === ",") {
+            if (draft.trim()) {
+              event.preventDefault();
+              commit();
+            }
+          } else if (
+            event.key === "Backspace" &&
+            !draft &&
+            option.values.length > 0
+          ) {
+            event.preventDefault();
+            ctx.removeValue(option.id, option.values.length - 1);
+          }
+        }}
+        onBlur={commit}
+        placeholder={option.values.length === 0 ? "Add value" : undefined}
+        aria-label="Add value"
+        data-slot="variant-values-field"
+        className="min-w-24 flex-1 bg-transparent px-1.5 py-0.5 text-sm outline-none placeholder:text-muted-foreground"
+      />
+    </div>
+  );
+}
+
+const VARIANT_FIELDS: Array<{
+  key: "price" | "sku" | "stock";
+  label: string;
+  placeholder: string;
+  inputMode?: React.ComponentProps<"input">["inputMode"];
+}> = [
+  { key: "price", label: "Price", placeholder: "0.00", inputMode: "decimal" },
+  { key: "sku", label: "SKU", placeholder: "SKU-000" },
+  { key: "stock", label: "Stock", placeholder: "0", inputMode: "numeric" },
+];
+
+type VariantTableProps = Omit<React.ComponentProps<"div">, "children"> & {
+  /** Shown when no variants are generated yet. */
+  emptyHint?: React.ReactNode;
+};
+
+function VariantTable({
+  className,
+  emptyHint = "Add options with values to generate variants.",
+  ...props
+}: VariantTableProps) {
+  const ctx = useVariantEditor();
+  const axisNames = ctx.options
+    .filter((option) => option.name.trim() !== "" && option.values.length > 0)
+    .map((option) => option.name);
+
+  if (ctx.rows.length === 0) {
+    return (
+      <div
+        data-slot="variant-table"
+        data-empty="true"
+        className={cn(
+          "rounded-md border border-dashed border-border px-4 py-6 text-center text-sm text-muted-foreground",
+          className,
+        )}
+        {...props}
+      >
+        {emptyHint}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-slot="variant-table"
+      className={cn(
+        "overflow-hidden rounded-md border border-border",
+        className,
+      )}
+      {...props}
+    >
+      <table className="w-full border-collapse text-sm">
+        <thead>
+          <tr className="border-b border-border bg-muted/50 text-start text-xs font-medium text-muted-foreground">
+            <th className="px-3 py-2 text-start font-medium">Variant</th>
+            {VARIANT_FIELDS.map((field) => (
+              <th
+                key={field.key}
+                className="px-3 py-2 text-start font-medium"
+              >
+                {field.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {ctx.rows.map((row) => (
+            <VariantTableRow key={row.id} row={row} axisNames={axisNames} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+type VariantRowProps = Omit<
+  React.ComponentProps<"tr">,
+  "children" | "row"
+> & {
+  row: VariantRow;
+  axisNames?: string[];
+};
+
+function VariantTableRow({
+  row,
+  axisNames,
+  className,
+  ...props
+}: VariantRowProps) {
+  const ctx = useVariantEditor();
+  const names =
+    axisNames ?? Object.keys(row.options).sort((a, b) => a.localeCompare(b));
+  const label = names
+    .map((name) => row.options[name])
+    .filter(Boolean)
+    .join(" / ");
+
+  return (
+    <tr
+      data-slot="variant-row"
+      className={cn(
+        "border-b border-border last:border-b-0 align-middle",
+        className,
+      )}
+      {...props}
+    >
+      <td className="px-3 py-2">
+        <span
+          data-slot="variant-row-label"
+          className="font-medium text-foreground"
+        >
+          {label}
+        </span>
+      </td>
+      {VARIANT_FIELDS.map((field) => (
+        <td key={field.key} className="px-3 py-2">
+          <Input
+            data-slot={`variant-row-${field.key}`}
+            value={row[field.key]}
+            onChange={(event) =>
+              ctx.updateRow(row.id, { [field.key]: event.target.value })
+            }
+            placeholder={field.placeholder}
+            inputMode={field.inputMode}
+            aria-label={`${label} ${field.label}`}
+            className="h-8 min-w-20"
+          />
+        </td>
+      ))}
+    </tr>
+  );
+}
+
+type VariantCountProps = Omit<React.ComponentProps<"p">, "children"> & {
+  /** Render the label from the variant count. */
+  children?: (count: number) => React.ReactNode;
+};
+
+function VariantCount({ className, children, ...props }: VariantCountProps) {
+  const ctx = useVariantEditor();
+  const count = ctx.rows.length;
+  return (
+    <p
+      data-slot="variant-count"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    >
+      {children
+        ? children(count)
+        : `${count} variant${count === 1 ? "" : "s"}`}
+    </p>
+  );
+}
+
+export {
+  VariantEditor,
+  VariantOptions,
+  VariantOptionRow as VariantOption,
+  VariantValues,
+  VariantTable,
+  VariantTableRow as VariantRow,
+  VariantCount,
+};

--- a/registry/hirael/ui/vendor-comparison.tsx
+++ b/registry/hirael/ui/vendor-comparison.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import * as React from "react";
+import { Check, Minus, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/registry/hirael/ui/badge";
+
+type Vendor = {
+  id: string;
+  name: string;
+  recommended?: boolean;
+};
+
+type CellValue = boolean | string | number;
+
+type Feature = {
+  id: string;
+  label: string;
+  group?: string;
+  values: Record<string, CellValue>;
+};
+
+type VendorComparisonContextValue = {
+  vendors: Vendor[];
+};
+
+const VendorComparisonContext =
+  React.createContext<VendorComparisonContextValue | null>(null);
+
+function useVendorComparison() {
+  const ctx = React.useContext(VendorComparisonContext);
+  if (!ctx) {
+    throw new Error(
+      "VendorComparison compound parts must be used inside <VendorComparison>",
+    );
+  }
+  return ctx;
+}
+
+export type VendorComparisonProps = React.ComponentProps<"div"> & {
+  /** Columns of the table. Mark one vendor `recommended` to tint its column and label it. */
+  vendors: Vendor[];
+  /** Rows of the table. Pass to render config-driven; omit to compose rows as children. Group adjacent features with `group`. */
+  features?: Feature[];
+};
+
+function VendorComparison({
+  vendors,
+  features,
+  className,
+  children,
+  ...props
+}: VendorComparisonProps) {
+  const ctx = React.useMemo<VendorComparisonContextValue>(
+    () => ({ vendors }),
+    [vendors],
+  );
+
+  const grouped = React.useMemo(() => {
+    if (!features) return [];
+    const sections: { group?: string; items: Feature[] }[] = [];
+    for (const feature of features) {
+      const last = sections[sections.length - 1];
+      if (last && last.group === feature.group) {
+        last.items.push(feature);
+      } else {
+        sections.push({ group: feature.group, items: [feature] });
+      }
+    }
+    return sections;
+  }, [features]);
+
+  return (
+    <VendorComparisonContext.Provider value={ctx}>
+      <div
+        data-slot="vendor-comparison"
+        className={cn(
+          "relative w-full overflow-x-auto rounded-lg border border-border bg-card text-card-foreground",
+          className,
+        )}
+        {...props}
+      >
+        <table
+          data-slot="vendor-comparison-table"
+          className="w-full border-collapse text-sm"
+        >
+          {children ?? (
+            <>
+              <VendorComparisonHeader />
+              <tbody data-slot="vendor-comparison-body">
+                {grouped.map((section, index) => (
+                  <React.Fragment key={section.group ?? `section-${index}`}>
+                    {section.group ? (
+                      <VendorComparisonGroup>
+                        {section.group}
+                      </VendorComparisonGroup>
+                    ) : null}
+                    {section.items.map((feature) => (
+                      <VendorComparisonRow key={feature.id} label={feature.label}>
+                        {vendors.map((vendor) => (
+                          <VendorComparisonCell
+                            key={vendor.id}
+                            value={feature.values[vendor.id]}
+                            recommended={vendor.recommended}
+                          />
+                        ))}
+                      </VendorComparisonRow>
+                    ))}
+                  </React.Fragment>
+                ))}
+              </tbody>
+            </>
+          )}
+        </table>
+      </div>
+    </VendorComparisonContext.Provider>
+  );
+}
+
+export type VendorComparisonHeaderProps = React.ComponentProps<"thead">;
+
+function VendorComparisonHeader({
+  className,
+  ...props
+}: VendorComparisonHeaderProps) {
+  const { vendors } = useVendorComparison();
+  return (
+    <thead
+      data-slot="vendor-comparison-header"
+      className={cn("border-b border-border bg-muted/40", className)}
+      {...props}
+    >
+      <tr data-slot="vendor-comparison-header-row">
+        <th
+          scope="col"
+          data-slot="vendor-comparison-corner"
+          className="sticky start-0 z-10 bg-muted/40 px-4 py-3 text-start align-bottom font-medium text-muted-foreground"
+        >
+          <span className="sr-only">Feature</span>
+        </th>
+        {vendors.map((vendor) => (
+          <th
+            key={vendor.id}
+            scope="col"
+            data-slot="vendor-comparison-vendor"
+            data-recommended={vendor.recommended ? "" : undefined}
+            className={cn(
+              "px-4 py-3 text-center align-bottom font-medium text-foreground",
+              vendor.recommended && "bg-primary/5",
+            )}
+          >
+            <div className="flex flex-col items-center gap-1.5">
+              <span>{vendor.name}</span>
+              {vendor.recommended ? (
+                <Badge data-slot="vendor-comparison-badge">Recommended</Badge>
+              ) : null}
+            </div>
+          </th>
+        ))}
+      </tr>
+    </thead>
+  );
+}
+
+export type VendorComparisonGroupProps = React.ComponentProps<"tr">;
+
+function VendorComparisonGroup({
+  className,
+  children,
+  ...props
+}: VendorComparisonGroupProps) {
+  const { vendors } = useVendorComparison();
+  return (
+    <tr
+      data-slot="vendor-comparison-group"
+      className={cn("border-b border-border bg-muted/20", className)}
+      {...props}
+    >
+      <th
+        scope="colgroup"
+        colSpan={vendors.length + 1}
+        className="sticky start-0 bg-muted/20 px-4 py-2 text-start text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground"
+      >
+        {children}
+      </th>
+    </tr>
+  );
+}
+
+export type VendorComparisonRowProps = React.ComponentProps<"tr"> & {
+  /** Feature name shown in the sticky start column. */
+  label: React.ReactNode;
+};
+
+function VendorComparisonRow({
+  label,
+  className,
+  children,
+  ...props
+}: VendorComparisonRowProps) {
+  return (
+    <tr
+      data-slot="vendor-comparison-row"
+      className={cn(
+        "border-b border-border transition-colors last:border-b-0 hover:bg-accent/40",
+        className,
+      )}
+      {...props}
+    >
+      <th
+        scope="row"
+        data-slot="vendor-comparison-label"
+        className="sticky start-0 z-10 bg-card px-4 py-2.5 text-start font-normal text-foreground"
+      >
+        {label}
+      </th>
+      {children}
+    </tr>
+  );
+}
+
+export type VendorComparisonCellProps = Omit<
+  React.ComponentProps<"td">,
+  "children"
+> & {
+  /** Cell content. `true`/`false` render a check or x icon; strings and numbers render as text. */
+  value?: CellValue;
+  /** Tint the cell to match a recommended vendor column. */
+  recommended?: boolean;
+};
+
+function VendorComparisonCell({
+  value,
+  recommended,
+  className,
+  ...props
+}: VendorComparisonCellProps) {
+  return (
+    <td
+      data-slot="vendor-comparison-cell"
+      data-recommended={recommended ? "" : undefined}
+      className={cn(
+        "px-4 py-2.5 text-center",
+        recommended && "bg-primary/5",
+        className,
+      )}
+      {...props}
+    >
+      {typeof value === "boolean" ? (
+        value ? (
+          <>
+            <Check
+              aria-hidden
+              className={cn(
+                "mx-auto size-4",
+                recommended ? "text-primary" : "text-foreground",
+              )}
+            />
+            <span className="sr-only">Yes</span>
+          </>
+        ) : (
+          <>
+            <X aria-hidden className="mx-auto size-4 text-muted-foreground" />
+            <span className="sr-only">No</span>
+          </>
+        )
+      ) : value === undefined || value === "" ? (
+        <>
+          <Minus
+            aria-hidden
+            className="mx-auto size-4 text-muted-foreground"
+          />
+          <span className="sr-only">Not available</span>
+        </>
+      ) : (
+        <span
+          data-slot="vendor-comparison-value"
+          className="font-mono text-xs text-foreground"
+        >
+          {value}
+        </span>
+      )}
+    </td>
+  );
+}
+
+export {
+  VendorComparison,
+  VendorComparisonHeader,
+  VendorComparisonGroup,
+  VendorComparisonRow,
+  VendorComparisonCell,
+};

--- a/vercel.json
+++ b/vercel.json
@@ -337,6 +337,26 @@
       "permanent": true
     },
     {
+      "source": "/components/agent-workflow",
+      "destination": "/components/ai/agent-workflow",
+      "permanent": true
+    },
+    {
+      "source": "/components/ai-chat",
+      "destination": "/components/ai/ai-chat",
+      "permanent": true
+    },
+    {
+      "source": "/components/ai-completion-input",
+      "destination": "/components/ai/ai-completion-input",
+      "permanent": true
+    },
+    {
+      "source": "/components/ai-tool-call",
+      "destination": "/components/ai/ai-tool-call",
+      "permanent": true
+    },
+    {
       "source": "/components/animated-number",
       "destination": "/components/data/animated-number",
       "permanent": true
@@ -552,6 +572,11 @@
       "permanent": true
     },
     {
+      "source": "/components/prompt-editor",
+      "destination": "/components/ai/prompt-editor",
+      "permanent": true
+    },
+    {
       "source": "/components/qr-code",
       "destination": "/components/display/qr-code",
       "permanent": true
@@ -559,6 +584,11 @@
     {
       "source": "/components/quick-actions",
       "destination": "/components/widgets/quick-actions",
+      "permanent": true
+    },
+    {
+      "source": "/components/rag-citations",
+      "destination": "/components/ai/rag-citations",
       "permanent": true
     },
     {

--- a/vercel.json
+++ b/vercel.json
@@ -337,6 +337,11 @@
       "permanent": true
     },
     {
+      "source": "/components/advanced-search-bar",
+      "destination": "/components/inputs/advanced-search-bar",
+      "permanent": true
+    },
+    {
       "source": "/components/agent-workflow",
       "destination": "/components/ai/agent-workflow",
       "permanent": true
@@ -412,6 +417,11 @@
       "permanent": true
     },
     {
+      "source": "/components/breadcrumb-generator",
+      "destination": "/components/navigation/breadcrumb-generator",
+      "permanent": true
+    },
+    {
       "source": "/components/bundle-builder",
       "destination": "/components/commerce/bundle-builder",
       "permanent": true
@@ -424,6 +434,11 @@
     {
       "source": "/components/callout",
       "destination": "/components/display/callout",
+      "permanent": true
+    },
+    {
+      "source": "/components/changelog-viewer",
+      "destination": "/components/display/changelog-viewer",
       "permanent": true
     },
     {
@@ -492,6 +507,11 @@
       "permanent": true
     },
     {
+      "source": "/components/feature-flag-manager",
+      "destination": "/components/saas/feature-flag-manager",
+      "permanent": true
+    },
+    {
       "source": "/components/file-dropzone",
       "destination": "/components/files/file-dropzone",
       "permanent": true
@@ -554,6 +574,11 @@
     {
       "source": "/components/kbd",
       "destination": "/components/display/kbd",
+      "permanent": true
+    },
+    {
+      "source": "/components/keyboard-shortcuts",
+      "destination": "/components/navigation/keyboard-shortcuts",
       "permanent": true
     },
     {
@@ -632,6 +657,11 @@
       "permanent": true
     },
     {
+      "source": "/components/onboarding",
+      "destination": "/components/navigation/onboarding",
+      "permanent": true
+    },
+    {
       "source": "/components/password-input",
       "destination": "/components/inputs/password-input",
       "permanent": true
@@ -682,6 +712,11 @@
       "permanent": true
     },
     {
+      "source": "/components/release-notes",
+      "destination": "/components/display/release-notes",
+      "permanent": true
+    },
+    {
       "source": "/components/request-builder",
       "destination": "/components/dev/request-builder",
       "permanent": true
@@ -689,6 +724,16 @@
     {
       "source": "/components/resizable-panels",
       "destination": "/components/navigation/resizable-panels",
+      "permanent": true
+    },
+    {
+      "source": "/components/review-queue",
+      "destination": "/components/saas/review-queue",
+      "permanent": true
+    },
+    {
+      "source": "/components/role-manager",
+      "destination": "/components/saas/role-manager",
       "permanent": true
     },
     {

--- a/vercel.json
+++ b/vercel.json
@@ -377,6 +377,16 @@
       "permanent": true
     },
     {
+      "source": "/components/asset-manager",
+      "destination": "/components/files/asset-manager",
+      "permanent": true
+    },
+    {
+      "source": "/components/auction-timeline",
+      "destination": "/components/data/auction-timeline",
+      "permanent": true
+    },
+    {
       "source": "/components/audio-player",
       "destination": "/components/display/audio-player",
       "permanent": true
@@ -487,6 +497,11 @@
       "permanent": true
     },
     {
+      "source": "/components/file-explorer",
+      "destination": "/components/files/file-explorer",
+      "permanent": true
+    },
+    {
       "source": "/components/filter-builder",
       "destination": "/components/data/filter-builder",
       "permanent": true
@@ -529,6 +544,11 @@
     {
       "source": "/components/json-viewer",
       "destination": "/components/dev/json-viewer",
+      "permanent": true
+    },
+    {
+      "source": "/components/kanban-board",
+      "destination": "/components/data/kanban-board",
       "permanent": true
     },
     {
@@ -594,6 +614,11 @@
     {
       "source": "/components/multi-select",
       "destination": "/components/inputs/multi-select",
+      "permanent": true
+    },
+    {
+      "source": "/components/nested-sortable",
+      "destination": "/components/data/nested-sortable",
       "permanent": true
     },
     {
@@ -674,6 +699,11 @@
     {
       "source": "/components/scroll-reveal",
       "destination": "/components/animation/scroll-reveal",
+      "permanent": true
+    },
+    {
+      "source": "/components/shipment-tracker",
+      "destination": "/components/data/shipment-tracker",
       "permanent": true
     },
     {
@@ -769,6 +799,11 @@
     {
       "source": "/components/tree-view",
       "destination": "/components/data/tree-view",
+      "permanent": true
+    },
+    {
+      "source": "/components/upload-manager",
+      "destination": "/components/files/upload-manager",
       "permanent": true
     },
     {

--- a/vercel.json
+++ b/vercel.json
@@ -402,6 +402,11 @@
       "permanent": true
     },
     {
+      "source": "/components/bundle-builder",
+      "destination": "/components/commerce/bundle-builder",
+      "permanent": true
+    },
+    {
       "source": "/components/calendar-heatmap",
       "destination": "/components/data/calendar-heatmap",
       "permanent": true
@@ -467,6 +472,11 @@
       "permanent": true
     },
     {
+      "source": "/components/discount-builder",
+      "destination": "/components/commerce/discount-builder",
+      "permanent": true
+    },
+    {
       "source": "/components/dock",
       "destination": "/components/navigation/dock",
       "permanent": true
@@ -509,6 +519,11 @@
     {
       "source": "/components/inspector-panel",
       "destination": "/components/navigation/inspector-panel",
+      "permanent": true
+    },
+    {
+      "source": "/components/inventory-matrix",
+      "destination": "/components/commerce/inventory-matrix",
       "permanent": true
     },
     {
@@ -604,6 +619,11 @@
     {
       "source": "/components/phone-input",
       "destination": "/components/inputs/phone-input",
+      "permanent": true
+    },
+    {
+      "source": "/components/pricing-rules-builder",
+      "destination": "/components/commerce/pricing-rules-builder",
       "permanent": true
     },
     {
@@ -754,6 +774,16 @@
     {
       "source": "/components/usage-dashboard",
       "destination": "/components/saas/usage-dashboard",
+      "permanent": true
+    },
+    {
+      "source": "/components/variant-editor",
+      "destination": "/components/commerce/variant-editor",
+      "permanent": true
+    },
+    {
+      "source": "/components/vendor-comparison",
+      "destination": "/components/commerce/vendor-comparison",
       "permanent": true
     },
     {

--- a/vercel.json
+++ b/vercel.json
@@ -372,6 +372,11 @@
       "permanent": true
     },
     {
+      "source": "/components/approval-workflow",
+      "destination": "/components/data/approval-workflow",
+      "permanent": true
+    },
+    {
       "source": "/components/audio-player",
       "destination": "/components/display/audio-player",
       "permanent": true
@@ -422,6 +427,11 @@
       "permanent": true
     },
     {
+      "source": "/components/command-palette",
+      "destination": "/components/navigation/command-palette",
+      "permanent": true
+    },
+    {
       "source": "/components/copy-button",
       "destination": "/components/display/copy-button",
       "permanent": true
@@ -452,6 +462,11 @@
       "permanent": true
     },
     {
+      "source": "/components/diff-viewer",
+      "destination": "/components/dev/diff-viewer",
+      "permanent": true
+    },
+    {
       "source": "/components/dock",
       "destination": "/components/navigation/dock",
       "permanent": true
@@ -459,6 +474,11 @@
     {
       "source": "/components/file-dropzone",
       "destination": "/components/files/file-dropzone",
+      "permanent": true
+    },
+    {
+      "source": "/components/filter-builder",
+      "destination": "/components/data/filter-builder",
       "permanent": true
     },
     {
@@ -492,6 +512,11 @@
       "permanent": true
     },
     {
+      "source": "/components/json-viewer",
+      "destination": "/components/dev/json-viewer",
+      "permanent": true
+    },
+    {
       "source": "/components/kbd",
       "destination": "/components/display/kbd",
       "permanent": true
@@ -509,6 +534,11 @@
     {
       "source": "/components/lightbox",
       "destination": "/components/display/lightbox",
+      "permanent": true
+    },
+    {
+      "source": "/components/log-viewer",
+      "destination": "/components/dev/log-viewer",
       "permanent": true
     },
     {
@@ -567,6 +597,11 @@
       "permanent": true
     },
     {
+      "source": "/components/permission-matrix",
+      "destination": "/components/data/permission-matrix",
+      "permanent": true
+    },
+    {
       "source": "/components/phone-input",
       "destination": "/components/inputs/phone-input",
       "permanent": true
@@ -582,6 +617,11 @@
       "permanent": true
     },
     {
+      "source": "/components/query-builder",
+      "destination": "/components/data/query-builder",
+      "permanent": true
+    },
+    {
       "source": "/components/quick-actions",
       "destination": "/components/widgets/quick-actions",
       "permanent": true
@@ -594,6 +634,11 @@
     {
       "source": "/components/rating",
       "destination": "/components/inputs/rating",
+      "permanent": true
+    },
+    {
+      "source": "/components/request-builder",
+      "destination": "/components/dev/request-builder",
       "permanent": true
     },
     {
@@ -637,6 +682,11 @@
       "permanent": true
     },
     {
+      "source": "/components/spotlight-search",
+      "destination": "/components/navigation/spotlight-search",
+      "permanent": true
+    },
+    {
       "source": "/components/stat-card",
       "destination": "/components/data/stat-card",
       "permanent": true
@@ -659,6 +709,11 @@
     {
       "source": "/components/tenant-switcher",
       "destination": "/components/navigation/tenant-switcher",
+      "permanent": true
+    },
+    {
+      "source": "/components/terminal",
+      "destination": "/components/dev/terminal",
       "permanent": true
     },
     {


### PR DESCRIPTION
## Summary

This PR adds a comprehensive collection of 40+ new React components to the Hirael registry, spanning three new categories: **AI** (chat, completions, tool calls, citations), **Dev** (query builders, request builders, log viewers, terminals), and **Commerce** (discount builders, bundle builders, pricing rules, inventory management).

## Key Changes

- **AI Components** (8 new): `ai-chat`, `ai-completion-input`, `ai-tool-call`, `prompt-editor`, `rag-citations`, `agent-workflow`, `approval-workflow`, `changelog-viewer`
- **Dev Components** (16 new): `advanced-search-bar`, `spotlight-search`, `file-explorer`, `nested-sortable`, `query-builder`, `request-builder`, `log-viewer`, `keyboard-shortcuts`, `command-palette`, `feature-flag-manager`, `json-viewer`, `diff-viewer`, `terminal`, `upload-manager`, `variant-editor`, `breadcrumb-generator`
- **Commerce Components** (12 new): `discount-builder`, `bundle-builder`, `pricing-rules-builder`, `kanban-board`, `role-manager`, `permission-matrix`, `inventory-matrix`, `asset-manager`, `auction-timeline`, `review-queue`, `onboarding`, `filter-builder`, `shipment-tracker`, `vendor-comparison`
- **Registry Updates**: Updated `registry.json` and `registry-meta.ts` with metadata for all new components
- **Demo Examples**: Added 40+ demo/example files showcasing each component's usage
- **Documentation**: Updated catalog and README to reflect new component counts

## Implementation Details

- All components follow the Hirael compound component pattern with React Context for state management
- Components use `class-variance-authority` for variant styling where applicable
- Consistent use of Lucide React icons throughout
- Each component includes TypeScript types and proper accessibility attributes
- Demo files provide realistic usage examples for each component

https://claude.ai/code/session_01CzbeV7nsXwJ8syyWUvXiko