### PR TITLE
Add component search and collapsible categories to sidebar

### DIFF
--- a/components/showcase/sidebar.tsx
+++ b/components/showcase/sidebar.tsx
@@ -44,8 +44,13 @@ import {
   useSidebar,
 } from "@/registry/hirael/ui/sidebar";
 
+// The recurring eyebrow label: mono, tiny, uppercase, tracked, muted — the
+// same treatment the "On this page" rail and changelog header use.
+const EYEBROW_CLASS =
+  "font-mono text-[10px] font-normal uppercase tracking-[0.14em] text-muted-foreground";
+
 const COUNT_CLASS =
-  "ms-auto font-mono text-[10px] tabular-nums text-muted-foreground";
+  "ms-auto font-mono text-[10px] tabular-nums tracking-normal text-muted-foreground";
 
 export function ShowcaseSidebar() {
   const pathname = usePathname();
@@ -164,7 +169,9 @@ export function ShowcaseSidebar() {
 
       <SidebarContent>
         <SidebarGroup>
-          <SidebarGroupLabel>Workspace</SidebarGroupLabel>
+          <SidebarGroupLabel className={EYEBROW_CLASS}>
+            Workspace
+          </SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
               <SidebarMenuItem>
@@ -227,7 +234,7 @@ export function ShowcaseSidebar() {
               placeholder="Filter components…"
               aria-label="Filter components"
               autoComplete="off"
-              className="h-8 ps-8 pe-10 text-sm"
+              className="h-8 border-sidebar-border bg-sidebar-accent/40 ps-8 pe-10 dark:bg-sidebar-accent/40"
             />
             {query ? (
               <button
@@ -262,11 +269,18 @@ export function ShowcaseSidebar() {
               className="group/collapsible"
             >
               <SidebarGroup className="px-2 py-0.5">
-                <SidebarGroupLabel asChild>
-                  <CollapsibleTrigger className="w-full cursor-pointer gap-1.5 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground">
+                <SidebarGroupLabel
+                  asChild
+                  className={`${EYEBROW_CLASS} w-full cursor-pointer gap-1.5 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground${
+                    cat === activeCategory
+                      ? " text-sidebar-accent-foreground"
+                      : ""
+                  }`}
+                >
+                  <CollapsibleTrigger>
                     <span className="truncate">{label}</span>
                     <span className={COUNT_CLASS}>{items.length}</span>
-                    <ChevronDown className="shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]/collapsible:rotate-180" />
+                    <ChevronDown className="shrink-0 text-muted-foreground/80 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-180" />
                   </CollapsibleTrigger>
                 </SidebarGroupLabel>
                 <CollapsibleContent>
@@ -277,7 +291,11 @@ export function ShowcaseSidebar() {
                         const active = isActive(href);
                         return (
                           <SidebarMenuItem key={entry.name}>
-                            <SidebarMenuButton asChild isActive={active}>
+                            <SidebarMenuButton
+                              asChild
+                              isActive={active}
+                              className="text-[13px] text-sidebar-foreground/70"
+                            >
                               <Link
                                 href={href}
                                 ref={active ? activeItemRef : undefined}
@@ -320,9 +338,7 @@ export function ShowcaseSidebar() {
 
       <SidebarFooter>
         <div className="flex items-center justify-between gap-2 bg-sidebar-accent/30 px-1 py-2">
-          <span className="font-mono text-sm uppercase text-muted-foreground">
-            peer of shadcn
-          </span>
+          <span className={EYEBROW_CLASS}>peer of shadcn</span>
           <ThemeSheetTrigger />
         </div>
       </SidebarFooter>

--- a/components/showcase/sidebar.tsx
+++ b/components/showcase/sidebar.tsx
@@ -2,8 +2,16 @@
 
 import * as React from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { Boxes, Frame, LayoutTemplate, Sparkles } from "lucide-react";
+import { usePathname, useRouter } from "next/navigation";
+import {
+  Boxes,
+  ChevronDown,
+  Frame,
+  LayoutTemplate,
+  Search,
+  Sparkles,
+  X,
+} from "lucide-react";
 
 import { LogoTile } from "@/components/showcase/logo";
 import { ThemeSheetTrigger } from "@/components/showcase/theme-sheet";
@@ -11,9 +19,17 @@ import { SITE } from "@/lib/site";
 import {
   CATEGORY_LABELS,
   COMPONENT_CATEGORY_ORDER,
+  COMPONENTS,
   REGISTRY_BY_CATEGORY,
   entryHref,
 } from "@/registry/hirael/registry-meta";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/registry/hirael/ui/collapsible";
+import { Input } from "@/registry/hirael/ui/input";
+import { KbdDisplay } from "@/registry/hirael/ui/kbd";
 import {
   Sidebar,
   SidebarContent,
@@ -28,9 +44,15 @@ import {
   useSidebar,
 } from "@/registry/hirael/ui/sidebar";
 
+const COUNT_CLASS =
+  "ms-auto font-mono text-[10px] tabular-nums text-muted-foreground";
+
 export function ShowcaseSidebar() {
   const pathname = usePathname();
+  const router = useRouter();
   const { setOpenMobile } = useSidebar();
+
+  const componentCount = COMPONENTS.length;
   const blockCount = REGISTRY_BY_CATEGORY.blocks.length;
   const templateCount = REGISTRY_BY_CATEGORY.templates.length;
 
@@ -39,11 +61,84 @@ export function ShowcaseSidebar() {
     return pathname === href || pathname.startsWith(`${href}/`);
   };
 
+  // Which component category the current route sits under, if any.
+  const activeCategory = React.useMemo(() => {
+    const seg = pathname.match(/^\/components\/([^/]+)/)?.[1];
+    return seg && (COMPONENT_CATEGORY_ORDER as readonly string[]).includes(seg)
+      ? seg
+      : null;
+  }, [pathname]);
+
+  // Collapsed/expanded category state. The active category is always open so
+  // you can see its siblings; the rest stay folded to keep the list short.
+  // Use the headers to pin extra categories open while you browse.
+  const [expanded, setExpanded] = React.useState<Set<string>>(() => new Set());
+  const toggle = React.useCallback((cat: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(cat)) next.delete(cat);
+      else next.add(cat);
+      return next;
+    });
+  }, []);
+
+  // Live filter over the component list.
+  const [query, setQuery] = React.useState("");
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  const isFiltering = tokens.length > 0;
+
+  const sections = COMPONENT_CATEGORY_ORDER.map((cat) => {
+    const label = CATEGORY_LABELS[cat];
+    const all = REGISTRY_BY_CATEGORY[cat];
+    const items = isFiltering
+      ? all.filter((entry) => {
+          const haystack =
+            `${entry.title} ${entry.name} ${label}`.toLowerCase();
+          return tokens.every((token) => haystack.includes(token));
+        })
+      : all;
+    return { cat, label, items };
+  }).filter((section) => section.items.length > 0);
+
+  const firstMatch = isFiltering ? sections[0]?.items[0] : undefined;
+
+  // "/" focuses the filter from anywhere, unless you're already typing.
+  React.useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "/" || event.metaKey || event.ctrlKey || event.altKey)
+        return;
+      const el = document.activeElement as HTMLElement | null;
+      if (
+        el &&
+        (el.tagName === "INPUT" ||
+          el.tagName === "TEXTAREA" ||
+          el.tagName === "SELECT" ||
+          el.isContentEditable)
+      )
+        return;
+      event.preventDefault();
+      inputRef.current?.focus();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
+
   // The mobile sidebar is an off-canvas sheet; close it when the route
   // changes so a tapped link doesn't leave it covering the page.
   React.useEffect(() => {
     setOpenMobile(false);
   }, [pathname, setOpenMobile]);
+
+  // Keep the active item in view when you arrive from search, the pager, or a
+  // deep link into a long, scrolled-away category.
+  const activeItemRef = React.useRef<HTMLAnchorElement>(null);
+  React.useEffect(() => {
+    const id = requestAnimationFrame(() =>
+      activeItemRef.current?.scrollIntoView({ block: "nearest" }),
+    );
+    return () => cancelAnimationFrame(id);
+  }, [pathname]);
 
   return (
     <Sidebar collapsible="offcanvas" className="border-r border-sidebar-border">
@@ -77,6 +172,7 @@ export function ShowcaseSidebar() {
                   <Link href="/components">
                     <Boxes />
                     <span>All components</span>
+                    <span className={COUNT_CLASS}>{componentCount}</span>
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>
@@ -85,9 +181,7 @@ export function ShowcaseSidebar() {
                   <Link href="/blocks">
                     <LayoutTemplate />
                     <span>Blocks</span>
-                    <span className="ml-auto font-mono text-[10px] tabular-nums text-muted-foreground">
-                      {blockCount}
-                    </span>
+                    <span className={COUNT_CLASS}>{blockCount}</span>
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>
@@ -96,9 +190,7 @@ export function ShowcaseSidebar() {
                   <Link href="/templates">
                     <Frame />
                     <span>Templates</span>
-                    <span className="ml-auto font-mono text-[10px] tabular-nums text-muted-foreground">
-                      {templateCount}
-                    </span>
+                    <span className={COUNT_CLASS}>{templateCount}</span>
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>
@@ -114,34 +206,116 @@ export function ShowcaseSidebar() {
           </SidebarGroupContent>
         </SidebarGroup>
 
-        {COMPONENT_CATEGORY_ORDER.map((cat) => {
-          const items = REGISTRY_BY_CATEGORY[cat];
-          if (!items.length) return null;
+        <div className="sticky top-0 z-10 bg-sidebar px-2 py-1.5">
+          <div className="relative">
+            <Search className="pointer-events-none absolute start-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  if (query) setQuery("");
+                  else inputRef.current?.blur();
+                } else if (event.key === "Enter" && firstMatch) {
+                  event.preventDefault();
+                  setQuery("");
+                  router.push(entryHref(firstMatch));
+                }
+              }}
+              placeholder="Filter components…"
+              aria-label="Filter components"
+              autoComplete="off"
+              className="h-8 ps-8 pe-10 text-sm"
+            />
+            {query ? (
+              <button
+                type="button"
+                onClick={() => {
+                  setQuery("");
+                  inputRef.current?.focus();
+                }}
+                aria-label="Clear filter"
+                className="absolute end-1.5 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+              >
+                <X className="size-3.5" />
+              </button>
+            ) : (
+              <KbdDisplay className="absolute end-2 top-1/2 -translate-y-1/2 border border-sidebar-border bg-sidebar-accent/40">
+                /
+              </KbdDisplay>
+            )}
+          </div>
+        </div>
+
+        {sections.map(({ cat, label, items }) => {
+          const open =
+            isFiltering || cat === activeCategory || expanded.has(cat);
           return (
-            <SidebarGroup key={cat}>
-              <SidebarGroupLabel asChild>
-                <Link href={`/components/${cat}`}>{CATEGORY_LABELS[cat]}</Link>
-              </SidebarGroupLabel>
-              <SidebarGroupContent>
-                <SidebarMenu>
-                  {items.map((entry) => {
-                    const href = entryHref(entry);
-                    const active = isActive(href);
-                    return (
-                      <SidebarMenuItem key={entry.name}>
-                        <SidebarMenuButton asChild isActive={active}>
-                          <Link href={href}>
-                            <span>{entry.title}</span>
-                          </Link>
-                        </SidebarMenuButton>
-                      </SidebarMenuItem>
-                    );
-                  })}
-                </SidebarMenu>
-              </SidebarGroupContent>
-            </SidebarGroup>
+            <Collapsible
+              key={cat}
+              open={open}
+              onOpenChange={() => {
+                if (!isFiltering) toggle(cat);
+              }}
+              className="group/collapsible"
+            >
+              <SidebarGroup className="px-2 py-0.5">
+                <SidebarGroupLabel asChild>
+                  <CollapsibleTrigger className="w-full cursor-pointer gap-1.5 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground">
+                    <span className="truncate">{label}</span>
+                    <span className={COUNT_CLASS}>{items.length}</span>
+                    <ChevronDown className="shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]/collapsible:rotate-180" />
+                  </CollapsibleTrigger>
+                </SidebarGroupLabel>
+                <CollapsibleContent>
+                  <SidebarGroupContent className="pt-0.5">
+                    <SidebarMenu>
+                      {items.map((entry) => {
+                        const href = entryHref(entry);
+                        const active = isActive(href);
+                        return (
+                          <SidebarMenuItem key={entry.name}>
+                            <SidebarMenuButton asChild isActive={active}>
+                              <Link
+                                href={href}
+                                ref={active ? activeItemRef : undefined}
+                              >
+                                <span>{entry.title}</span>
+                              </Link>
+                            </SidebarMenuButton>
+                          </SidebarMenuItem>
+                        );
+                      })}
+                    </SidebarMenu>
+                  </SidebarGroupContent>
+                </CollapsibleContent>
+              </SidebarGroup>
+            </Collapsible>
           );
         })}
+
+        {isFiltering && sections.length === 0 && (
+          <div className="px-4 py-6 text-center">
+            <p className="text-sm text-sidebar-foreground/70">
+              No components match.
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Blocks and templates live in the top-bar search.
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                setQuery("");
+                inputRef.current?.focus();
+              }}
+              className="mt-3 text-xs text-foreground underline-offset-4 hover:underline"
+            >
+              Clear filter
+            </button>
+          </div>
+        )}
       </SidebarContent>
 
       <SidebarFooter>


### PR DESCRIPTION
## Summary
Enhanced the showcase sidebar with a live search filter for components and collapsible category sections to improve navigation and discoverability.

## Key Changes
- **Search functionality**: Added a sticky search input that filters components in real-time by title, name, and category label
  - "/" keyboard shortcut focuses the search from anywhere
  - "Escape" clears the filter or unfocuses the input
  - "Enter" navigates to the first matching component
  - Clear button (X) appears when filtering is active

- **Collapsible categories**: Converted component categories from always-expanded to collapsible sections
  - Active category automatically expands to show context
  - Users can manually toggle other categories open/closed
  - Categories stay expanded while filtering to show all matches
  - Added item count badges to each category

- **UI improvements**:
  - Added component count to "All components" header
  - Extracted count styling to reusable `COUNT_CLASS` constant
  - Added empty state message when no components match the filter
  - Smooth chevron rotation animation for category toggles
  - Active item auto-scrolls into view on navigation

- **New imports**: Added `useRouter`, `ChevronDown`, `Search`, `X` icons; imported `Collapsible` components and `Input`/`KbdDisplay` UI elements

## Implementation Details
- Search uses token-based matching (space-separated terms) for flexible filtering
- Category expansion state managed separately from active category to allow pinning categories open
- Keyboard event listener prevents "/" from triggering when already in an input field
- `requestAnimationFrame` used for smooth scroll-into-view on route changes

https://claude.ai/code/session_01SyYk63ojrt4vMgcEGDUQAw