### PR TITLE
fix: add demo notice to auth block embeds for Safe Browsing

### DIFF
--- a/app/embed/blocks/[category]/[block]/embed-shell.tsx
+++ b/app/embed/blocks/[category]/[block]/embed-shell.tsx
@@ -1,11 +1,47 @@
 import type { ReactNode } from "react";
+import Link from "next/link";
 
 /**
  * Background wrapper for statically exported block embeds. Reading
  * direction is set on `<html>` before paint by the inline script in
  * `page.tsx` (see `lib/embed.ts`), so this stays a plain server wrapper
  * with no direction state to flip after mount.
+ *
+ * `demoNotice` renders a banner telling visitors the form is a demo. It is
+ * always in the static HTML but hidden pre-paint when the page is framed
+ * by the showcase (`html[data-framed]`, set in `lib/embed.ts`), so only
+ * direct visits — including Safe Browsing's crawler — see it. Auth block
+ * embeds are bare full-page login forms at a hirael.com URL; without the
+ * notice Google's phishing classifier can flag them as credential
+ * harvesting (Search Console: "Possible phishing detected on user login").
  */
-export function BlockEmbedShell({ children }: { children: ReactNode }) {
-  return <div className="min-h-svh bg-background">{children}</div>;
+export function BlockEmbedShell({
+  children,
+  demoNotice = false,
+}: {
+  children: ReactNode;
+  demoNotice?: boolean;
+}) {
+  return (
+    <div className="min-h-svh bg-background">
+      {demoNotice && (
+        <div
+          role="note"
+          className="fixed inset-x-0 top-0 z-50 border-b border-border bg-card px-4 py-2 text-center text-xs text-muted-foreground [[data-framed]_&]:hidden"
+        >
+          Demo from the{" "}
+          <Link
+            href="/"
+            target="_top"
+            className="font-medium text-foreground underline-offset-4 hover:underline"
+          >
+            Hirael
+          </Link>{" "}
+          component library. This form doesn&apos;t submit — don&apos;t enter
+          real credentials.
+        </div>
+      )}
+      {children}
+    </div>
+  );
 }

--- a/app/embed/blocks/[category]/[block]/page.tsx
+++ b/app/embed/blocks/[category]/[block]/page.tsx
@@ -38,7 +38,7 @@ export default async function BlockEmbedRoute({
   return (
     <>
       <script dangerouslySetInnerHTML={{ __html: embedDirScript() }} />
-      <BlockEmbedShell>
+      <BlockEmbedShell demoNotice={entry.blockKind === "login"}>
         <RegistryDemo name={entry.name} />
       </BlockEmbedShell>
     </>

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -4,13 +4,20 @@ import { SITE } from "@/lib/site";
 
 export const dynamic = "force-static";
 
+/**
+ * `/embed/*` is deliberately NOT disallowed here even though it should
+ * never rank: the embed pages carry `robots: { index: false }` metadata,
+ * and a robots.txt disallow would stop Google from ever fetching them —
+ * so the noindex would go unseen, and a Safe Browsing security review
+ * (the auth block embeds were once flagged as phishing) couldn't verify
+ * the pages either. Keeping them crawlable but noindexed does both jobs.
+ */
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
       {
         userAgent: "*",
         allow: "/",
-        disallow: "/embed/",
       },
     ],
     sitemap: `${SITE.url}/sitemap.xml`,

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -234,6 +234,32 @@ demo, a portfolio status dot). Don't mass-rewrite; fix in passing.
   from the repo (not the build output), so it must be regenerated and committed
   at authoring time, never during the deploy build.
 
+## Embed pages & Safe Browsing
+
+- **Bare auth embeds read as phishing to Google.** `/embed/blocks/auth/*`
+  serves full-viewport login forms — brand mark, password field, OAuth
+  buttons, no site chrome. Google Safe Browsing flagged exactly that as
+  "Possible phishing detected on user login" (Chrome then warns users who
+  type saved passwords anywhere on the site). The fix is a demo notice, not
+  neutering the components: `BlockEmbedShell` takes `demoNotice` (passed for
+  `blockKind === "login"`) and renders a "this form doesn't submit" banner.
+- **The notice is standalone-only via `html[data-framed]`.** The pre-paint
+  script in `lib/embed.ts` stamps `data-framed` on `<html>` when the page is
+  iframed, and the banner carries `[[data-framed]_&]:hidden`. So the static
+  HTML (what the Safe Browsing crawler sees) and direct visits show the
+  notice, while the showcase's framed previews never flash it. Any future
+  auth-looking embed (e.g. a login template) must get the same notice.
+- **Don't robots-disallow `/embed/`.** The embed routes rely on
+  `robots: { index: false }` metadata; a robots.txt disallow would keep
+  Google from fetching the pages at all, so the noindex would go unseen and
+  a Safe Browsing security review couldn't verify a fix. Crawlable +
+  noindexed is the correct pair.
+- **Registry components stay real.** `PasswordInputField` keeps native
+  `type="password"` and `autoComplete="current-password"` — consumers install
+  it for actual login forms. Don't ship demo-mode workarounds (masked text
+  inputs, `autocomplete="off"`) into registry source to appease the
+  classifier; fix it at the showcase layer.
+
 ## RTL
 
 Components, blocks, and templates must work under `dir="rtl"` with no extra

--- a/lib/embed.ts
+++ b/lib/embed.ts
@@ -7,7 +7,13 @@
  * reads as a flash. Running this synchronously in the document head sets
  * `<html dir>` before anything paints, so RTL previews come up correct on
  * the first frame — the same trick the theme uses in `lib/theme.ts`.
+ *
+ * It also stamps `data-framed` on `<html>` when the page is inside an
+ * iframe (the showcase preview). Standalone-only UI — like the
+ * demo-credentials notice on auth block embeds — hides itself under that
+ * attribute, so it shows in the static HTML and on direct visits (what
+ * Safe Browsing and stray visitors see) but never inside the showcase.
  */
 export function embedDirScript(): string {
-  return `(()=>{try{var d=new URLSearchParams(location.search).get('dir');document.documentElement.dir=d==='rtl'?'rtl':'ltr';}catch(e){}})();`;
+  return `(()=>{try{var d=new URLSearchParams(location.search).get('dir');document.documentElement.dir=d==='rtl'?'rtl':'ltr';if(window.self!==window.top)document.documentElement.setAttribute('data-framed','');}catch(e){}})();`;
 }


### PR DESCRIPTION
## Summary

Adds a demo notice banner to auth block embeds to prevent Google Safe Browsing from flagging them as phishing. The notice is only shown on direct visits and in the static HTML (visible to crawlers), but hidden when the page is framed in the showcase preview.

This fixes a security classification issue where bare login forms at `/embed/blocks/auth/*` were flagged as "Possible phishing detected on user login" by Google's classifier, causing Chrome to warn users about entering saved passwords on the site.

## Changes

- **`BlockEmbedShell`**: Added optional `demoNotice` prop that renders a banner explaining the form is a demo and doesn't submit. The banner uses `[[data-framed]_&]:hidden` to hide itself when iframed by the showcase.
- **`lib/embed.ts`**: Updated the pre-paint script to stamp `data-framed` on `<html>` when the page is inside an iframe, enabling the notice to hide itself in framed contexts.
- **`app/robots.ts`**: Removed the `/embed/` disallow rule. The embed pages carry `robots: { index: false }` metadata; keeping them crawlable but noindexed allows Safe Browsing to verify the fix while preventing them from ranking.
- **`app/embed/blocks/[category]/[block]/page.tsx`**: Pass `demoNotice={true}` to `BlockEmbedShell` for login blocks.
- **`docs/conventions.md`**: Added guidance on embed pages and Safe Browsing, covering the notice implementation, the `data-framed` mechanism, robots.txt strategy, and why registry components should stay real.

## Type of change

- [x] Bug fix (`fix`)
- [x] Docs (`docs`)

## Checklist

- [x] `pnpm lint && pnpm typecheck && pnpm registry:build && pnpm build` pass locally
- [x] No registry changes needed (no new components)
- [x] Works under `dir="rtl"` (uses existing RTL-safe styling)
- [x] Copy is concise and human

## Test plan

Verified that:
- Auth block embeds now display the demo notice on direct visits
- The notice is hidden when the page is framed in the showcase (via `data-framed` attribute)
- The notice includes a link back to the homepage with `target="_top"` to escape the iframe
- The embed script correctly sets `data-framed` when `window.self !== window.top`

https://claude.ai/code/session_01QbydQBEP8ycq27ZeoHmsMs