### PR TITLE
Add Confirm and Unsaved Guard components

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -93,7 +93,7 @@ vercel.json                       # GENERATED redirects (old flat URLs → categ
 - **Registry pipeline** — `registry-meta.ts` as the single source of truth,
   generation + drift check + prop extraction + comment stripping wired into
   `pnpm build`.
-- **Catalog** — 72 registry UI items (70 components + 2 distribution-only
+- **Catalog** — 73 registry UI items (71 components + 2 distribution-only
   primitives), 56 blocks, and 9 full-page templates (Creative Studio,
   Agency Landing, Portfolio, USD Halo, Mindloop, Rivr, NexaCore, Velorah,
   Asme). Full list in [catalog.md](./catalog.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,8 +93,8 @@ vercel.json                       # GENERATED redirects (old flat URLs → categ
 - **Registry pipeline** — `registry-meta.ts` as the single source of truth,
   generation + drift check + prop extraction + comment stripping wired into
   `pnpm build`.
-- **Catalog** — 70 registry UI items (69 components + the distribution-only
-  `accordion`), 40 blocks, and 9 full-page templates (Creative Studio,
+- **Catalog** — 72 registry UI items (70 components + 2 distribution-only
+  primitives), 56 blocks, and 9 full-page templates (Creative Studio,
   Agency Landing, Portfolio, USD Halo, Mindloop, Rivr, NexaCore, Velorah,
   Asme). Full list in [catalog.md](./catalog.md).
 - **Showcase** — landing with live demos, component/block/template indexes,

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -8,7 +8,7 @@ table here in the same change.
 
 The catalog spans three tiers: **components** (single UI primitives),
 **blocks** (marketing / app sections), and **templates** (full, multi-section
-pages). As of the last update: **72 registry UI items** (70 standalone
+pages). As of the last update: **73 registry UI items** (71 standalone
 components + 2 distribution-only primitives), **56 section blocks**, and
 **9 templates**. Counts come from `registry.json`; the landing page derives
 its counts from `registry-meta.ts`, so treat that file as the truth if these
@@ -84,7 +84,7 @@ and a breadcrumb trail. Build links with `entryHref(entry)` from
 | `timeline`         | —             | Vertical event timeline with default or icon dots, tone variants and labelled time / title / description parts.                                                  |
 | `tree-view`        | `collapsible` | Collapsible nested tree for file explorers and hierarchical data, with auto folder/file icons, depth indentation, selection and keyboard focus.                  |
 
-#### Display & feedback (14)
+#### Display & feedback (15)
 
 | Component          | Registry deps                    | What it is                                                                                                                                                                                     |
 | ------------------ | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -102,6 +102,7 @@ and a breadcrumb trail. Build links with `entryHref(entry)` from
 | `qr-code`          | —                                | Dependency-free QR code generator rendering crisp SVG, with L/M/Q/H error correction, quiet-zone control and `currentColor` theming.                                                           |
 | `scroll-progress`  | —                                | Fixed reading progress bar. Tracks document scroll by default or a scoped container ref.                                                                                                       |
 | `spinner`          | —                                | Loading indicator with circle, dots and bars variants, sm / md / lg sizes. Inherits text color and ships an accessible status label.                                                           |
+| `unsaved-guard`    | `confirm`                        | Unsaved-changes navigation guard from a provider and a `useUnsavedGuard` hook. Warns on reload, tab close and in-app links, with a `guard(proceed)` for programmatic navigation.               |
 
 #### Navigation (10)
 

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -8,8 +8,8 @@ table here in the same change.
 
 The catalog spans three tiers: **components** (single UI primitives),
 **blocks** (marketing / app sections), and **templates** (full, multi-section
-pages). As of the last update: **70 registry UI items** (69 standalone
-components + 1 distribution-only primitive), **56 section blocks**, and
+pages). As of the last update: **72 registry UI items** (70 standalone
+components + 2 distribution-only primitives), **56 section blocks**, and
 **9 templates**. Counts come from `registry.json`; the landing page derives
 its counts from `registry-meta.ts`, so treat that file as the truth if these
 drift.
@@ -84,23 +84,24 @@ and a breadcrumb trail. Build links with `entryHref(entry)` from
 | `timeline`         | —             | Vertical event timeline with default or icon dots, tone variants and labelled time / title / description parts.                                                  |
 | `tree-view`        | `collapsible` | Collapsible nested tree for file explorers and hierarchical data, with auto folder/file icons, depth indentation, selection and keyboard focus.                  |
 
-#### Display & feedback (13)
+#### Display & feedback (14)
 
-| Component          | Registry deps                    | What it is                                                                                                                                   |
-| ------------------ | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `announcement-bar` | —                                | Top-of-page banner with default / primary / muted tones, optional dismiss button and localStorage persistence.                               |
-| `audio-player`     | `button`, `slider`               | Composable audio player with play/pause, scrub-safe seek with buffered tint, skip, time readouts, volume and playback rate.                  |
-| `callout`          | —                                | MDX-style admonition with info / success / warning / error / neutral variants. Ships `--info` / `--success` / `--warning` theme tokens.      |
-| `code-block`       | `badge`, `button`, `copy-button` | Code display with dependency-free token highlighting, line numbers, line highlights, diff gutters, copy button and collapsible max-height.   |
-| `copy-button`      | —                                | Click-to-copy button with copied feedback, icon-only or labelled, ghost / outline variants and a non-secure-context clipboard fallback.      |
-| `image-compare`    | —                                | Before/after comparison slider with a draggable, keyboard-accessible divider, horizontal or vertical orientation and hover-follow mode.      |
-| `kbd`              | —                                | 3D tactile keycap with hover lift and pressed states. Compound API with `KbdGroup` for chords and `KbdDisplay` for inline keys.              |
-| `lightbox`         | —                                | Fullscreen image lightbox on Radix Dialog with gallery navigation, zoom and pan, swipe gestures, captions and a thumbnail strip.             |
-| `marquee`          | —                                | Infinite scrolling row or column for logos and testimonials, with pause-on-hover, reverse and vertical modes. Keyframes inline, zero config. |
-| `masonry`          | —                                | True masonry layout that balances children into the shortest column by measured height, order-preserving, responsive, dependency-free.       |
-| `qr-code`          | —                                | Dependency-free QR code generator rendering crisp SVG, with L/M/Q/H error correction, quiet-zone control and `currentColor` theming.         |
-| `scroll-progress`  | —                                | Fixed reading progress bar. Tracks document scroll by default or a scoped container ref.                                                     |
-| `spinner`          | —                                | Loading indicator with circle, dots and bars variants, sm / md / lg sizes. Inherits text color and ships an accessible status label.         |
+| Component          | Registry deps                    | What it is                                                                                                                                                                                     |
+| ------------------ | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `announcement-bar` | —                                | Top-of-page banner with default / primary / muted tones, optional dismiss button and localStorage persistence.                                                                                 |
+| `audio-player`     | `button`, `slider`               | Composable audio player with play/pause, scrub-safe seek with buffered tint, skip, time readouts, volume and playback rate.                                                                    |
+| `callout`          | —                                | MDX-style admonition with info / success / warning / error / neutral variants. Ships `--info` / `--success` / `--warning` theme tokens.                                                        |
+| `code-block`       | `badge`, `button`, `copy-button` | Code display with dependency-free token highlighting, line numbers, line highlights, diff gutters, copy button and collapsible max-height.                                                     |
+| `confirm`          | `alert-dialog`, `button`         | Imperative confirm dialog from a root provider and a `useConfirm` hook that resolves a promise. Default or destructive tone, optional icon and an async confirm action with a pending spinner. |
+| `copy-button`      | —                                | Click-to-copy button with copied feedback, icon-only or labelled, ghost / outline variants and a non-secure-context clipboard fallback.                                                        |
+| `image-compare`    | —                                | Before/after comparison slider with a draggable, keyboard-accessible divider, horizontal or vertical orientation and hover-follow mode.                                                        |
+| `kbd`              | —                                | 3D tactile keycap with hover lift and pressed states. Compound API with `KbdGroup` for chords and `KbdDisplay` for inline keys.                                                                |
+| `lightbox`         | —                                | Fullscreen image lightbox on Radix Dialog with gallery navigation, zoom and pan, swipe gestures, captions and a thumbnail strip.                                                               |
+| `marquee`          | —                                | Infinite scrolling row or column for logos and testimonials, with pause-on-hover, reverse and vertical modes. Keyframes inline, zero config.                                                   |
+| `masonry`          | —                                | True masonry layout that balances children into the shortest column by measured height, order-preserving, responsive, dependency-free.                                                         |
+| `qr-code`          | —                                | Dependency-free QR code generator rendering crisp SVG, with L/M/Q/H error correction, quiet-zone control and `currentColor` theming.                                                           |
+| `scroll-progress`  | —                                | Fixed reading progress bar. Tracks document scroll by default or a scoped container ref.                                                                                                       |
+| `spinner`          | —                                | Loading indicator with circle, dots and bars variants, sm / md / lg sizes. Inherits text color and ships an accessible status label.                                                           |
 
 #### Navigation (10)
 

--- a/registry.json
+++ b/registry.json
@@ -3459,6 +3459,26 @@
       ]
     },
     {
+      "name": "unsaved-guard",
+      "type": "registry:ui",
+      "title": "Unsaved Guard",
+      "description": "Unsaved-changes guard: a root provider plus a useUnsavedGuard hook. Warns before reload, tab close and in-app link navigation, and returns a guard(proceed) to wrap programmatic navigation in a confirm dialog.",
+      "categories": [
+        "display"
+      ],
+      "dependencies": [],
+      "registryDependencies": [
+        "confirm"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/unsaved-guard.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/unsaved-guard.tsx"
+        }
+      ]
+    },
+    {
       "name": "accordion",
       "type": "registry:ui",
       "title": "Accordion",

--- a/registry.json
+++ b/registry.json
@@ -3438,6 +3438,27 @@
       ]
     },
     {
+      "name": "confirm",
+      "type": "registry:ui",
+      "title": "Confirm",
+      "description": "Imperative confirmation dialog: a root provider plus a useConfirm hook that resolves a promise on confirm or cancel. Default or destructive tone, an optional icon, and an async confirm action with a pending spinner.",
+      "categories": [
+        "display"
+      ],
+      "dependencies": [],
+      "registryDependencies": [
+        "alert-dialog",
+        "button"
+      ],
+      "files": [
+        {
+          "path": "registry/hirael/ui/confirm.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/confirm.tsx"
+        }
+      ]
+    },
+    {
       "name": "accordion",
       "type": "registry:ui",
       "title": "Accordion",

--- a/registry/hirael/examples/confirm-demo.tsx
+++ b/registry/hirael/examples/confirm-demo.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import * as React from "react";
+import { Trash2 } from "lucide-react";
+
+import { useT } from "@/lib/demo-locale";
+import { Button } from "@/registry/hirael/ui/button";
+import { ConfirmProvider, useConfirm } from "@/registry/hirael/ui/confirm";
+
+function ConfirmDemoInner() {
+  const t = useT();
+  const confirm = useConfirm();
+  const [status, setStatus] = React.useState<React.ReactNode>(
+    t({ en: "No action yet.", ar: "لا إجراء بعد." }),
+  );
+  const [deleted, setDeleted] = React.useState(false);
+
+  async function handlePublish() {
+    const ok = await confirm({
+      title: t({ en: "Publish changes?", ar: "نشر التغييرات؟" }),
+      description: t({
+        en: "Your edits go live for everyone right away.",
+        ar: "ستظهر تعديلاتك للجميع فورًا.",
+      }),
+      confirmText: t({ en: "Publish", ar: "نشر" }),
+    });
+    setStatus(
+      ok
+        ? t({ en: "Changes published.", ar: "تم نشر التغييرات." })
+        : t({ en: "Publish cancelled.", ar: "أُلغي النشر." }),
+    );
+  }
+
+  async function handleDelete() {
+    await confirm({
+      tone: "destructive",
+      icon: <Trash2 />,
+      title: t({ en: "Delete project?", ar: "حذف المشروع؟" }),
+      description: t({
+        en: "This removes the project and all of its files. You can't undo it.",
+        ar: "سيؤدي هذا إلى حذف المشروع وكل ملفاته. لا يمكن التراجع.",
+      }),
+      confirmText: t({ en: "Delete", ar: "حذف" }),
+      onConfirm: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1200));
+        setDeleted(true);
+        setStatus(t({ en: "Project deleted.", ar: "تم حذف المشروع." }));
+      },
+    });
+  }
+
+  return (
+    <div className="grid w-full max-w-sm gap-4">
+      <div className="flex flex-wrap gap-2">
+        <Button variant="outline" onClick={handlePublish}>
+          {t({ en: "Publish changes", ar: "نشر التغييرات" })}
+        </Button>
+        <Button variant="outline" onClick={handleDelete} disabled={deleted}>
+          {t({ en: "Delete project", ar: "حذف المشروع" })}
+        </Button>
+      </div>
+      <p className="text-sm text-muted-foreground" aria-live="polite">
+        {status}
+      </p>
+    </div>
+  );
+}
+
+export default function ConfirmDemo() {
+  return (
+    <ConfirmProvider>
+      <ConfirmDemoInner />
+    </ConfirmProvider>
+  );
+}

--- a/registry/hirael/examples/unsaved-guard-demo.tsx
+++ b/registry/hirael/examples/unsaved-guard-demo.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { useT } from "@/lib/demo-locale";
+import { Button } from "@/registry/hirael/ui/button";
+import { Input } from "@/registry/hirael/ui/input";
+import {
+  UnsavedGuardProvider,
+  useUnsavedGuard,
+} from "@/registry/hirael/ui/unsaved-guard";
+
+type Tab = "profile" | "billing";
+
+function UnsavedGuardDemoInner() {
+  const t = useT();
+  const [tab, setTab] = React.useState<Tab>("profile");
+  const [name, setName] = React.useState("Mohammad Shehadeh");
+  const [savedName, setSavedName] = React.useState("Mohammad Shehadeh");
+  const dirty = name !== savedName;
+
+  const guard = useUnsavedGuard({
+    when: dirty,
+    title: t({ en: "Discard changes?", ar: "تجاهل التغييرات؟" }),
+    description: t({
+      en: "Your profile edits haven't been saved yet.",
+      ar: "لم تُحفظ تعديلات ملفك الشخصي بعد.",
+    }),
+    confirmText: t({ en: "Discard", ar: "تجاهل" }),
+    cancelText: t({ en: "Keep editing", ar: "متابعة التحرير" }),
+  });
+
+  function goTo(next: Tab) {
+    if (next === tab) return;
+    void guard(() => {
+      setName(savedName);
+      setTab(next);
+    });
+  }
+
+  const tabs: { id: Tab; label: React.ReactNode }[] = [
+    { id: "profile", label: t({ en: "Profile", ar: "الملف الشخصي" }) },
+    { id: "billing", label: t({ en: "Billing", ar: "الفوترة" }) },
+  ];
+
+  return (
+    <div className="grid w-full max-w-sm gap-4">
+      <div role="tablist" className="flex gap-1">
+        {tabs.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            role="tab"
+            aria-selected={tab === item.id}
+            onClick={() => goTo(item.id)}
+            className={cn(
+              "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+              tab === item.id
+                ? "bg-secondary text-secondary-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+
+      {tab === "profile" ? (
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            setSavedName(name);
+          }}
+          className="grid gap-3"
+        >
+          <label className="grid gap-1.5">
+            <span className="text-sm font-medium">
+              {t({ en: "Display name", ar: "الاسم الظاهر" })}
+            </span>
+            <Input
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+            />
+          </label>
+          <div className="flex items-center gap-3">
+            <Button type="submit" size="sm" disabled={!dirty}>
+              {t({ en: "Save", ar: "حفظ" })}
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              {dirty
+                ? t({ en: "Unsaved changes", ar: "تغييرات غير محفوظة" })
+                : t({ en: "All changes saved", ar: "حُفظت كل التغييرات" })}
+            </span>
+          </div>
+        </form>
+      ) : (
+        <p className="rounded-md border border-border bg-card p-4 text-sm text-muted-foreground">
+          {t({
+            en: "Edit your name on Profile, then switch tabs to trigger the guard.",
+            ar: "عدّل اسمك في تبويب الملف الشخصي ثم بدّل التبويب لتشغيل الحارس.",
+          })}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default function UnsavedGuardDemo() {
+  return (
+    <UnsavedGuardProvider beforeUnload={false}>
+      <UnsavedGuardDemoInner />
+    </UnsavedGuardProvider>
+  );
+}

--- a/registry/hirael/registry-demos.tsx
+++ b/registry/hirael/registry-demos.tsx
@@ -184,6 +184,8 @@ const EXAMPLE_LOADERS: Record<
     import("@/registry/hirael/examples/calendar-heatmap-demo"),
   "code-block-demo": () => import("@/registry/hirael/examples/code-block-demo"),
   "confirm-demo": () => import("@/registry/hirael/examples/confirm-demo"),
+  "unsaved-guard-demo": () =>
+    import("@/registry/hirael/examples/unsaved-guard-demo"),
   "masonry-demo": () => import("@/registry/hirael/examples/masonry-demo"),
   "audio-player-demo": () =>
     import("@/registry/hirael/examples/audio-player-demo"),

--- a/registry/hirael/registry-demos.tsx
+++ b/registry/hirael/registry-demos.tsx
@@ -183,6 +183,7 @@ const EXAMPLE_LOADERS: Record<
   "calendar-heatmap-demo": () =>
     import("@/registry/hirael/examples/calendar-heatmap-demo"),
   "code-block-demo": () => import("@/registry/hirael/examples/code-block-demo"),
+  "confirm-demo": () => import("@/registry/hirael/examples/confirm-demo"),
   "masonry-demo": () => import("@/registry/hirael/examples/masonry-demo"),
   "audio-player-demo": () =>
     import("@/registry/hirael/examples/audio-player-demo"),

--- a/registry/hirael/registry-meta.ts
+++ b/registry/hirael/registry-meta.ts
@@ -2295,6 +2295,16 @@ export const REGISTRY: RegistryEntryMeta[] = [
     registryDependencies: ["alert-dialog", "button"],
     dependencies: [],
   },
+  {
+    name: "unsaved-guard",
+    title: "Unsaved Guard",
+    description:
+      "Unsaved-changes guard: a root provider plus a useUnsavedGuard hook. Warns before reload, tab close and in-app link navigation, and returns a guard(proceed) to wrap programmatic navigation in a confirm dialog.",
+    category: "display",
+    files: [{ path: "registry/hirael/ui/unsaved-guard.tsx" }],
+    registryDependencies: ["confirm"],
+    dependencies: [],
+  },
 ];
 
 /**

--- a/registry/hirael/registry-meta.ts
+++ b/registry/hirael/registry-meta.ts
@@ -2285,6 +2285,16 @@ export const REGISTRY: RegistryEntryMeta[] = [
     registryDependencies: ["card", "chart", "empty", "tooltip", "button"],
     dependencies: ["recharts", "lucide-react"],
   },
+  {
+    name: "confirm",
+    title: "Confirm",
+    description:
+      "Imperative confirmation dialog: a root provider plus a useConfirm hook that resolves a promise on confirm or cancel. Default or destructive tone, an optional icon, and an async confirm action with a pending spinner.",
+    category: "display",
+    files: [{ path: "registry/hirael/ui/confirm.tsx" }],
+    registryDependencies: ["alert-dialog", "button"],
+    dependencies: [],
+  },
 ];
 
 /**

--- a/registry/hirael/registry-props.json
+++ b/registry/hirael/registry-props.json
@@ -7072,5 +7072,41 @@
       ],
       "extendsNative": false
     }
+  ],
+  "unsaved-guard": [
+    {
+      "name": "UnsavedGuardProvider",
+      "props": [
+        {
+          "name": "children",
+          "type": "React.ReactNode",
+          "required": true,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "beforeUnload",
+          "type": "boolean",
+          "required": false,
+          "default": "true",
+          "description": "Warn on reload / tab close via the browser's native prompt. Default true."
+        },
+        {
+          "name": "onProceed",
+          "type": "((href: string) => void)",
+          "required": false,
+          "default": null,
+          "description": "Called with the destination URL when the user confirms leaving via an\nin-app link. Use it to navigate through your router (e.g. `router.push`);\ndefaults to a full navigation."
+        },
+        {
+          "name": "defaultOptions",
+          "type": "Omit<UnsavedGuardOptions, \"when\">",
+          "required": false,
+          "default": null,
+          "description": "Default leave-dialog copy, overridden per `useUnsavedGuard` call."
+        }
+      ],
+      "extendsNative": false
+    }
   ]
 }

--- a/registry/hirael/registry-props.json
+++ b/registry/hirael/registry-props.json
@@ -7050,5 +7050,27 @@
       ],
       "extendsNative": true
     }
+  ],
+  "confirm": [
+    {
+      "name": "ConfirmProvider",
+      "props": [
+        {
+          "name": "children",
+          "type": "React.ReactNode",
+          "required": true,
+          "default": null,
+          "description": null
+        },
+        {
+          "name": "defaultOptions",
+          "type": "Pick<ConfirmOptions, \"tone\" | \"confirmText\" | \"cancelText\" | \"dismissible\">",
+          "required": false,
+          "default": null,
+          "description": "Defaults merged under every `confirm()` call."
+        }
+      ],
+      "extendsNative": false
+    }
   ]
 }

--- a/registry/hirael/ui/confirm.tsx
+++ b/registry/hirael/ui/confirm.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+} from "@/registry/hirael/ui/alert-dialog";
+import { Button } from "@/registry/hirael/ui/button";
+
+export type ConfirmTone = "default" | "destructive";
+
+export type ConfirmOptions = {
+  /** Dialog heading. */
+  title?: React.ReactNode;
+  /** Supporting line under the title. */
+  description?: React.ReactNode;
+  /** Confirm button label. Defaults to "Confirm". */
+  confirmText?: React.ReactNode;
+  /** Cancel button label. Defaults to "Cancel". */
+  cancelText?: React.ReactNode;
+  /** `destructive` tints the confirm button as a danger action. */
+  tone?: ConfirmTone;
+  /** Optional icon shown in the header media slot. */
+  icon?: React.ReactNode;
+  /** Whether Escape dismisses the dialog (counts as cancel). Defaults to true. */
+  dismissible?: boolean;
+  /**
+   * Runs when the user confirms. While the returned promise is pending the
+   * confirm button shows a spinner and the dialog stays open, closing once it
+   * resolves. If it rejects, the dialog returns to its idle state so the user
+   * can retry, so handle the error inside `onConfirm`. When omitted,
+   * confirming closes immediately.
+   */
+  onConfirm?: () => void | Promise<void>;
+};
+
+/** Opens the dialog and resolves `true` on confirm, `false` on cancel/dismiss. */
+export type ConfirmFn = (options?: ConfirmOptions) => Promise<boolean>;
+
+const ConfirmContext = React.createContext<ConfirmFn | null>(null);
+
+/**
+ * Returns a `confirm(options)` function that opens the shared dialog and
+ * resolves to `true` when the user confirms or `false` when they cancel or
+ * dismiss it. Must be called under a `<ConfirmProvider>`.
+ */
+function useConfirm(): ConfirmFn {
+  const ctx = React.useContext(ConfirmContext);
+  if (!ctx) {
+    throw new Error("useConfirm must be used inside <ConfirmProvider>");
+  }
+  return ctx;
+}
+
+type ConfirmRequest = {
+  options: ConfirmOptions;
+  resolve: (value: boolean) => void;
+};
+
+export type ConfirmProviderProps = {
+  children: React.ReactNode;
+  /** Defaults merged under every `confirm()` call. */
+  defaultOptions?: Pick<
+    ConfirmOptions,
+    "confirmText" | "cancelText" | "tone" | "dismissible"
+  >;
+};
+
+const CLOSE_DURATION = 200;
+
+/**
+ * Wrap your app once, near the root. Renders a single shared alert dialog and
+ * exposes `useConfirm()` to any descendant. Re-entrant `confirm()` calls queue
+ * behind the open one.
+ */
+function ConfirmProvider({ children, defaultOptions }: ConfirmProviderProps) {
+  const [open, setOpen] = React.useState(false);
+  const [pending, setPending] = React.useState(false);
+  const [active, setActive] = React.useState<ConfirmRequest | null>(null);
+  const activeRef = React.useRef<ConfirmRequest | null>(null);
+  const queueRef = React.useRef<ConfirmRequest[]>([]);
+  const closingRef = React.useRef(false);
+
+  const confirm = React.useCallback<ConfirmFn>((options = {}) => {
+    return new Promise<boolean>((resolve) => {
+      const request: ConfirmRequest = { options, resolve };
+      if (activeRef.current) {
+        queueRef.current.push(request);
+        return;
+      }
+      activeRef.current = request;
+      setActive(request);
+      setOpen(true);
+    });
+  }, []);
+
+  const settle = React.useCallback((value: boolean) => {
+    const current = activeRef.current;
+    if (!current || closingRef.current) return;
+    closingRef.current = true;
+    current.resolve(value);
+    setPending(false);
+    setOpen(false);
+    window.setTimeout(() => {
+      closingRef.current = false;
+      const next = queueRef.current.shift() ?? null;
+      activeRef.current = next;
+      setActive(next);
+      setOpen(next !== null);
+    }, CLOSE_DURATION);
+  }, []);
+
+  const handleConfirm = React.useCallback(() => {
+    if (closingRef.current) return;
+    const onConfirm = activeRef.current?.options.onConfirm;
+    if (!onConfirm) {
+      settle(true);
+      return;
+    }
+    setPending(true);
+    Promise.resolve()
+      .then(onConfirm)
+      .then(
+        () => settle(true),
+        (error) => {
+          setPending(false);
+          throw error;
+        },
+      );
+  }, [settle]);
+
+  const handleOpenChange = React.useCallback(
+    (next: boolean) => {
+      if (next || pending) return;
+      settle(false);
+    },
+    [pending, settle],
+  );
+
+  const options: ConfirmOptions = {
+    confirmText: "Confirm",
+    cancelText: "Cancel",
+    tone: "default",
+    dismissible: true,
+    ...defaultOptions,
+    ...active?.options,
+  };
+  const tone = options.tone ?? "default";
+  const dismissible = options.dismissible ?? true;
+  const hasDescription = options.description != null;
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      <AlertDialog open={open} onOpenChange={handleOpenChange}>
+        <AlertDialogContent
+          data-tone={tone}
+          onEscapeKeyDown={(event) => {
+            if (!dismissible || pending) event.preventDefault();
+          }}
+          {...(hasDescription ? {} : { "aria-describedby": undefined })}
+        >
+          <AlertDialogHeader>
+            {options.icon != null ? (
+              <AlertDialogMedia
+                className={cn(
+                  tone === "destructive" &&
+                    "bg-destructive/10 text-destructive",
+                )}
+              >
+                {options.icon}
+              </AlertDialogMedia>
+            ) : null}
+            <AlertDialogTitle>{options.title}</AlertDialogTitle>
+            {hasDescription ? (
+              <AlertDialogDescription>
+                {options.description}
+              </AlertDialogDescription>
+            ) : null}
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={pending}>
+              {options.cancelText}
+            </AlertDialogCancel>
+            <Button
+              type="button"
+              data-slot="confirm-action"
+              data-tone={tone}
+              variant={tone === "destructive" ? "destructive" : "default"}
+              disabled={pending}
+              onClick={handleConfirm}
+            >
+              {pending ? <ConfirmSpinner /> : null}
+              {options.confirmText}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </ConfirmContext.Provider>
+  );
+}
+
+function ConfirmSpinner() {
+  return (
+    <span
+      data-slot="confirm-spinner"
+      aria-hidden
+      className="size-4 animate-spin rounded-full border-2 border-current border-e-transparent"
+    />
+  );
+}
+
+export { ConfirmProvider, useConfirm };

--- a/registry/hirael/ui/unsaved-guard.tsx
+++ b/registry/hirael/ui/unsaved-guard.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import * as React from "react";
+
+import { ConfirmProvider, useConfirm } from "@/registry/hirael/ui/confirm";
+
+export type UnsavedGuardOptions = {
+  /** Whether there are unsaved changes to guard. */
+  when: boolean;
+  /** Leave-dialog heading. */
+  title?: React.ReactNode;
+  /** Leave-dialog supporting line. */
+  description?: React.ReactNode;
+  /** Leave (proceed) button label. */
+  confirmText?: React.ReactNode;
+  /** Stay (cancel) button label. */
+  cancelText?: React.ReactNode;
+};
+
+/**
+ * Runs `proceed` once it is safe to navigate. With no unsaved changes it runs
+ * immediately; otherwise it asks for confirmation first. Resolves `true` when
+ * the navigation went ahead, `false` when it was cancelled.
+ */
+export type GuardNavigation = (
+  proceed?: () => void | Promise<void>,
+) => Promise<boolean>;
+
+type UnsavedGuardContextValue = {
+  register: (id: string, options: UnsavedGuardOptions) => void;
+  unregister: (id: string) => void;
+  confirmLeave: (options?: Partial<UnsavedGuardOptions>) => Promise<boolean>;
+};
+
+const UnsavedGuardContext =
+  React.createContext<UnsavedGuardContextValue | null>(null);
+
+/**
+ * Registers an unsaved-changes guard. While `when` is true, leaving the page
+ * (reload, tab close, in-app link) is intercepted with a confirm dialog.
+ * Returns a `guard(proceed)` to wrap programmatic navigation. Must be used
+ * under an `<UnsavedGuardProvider>`.
+ */
+function useUnsavedGuard(options: UnsavedGuardOptions): GuardNavigation {
+  const ctx = React.useContext(UnsavedGuardContext);
+  if (!ctx) {
+    throw new Error(
+      "useUnsavedGuard must be used inside <UnsavedGuardProvider>",
+    );
+  }
+  const id = React.useId();
+  const { when, title, description, confirmText, cancelText } = options;
+
+  const latestRef = React.useRef(options);
+  React.useEffect(() => {
+    latestRef.current = { when, title, description, confirmText, cancelText };
+  });
+
+  React.useEffect(() => {
+    ctx.register(id, { when, title, description, confirmText, cancelText });
+    return () => ctx.unregister(id);
+  }, [ctx, id, when, title, description, confirmText, cancelText]);
+
+  return React.useCallback<GuardNavigation>(
+    (proceed) => {
+      const current = latestRef.current;
+      if (!current.when) {
+        return Promise.resolve(proceed?.()).then(() => true);
+      }
+      return ctx.confirmLeave(current).then((ok) => {
+        if (!ok) return false;
+        return Promise.resolve(proceed?.()).then(() => true);
+      });
+    },
+    [ctx],
+  );
+}
+
+export type UnsavedGuardProviderProps = {
+  children: React.ReactNode;
+  /** Warn on reload / tab close via the browser's native prompt. Default true. */
+  beforeUnload?: boolean;
+  /**
+   * Called with the destination URL when the user confirms leaving via an
+   * in-app link. Use it to navigate through your router (e.g. `router.push`);
+   * defaults to a full navigation.
+   */
+  onProceed?: (href: string) => void;
+  /** Default leave-dialog copy, overridden per `useUnsavedGuard` call. */
+  defaultOptions?: Omit<UnsavedGuardOptions, "when">;
+};
+
+function UnsavedGuardProvider({
+  children,
+  beforeUnload = true,
+  onProceed,
+  defaultOptions,
+}: UnsavedGuardProviderProps) {
+  return (
+    <ConfirmProvider>
+      <UnsavedGuardInner
+        beforeUnload={beforeUnload}
+        onProceed={onProceed}
+        defaultOptions={defaultOptions}
+      >
+        {children}
+      </UnsavedGuardInner>
+    </ConfirmProvider>
+  );
+}
+
+function UnsavedGuardInner({
+  children,
+  beforeUnload,
+  onProceed,
+  defaultOptions,
+}: Required<Pick<UnsavedGuardProviderProps, "beforeUnload">> &
+  Pick<
+    UnsavedGuardProviderProps,
+    "onProceed" | "defaultOptions" | "children"
+  >) {
+  const confirm = useConfirm();
+  const guardsRef = React.useRef(new Map<string, UnsavedGuardOptions>());
+  const blockedRef = React.useRef(false);
+  const activeRef = React.useRef<UnsavedGuardOptions | null>(null);
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
+
+  const {
+    title: defTitle,
+    description: defDescription,
+    confirmText: defConfirmText,
+    cancelText: defCancelText,
+  } = defaultOptions ?? {};
+
+  const recompute = React.useCallback(() => {
+    let active: UnsavedGuardOptions | null = null;
+    for (const value of guardsRef.current.values()) {
+      if (value.when) {
+        active = value;
+        break;
+      }
+    }
+    blockedRef.current = active !== null;
+    activeRef.current = active;
+  }, []);
+
+  const register = React.useCallback(
+    (id: string, options: UnsavedGuardOptions) => {
+      guardsRef.current.set(id, options);
+      recompute();
+    },
+    [recompute],
+  );
+
+  const unregister = React.useCallback(
+    (id: string) => {
+      guardsRef.current.delete(id);
+      recompute();
+    },
+    [recompute],
+  );
+
+  const confirmLeave = React.useCallback(
+    (options?: Partial<UnsavedGuardOptions>) =>
+      confirm({
+        tone: "destructive",
+        title: options?.title ?? defTitle ?? "Discard unsaved changes?",
+        description:
+          options?.description ??
+          defDescription ??
+          "You have unsaved changes that will be lost if you leave.",
+        confirmText: options?.confirmText ?? defConfirmText ?? "Leave",
+        cancelText: options?.cancelText ?? defCancelText ?? "Stay",
+      }),
+    [confirm, defTitle, defDescription, defConfirmText, defCancelText],
+  );
+
+  React.useEffect(() => {
+    if (!beforeUnload) return;
+    const handler = (event: BeforeUnloadEvent) => {
+      if (!blockedRef.current) return;
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [beforeUnload]);
+
+  React.useEffect(() => {
+    const root = wrapperRef.current;
+    if (!root) return;
+    const onClick = (event: MouseEvent) => {
+      if (!blockedRef.current || event.defaultPrevented) return;
+      if (
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+      ) {
+        return;
+      }
+      const anchor =
+        event.target instanceof Element ? event.target.closest("a") : null;
+      if (
+        !anchor ||
+        anchor.target === "_blank" ||
+        anchor.hasAttribute("download")
+      ) {
+        return;
+      }
+      const href = anchor.getAttribute("href");
+      if (!href || href.startsWith("#")) return;
+      let url: URL;
+      try {
+        url = new URL(anchor.href, window.location.href);
+      } catch {
+        return;
+      }
+      if (url.origin !== window.location.origin) return;
+      if (url.href === window.location.href) return;
+      event.preventDefault();
+      event.stopPropagation();
+      void confirmLeave(activeRef.current ?? undefined).then((ok) => {
+        if (!ok) return;
+        if (onProceed) {
+          onProceed(url.href);
+        } else {
+          window.location.assign(url.href);
+        }
+      });
+    };
+    root.addEventListener("click", onClick, true);
+    return () => root.removeEventListener("click", onClick, true);
+  }, [confirmLeave, onProceed]);
+
+  const value = React.useMemo<UnsavedGuardContextValue>(
+    () => ({ register, unregister, confirmLeave }),
+    [register, unregister, confirmLeave],
+  );
+
+  return (
+    <UnsavedGuardContext.Provider value={value}>
+      <div ref={wrapperRef} style={{ display: "contents" }}>
+        {children}
+      </div>
+    </UnsavedGuardContext.Provider>
+  );
+}
+
+export { UnsavedGuardProvider, useUnsavedGuard };

--- a/vercel.json
+++ b/vercel.json
@@ -672,6 +672,11 @@
       "permanent": true
     },
     {
+      "source": "/components/unsaved-guard",
+      "destination": "/components/display/unsaved-guard",
+      "permanent": true
+    },
+    {
       "source": "/components/usage-dashboard",
       "destination": "/components/saas/usage-dashboard",
       "permanent": true

--- a/vercel.json
+++ b/vercel.json
@@ -402,6 +402,11 @@
       "permanent": true
     },
     {
+      "source": "/components/confirm",
+      "destination": "/components/display/confirm",
+      "permanent": true
+    },
+    {
       "source": "/components/copy-button",
       "destination": "/components/display/copy-button",
       "permanent": true


### PR DESCRIPTION
## Summary

Adds two new UI components to the registry: **Confirm** (an imperative confirmation dialog) and **Unsaved Guard** (an unsaved-changes guard for navigation).

## Key Changes

- **Confirm component** (`registry/hirael/ui/confirm.tsx`)
  - Root provider (`ConfirmProvider`) that renders a single shared alert dialog
  - `useConfirm()` hook that returns a promise-based confirm function
  - Supports default and destructive tones, optional icons, and async confirm actions with pending spinners
  - Re-entrant calls queue behind the open dialog
  - Configurable default options and dismissible behavior

- **Unsaved Guard component** (`registry/hirael/ui/unsaved-guard.tsx`)
  - Root provider (`UnsavedGuardProvider`) that wraps the app
  - `useUnsavedGuard()` hook that registers unsaved-changes guards
  - Intercepts page reload/tab close via `beforeunload` event (configurable)
  - Intercepts in-app link navigation via click event delegation
  - Returns a `guard(proceed)` function to wrap programmatic navigation
  - Supports custom dialog copy per guard or via provider defaults
  - Integrates with the Confirm component for the dialog UI

- **Demo components**
  - `confirm-demo.tsx`: Shows publish and delete confirmation flows
  - `unsaved-guard-demo.tsx`: Shows tab switching with unsaved profile edits

- **Registry updates**
  - Added entries to `registry.json`, `registry-meta.ts`, and `registry-props.json`
  - Added redirect rules in `vercel.json` for old flat URLs
  - Updated `catalog.md` component counts (70 → 73 items)
  - Registered demo loaders in `registry-demos.tsx`

## Notable Implementation Details

- Confirm uses a queue system to handle re-entrant calls, with a 200ms close animation delay between dialogs
- Unsaved Guard uses refs to track the latest options and active guards without re-registering effects
- In-app link interception filters for same-origin navigation, respects modifier keys and special link attributes (`target="_blank"`, `download`)
- Both components are client-only (`"use client"`) and support i18n via the demo locale utility

https://claude.ai/code/session_01KSLtvuxgki2JhQv3Jiqusc