### PR TITLE
Fix marquee animation direction for RTL layouts

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -140,6 +140,14 @@ positioning is fine where geometry genuinely is physical (Radix
 `data-[side]` animations, the color-picker canvas, `side="left|right"` on
 Sheet/Sidebar). Every preview has an RTL toggle — verify with it.
 
+**CSS-transform animations don't flip themselves.** `translateX` is physical,
+so a keyframe that scrolls a `dir`-aware flex flow has to flip its sign under
+RTL or the loop tears (content exits with nothing trailing it). The marquee
+(`ui/marquee.tsx`) drives its horizontal travel through a `--marquee-x-dir`
+sign (`-1` ltr, `1` rtl, set by a `[dir="rtl"] [data-slot="marquee-track"]`
+rule) so the track moves toward the inline-start either way; `translateY` for
+the vertical mode stays put since the block axis doesn't flip.
+
 The framed `/embed/*` previews carry direction as a `?dir=rtl` query
 param. It's applied to `<html dir>` by a pre-paint inline script
 (`lib/embed.ts`, rendered from each embed `page.tsx`), the same trick the

--- a/registry/hirael/ui/marquee.tsx
+++ b/registry/hirael/ui/marquee.tsx
@@ -19,10 +19,13 @@ export type MarqueeProps = React.ComponentProps<"div"> & {
 
 // Keyframes travel with the component so it works the moment it is copied
 // into a project — no Tailwind config or globals.css edits required.
+// The horizontal track moves toward the inline-start: flex reverses the
+// duplicated tracks under dir="rtl", so the travel sign flips with it
+// (--marquee-x-dir: -1 ltr, 1 rtl) to keep the loop seamless either way.
 const MARQUEE_KEYFRAMES = `
 @keyframes msh-marquee-x {
   from { transform: translateX(0); }
-  to { transform: translateX(calc(-100% - var(--marquee-gap))); }
+  to { transform: translateX(calc(var(--marquee-x-dir, -1) * (100% + var(--marquee-gap)))); }
 }
 @keyframes msh-marquee-y {
   from { transform: translateY(0); }
@@ -30,6 +33,9 @@ const MARQUEE_KEYFRAMES = `
 }
 [data-slot="marquee"][data-pause="true"]:hover [data-slot="marquee-track"] {
   animation-play-state: paused;
+}
+[dir="rtl"] [data-slot="marquee-track"] {
+  --marquee-x-dir: 1;
 }
 `;
 


### PR DESCRIPTION
## Summary
Fixed the marquee component's horizontal animation to properly reverse direction in RTL layouts, preventing the animation loop from tearing when content exits without trailing replacements.

## Changes
- **Animation keyframe update**: Modified the `msh-marquee-x` keyframe to use a CSS variable (`--marquee-x-dir`) that flips the translation sign based on text direction, ensuring the marquee moves toward the inline-start in both LTR and RTL modes
- **RTL variable binding**: Added a CSS rule that sets `--marquee-x-dir: 1` for RTL contexts (default is `-1` for LTR), allowing the same keyframe to work bidirectionally
- **Documentation**: Updated `docs/conventions.md` with guidance on handling CSS transform animations in RTL, explaining the marquee implementation as a reference example

## Implementation Details
The marquee component uses `translateX` for horizontal movement, which is a physical (not logical) CSS property. Since flexbox reverses the track order under `dir="rtl"`, the animation travel direction must also flip to maintain a seamless loop. By multiplying the distance by `--marquee-x-dir`, the animation naturally adapts to the layout direction without requiring separate keyframe definitions. The vertical `translateY` animation remains unchanged since the block axis doesn't flip in RTL.

https://claude.ai/code/session_01F3fX4oF7SqmyaDvKmD1cmK