### PR TITLE
feat: integrate composeRefs utility across components for improved ref handling

### DIFF
--- a/components/component-page.tsx
+++ b/components/component-page.tsx
@@ -447,7 +447,7 @@ const ApiPanel = ({ parts }: { parts: ApiPart[] }) => {
           </div>
           {part.props.length ? (
             <Table>
-              <TableHeader className="sticky top-14 z-10 bg-card">
+              <TableHeader className="bg-card">
                 <TableRow>
                   <TableHead className={API_TH}>Prop</TableHead>
                   <TableHead className={API_TH}>Type</TableHead>

--- a/registry/hirael/bases/base/components/avatar-upload.tsx
+++ b/registry/hirael/bases/base/components/avatar-upload.tsx
@@ -5,6 +5,7 @@ import { Camera, X } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { Button } from '@/registry/hirael/bases/base/ui/button';
+import { composeRefs } from '@/registry/hirael/bases/base/components/compose-refs';
 import {
   Dialog,
   DialogContent,
@@ -438,11 +439,12 @@ const AvatarUploadTrigger = ({
 
 type AvatarUploadInputProps = Omit<React.ComponentProps<'input'>, 'type' | 'accept' | 'onChange' | 'multiple'>;
 
-const AvatarUploadInput = ({ className, ...props }: AvatarUploadInputProps) => {
+const AvatarUploadInput = ({ className, ref, ...props }: AvatarUploadInputProps) => {
   const ctx = useAvatarUpload();
+  const composedRef = React.useMemo(() => composeRefs(ctx.registerInput, ref), [ctx.registerInput, ref]);
   return (
     <input
-      ref={(el) => ctx.registerInput(el)}
+      ref={composedRef}
       id={`${ctx.id}-input`}
       type="file"
       accept={ctx.accept}
@@ -508,6 +510,8 @@ const AvatarUploadCropDialog = ({
   ...props
 }: AvatarUploadCropDialogProps) => {
   const ctx = useAvatarUpload();
+  // Destructured: `ctx.registerCropper` at a ref site makes the compiler read every ctx.* as a ref.
+  const { registerCropper } = ctx;
   return (
     <Dialog
       open={ctx.pending !== null}
@@ -522,7 +526,7 @@ const AvatarUploadCropDialog = ({
         </DialogHeader>
         {ctx.pending && (
           <ImageCropper
-            ref={(ref) => ctx.registerCropper(ref)}
+            ref={registerCropper}
             src={ctx.pending}
             alt={title}
             aspect={1}

--- a/registry/hirael/bases/base/components/callout.tsx
+++ b/registry/hirael/bases/base/components/callout.tsx
@@ -44,23 +44,32 @@ const Callout = ({ title, icon, className, variant = 'info', children, ...props 
     if (icon === false) return null;
     if (React.isValidElement(icon)) return icon;
     const IconComponent = (icon as React.ElementType | undefined) ?? variantIcons[variantKey];
-    return <IconComponent className="size-5 shrink-0" aria-hidden />;
+    return <IconComponent data-slot="callout-icon" className="size-5 shrink-0" aria-hidden />;
   };
 
   return (
     <div
       data-slot="callout"
       data-variant={variantKey}
+      role={variantKey === 'error' ? 'alert' : undefined}
       className={cn(calloutVariants({ variant }), className)}
       {...props}
     >
       {(title || icon !== false) && (
         <div className="flex items-start gap-2">
           {renderIcon()}
-          {title && <span className="font-semibold leading-5">{title}</span>}
+          {title && (
+            <span data-slot="callout-title" className="font-semibold leading-5">
+              {title}
+            </span>
+          )}
         </div>
       )}
-      {children && <div className="text-sm leading-relaxed [&_a]:underline [&_a]:underline-offset-2">{children}</div>}
+      {children && (
+        <div data-slot="callout-content" className="text-sm leading-relaxed [&_a]:underline [&_a]:underline-offset-2">
+          {children}
+        </div>
+      )}
     </div>
   );
 };

--- a/registry/hirael/bases/base/components/color-picker.tsx
+++ b/registry/hirael/bases/base/components/color-picker.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { Pipette } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
+import { composeRefs } from '@/registry/hirael/bases/base/components/compose-refs';
 import { Button } from '@/registry/hirael/bases/base/ui/button';
 import { Input } from '@/registry/hirael/bases/base/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/registry/hirael/bases/base/ui/popover';
@@ -316,6 +317,8 @@ const ColorPickerTrigger = ({
           disabled={ctx.disabled}
           data-slot="color-picker-trigger"
           data-state={ctx.open ? 'open' : 'closed'}
+          aria-haspopup="dialog"
+          aria-expanded={ctx.open}
           className={cn(
             'inline-flex h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-3 text-start text-sm font-mono tabular-nums uppercase outline-none transition-colors',
             'hover:border-ring/60 focus-visible:border-ring data-open:border-ring',
@@ -340,9 +343,10 @@ const ColorPickerTrigger = ({
   );
 };
 
-const ColorPickerArea = ({ className, ...props }: React.ComponentProps<'div'>) => {
+const ColorPickerArea = ({ className, ref, ...props }: React.ComponentProps<'div'>) => {
   const ctx = useColorPicker();
   const areaRef = React.useRef<HTMLDivElement>(null);
+  const composedRef = React.useMemo(() => composeRefs(areaRef, ref), [ref]);
   const draggingRef = React.useRef(false);
 
   const updateFromPointer = (clientX: number, clientY: number) => {
@@ -386,23 +390,27 @@ const ColorPickerArea = ({ className, ...props }: React.ComponentProps<'div'>) =
 
   return (
     <div
-      {...props}
-      ref={areaRef}
+      ref={composedRef}
       data-slot="color-picker-area"
       role="slider"
-      aria-label="Saturation and brightness"
       aria-valuetext={`saturation ${Math.round(ctx.hsv.s)}%, brightness ${Math.round(ctx.hsv.v)}%`}
       aria-valuenow={Math.round(ctx.hsv.s)}
       aria-valuemin={0}
       aria-valuemax={100}
       tabIndex={0}
+      {...props}
+      aria-label={props['aria-label'] ?? 'Saturation and brightness'}
       onPointerDown={(e) => {
+        props.onPointerDown?.(e);
+        if (e.defaultPrevented) return;
         e.preventDefault();
         (e.target as HTMLElement).setPointerCapture(e.pointerId);
         draggingRef.current = true;
         updateFromPointer(e.clientX, e.clientY);
       }}
       onKeyDown={(e) => {
+        props.onKeyDown?.(e);
+        if (e.defaultPrevented) return;
         const step = e.shiftKey ? 10 : 2;
         let { s, v } = ctx.hsv;
         switch (e.key) {
@@ -448,9 +456,10 @@ const ColorPickerArea = ({ className, ...props }: React.ComponentProps<'div'>) =
   );
 };
 
-const ColorPickerHueSlider = ({ className, ...props }: React.ComponentProps<'div'>) => {
+const ColorPickerHueSlider = ({ className, ref, ...props }: React.ComponentProps<'div'>) => {
   const ctx = useColorPicker();
   const trackRef = React.useRef<HTMLDivElement>(null);
+  const composedRef = React.useMemo(() => composeRefs(trackRef, ref), [ref]);
   const draggingRef = React.useRef(false);
 
   const updateFromPointer = (clientX: number) => {
@@ -491,22 +500,26 @@ const ColorPickerHueSlider = ({ className, ...props }: React.ComponentProps<'div
 
   return (
     <div
-      {...props}
-      ref={trackRef}
+      ref={composedRef}
       data-slot="color-picker-hue-slider"
       role="slider"
-      aria-label="Hue"
       aria-valuemin={0}
       aria-valuemax={360}
       aria-valuenow={Math.round(ctx.hsv.h)}
       tabIndex={0}
+      {...props}
+      aria-label={props['aria-label'] ?? 'Hue'}
       onPointerDown={(e) => {
+        props.onPointerDown?.(e);
+        if (e.defaultPrevented) return;
         e.preventDefault();
         (e.target as HTMLElement).setPointerCapture(e.pointerId);
         draggingRef.current = true;
         updateFromPointer(e.clientX);
       }}
       onKeyDown={(e) => {
+        props.onKeyDown?.(e);
+        if (e.defaultPrevented) return;
         const step = e.shiftKey ? 24 : 6;
         let h = ctx.hsv.h;
         if (e.key === 'ArrowLeft') h -= step;

--- a/registry/hirael/bases/base/components/combobox.tsx
+++ b/registry/hirael/bases/base/components/combobox.tsx
@@ -20,7 +20,7 @@ const Combobox = <Value, Multiple extends boolean | undefined = false>(
 };
 
 const ComboboxValue = (props: ComboboxPrimitive.Value.Props) => {
-  return <ComboboxPrimitive.Value {...props} />;
+  return <ComboboxPrimitive.Value data-slot="combobox-value" {...props} />;
 };
 
 /**
@@ -34,10 +34,11 @@ const useComboboxAnchor = () => {
 
 const ComboboxInput = ({
   className,
+  inputClassName,
   children,
   showClear = false,
   ...props
-}: WithClassName<ComboboxPrimitive.Input.Props> & { showClear?: boolean }) => {
+}: WithClassName<ComboboxPrimitive.Input.Props> & { showClear?: boolean; inputClassName?: string }) => {
   return (
     <InputGroup
       className={cn(
@@ -48,12 +49,16 @@ const ComboboxInput = ({
       {children}
       <ComboboxPrimitive.Input
         data-slot="combobox-input"
-        className="flex-1 rounded-none border-0 bg-transparent px-2 text-sm shadow-none outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+        className={cn(
+          'flex-1 rounded-none border-0 bg-transparent px-2 text-sm shadow-none outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
+          inputClassName,
+        )}
         {...props}
       />
       <InputGroupAddon align="inline-end">
         {showClear && <ComboboxClear />}
         <ComboboxPrimitive.Trigger
+          data-slot="combobox-trigger"
           aria-label="Toggle"
           className="flex size-6 shrink-0 items-center justify-center rounded-[calc(var(--radius)-5px)] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
         >
@@ -112,6 +117,7 @@ const ComboboxChip = ({ className, children, ...props }: WithClassName<ComboboxP
     >
       {children}
       <ComboboxPrimitive.ChipRemove
+        data-slot="combobox-chip-remove"
         aria-label="Remove"
         className="flex size-3.5 items-center justify-center rounded-[3px] text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
       >
@@ -219,7 +225,7 @@ const ComboboxItem = ({ className, children, ...props }: WithClassName<ComboboxP
       {...props}
     >
       <span className="min-w-0 flex-1 truncate">{children}</span>
-      <ComboboxPrimitive.ItemIndicator className="flex shrink-0 items-center">
+      <ComboboxPrimitive.ItemIndicator data-slot="combobox-item-indicator" className="flex shrink-0 items-center">
         <CheckIcon className="size-4" strokeWidth={3} />
       </ComboboxPrimitive.ItemIndicator>
     </ComboboxPrimitive.Item>

--- a/registry/hirael/bases/base/components/compose-refs.ts
+++ b/registry/hirael/bases/base/components/compose-refs.ts
@@ -1,0 +1,24 @@
+import type * as React from 'react';
+
+const setRef = <T>(ref: React.Ref<T> | undefined, node: T | null) => {
+  if (typeof ref === 'function') return ref(node);
+  if (ref) ref.current = node;
+};
+
+/**
+ * Fans one node out to several refs: a part's own, plus whatever the consumer
+ * passed. Cleanup functions returned by callback refs (React 19) are kept, so
+ * a consumer ref that observes the node is torn down instead of called with null.
+ */
+export const composeRefs =
+  <T>(...refs: (React.Ref<T> | undefined)[]): React.RefCallback<T> =>
+  (node) => {
+    const cleanups = refs.map((ref) => setRef(ref, node));
+    if (!cleanups.some((cleanup) => typeof cleanup === 'function')) return;
+    return () => {
+      cleanups.forEach((cleanup, i) => {
+        if (typeof cleanup === 'function') cleanup();
+        else setRef(refs[i], null);
+      });
+    };
+  };

--- a/registry/hirael/bases/base/components/confirm.tsx
+++ b/registry/hirael/bases/base/components/confirm.tsx
@@ -85,6 +85,7 @@ const ConfirmProvider = ({ children, defaultOptions }: ConfirmProviderProps) => 
   const activeRef = React.useRef<ConfirmRequest | null>(null);
   const queueRef = React.useRef<ConfirmRequest[]>([]);
   const closingRef = React.useRef(false);
+  const closeTimerRef = React.useRef<number | undefined>(undefined);
 
   const confirm = React.useCallback<ConfirmFn>((options = {}) => {
     return new Promise<boolean>((resolve) => {
@@ -106,7 +107,7 @@ const ConfirmProvider = ({ children, defaultOptions }: ConfirmProviderProps) => 
     current.resolve(value);
     setPending(false);
     setOpen(false);
-    window.setTimeout(() => {
+    closeTimerRef.current = window.setTimeout(() => {
       closingRef.current = false;
       const next = queueRef.current.shift() ?? null;
       activeRef.current = next;
@@ -114,6 +115,16 @@ const ConfirmProvider = ({ children, defaultOptions }: ConfirmProviderProps) => 
       setOpen(next !== null);
     }, CLOSE_DURATION);
   }, []);
+
+  React.useEffect(
+    () => () => {
+      window.clearTimeout(closeTimerRef.current);
+      activeRef.current?.resolve(false);
+      for (const queued of queueRef.current) queued.resolve(false);
+      queueRef.current = [];
+    },
+    [],
+  );
 
   const handleConfirm = React.useCallback(() => {
     if (closingRef.current) return;
@@ -127,10 +138,8 @@ const ConfirmProvider = ({ children, defaultOptions }: ConfirmProviderProps) => 
       .then(onConfirm)
       .then(
         () => settle(true),
-        (error) => {
-          setPending(false);
-          throw error;
-        },
+        // Back to idle so the user can retry; per onConfirm's contract the error is theirs to surface.
+        () => setPending(false),
       );
   }, [settle]);
 

--- a/registry/hirael/bases/base/components/copy-button.tsx
+++ b/registry/hirael/bases/base/components/copy-button.tsx
@@ -38,6 +38,7 @@ const CopyButton = ({
   size = 'md',
   timeout = 1500,
   onCopy,
+  onClick,
   className,
   children,
   ...props
@@ -47,17 +48,22 @@ const CopyButton = ({
 
   React.useEffect(() => () => clearTimeout(timer.current), []);
 
-  const handleCopy = async () => {
-    try {
-      await writeClipboard(value);
-      setCopied(true);
-      onCopy?.(value);
-      clearTimeout(timer.current);
-      timer.current = setTimeout(() => setCopied(false), timeout);
-    } catch {
-      setCopied(false);
-    }
-  };
+  const handleCopy = React.useCallback(
+    async (event: React.MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      if (event.defaultPrevented) return;
+      try {
+        await writeClipboard(value);
+        setCopied(true);
+        onCopy?.(value);
+        clearTimeout(timer.current);
+        timer.current = setTimeout(() => setCopied(false), timeout);
+      } catch {
+        setCopied(false);
+      }
+    },
+    [value, onCopy, timeout, onClick],
+  );
 
   const hasLabel = children != null;
 

--- a/registry/hirael/bases/base/components/country-select.tsx
+++ b/registry/hirael/bases/base/components/country-select.tsx
@@ -117,6 +117,7 @@ interface CountrySelectContextValue {
   open: boolean;
   setOpen: (next: boolean) => void;
   find: (iso2: string) => Country | undefined;
+  listboxId: string;
 }
 
 const CountrySelectContext = React.createContext<CountrySelectContextValue | null>(null);
@@ -143,6 +144,7 @@ interface CountrySelectBaseProps {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
+  name?: string;
   children?: React.ReactNode;
 }
 
@@ -179,6 +181,7 @@ const CountrySelect = (props: CountrySelectProps) => {
     open: openProp,
     defaultOpen = false,
     onOpenChange,
+    name,
     children,
     multiple = false,
     value: valueProp,
@@ -187,6 +190,7 @@ const CountrySelect = (props: CountrySelectProps) => {
 
   const reactId = React.useId();
   const selectId = id ?? reactId;
+  const listboxId = React.useId();
 
   const [internal, setInternal] = React.useState<string[]>(() => toList(defaultValue));
   const selected = React.useMemo(() => (valueProp === undefined ? internal : toList(valueProp)), [valueProp, internal]);
@@ -248,8 +252,22 @@ const CountrySelect = (props: CountrySelectProps) => {
       open,
       setOpen,
       find: (iso2) => countries.find((c) => c.iso2 === iso2.toUpperCase()),
+      listboxId,
     }),
-    [selectId, countries, priorityList, rest, selected, select, multiple, showDialCode, disabled, open, setOpen],
+    [
+      selectId,
+      countries,
+      priorityList,
+      rest,
+      selected,
+      select,
+      multiple,
+      showDialCode,
+      disabled,
+      open,
+      setOpen,
+      listboxId,
+    ],
   );
 
   return (
@@ -257,6 +275,7 @@ const CountrySelect = (props: CountrySelectProps) => {
       <Popover open={open} onOpenChange={setOpen}>
         {children}
       </Popover>
+      {name && <input type="hidden" name={name} value={selected.join(',')} />}
     </CountrySelectContext.Provider>
   );
 };
@@ -298,6 +317,7 @@ const CountrySelectTrigger = ({ className, children, variant = 'outline', ...pro
           variant={variant}
           role="combobox"
           id={ctx.id}
+          aria-controls={ctx.listboxId}
           aria-expanded={ctx.open}
           aria-haspopup="listbox"
           disabled={ctx.disabled}
@@ -430,7 +450,7 @@ const CountrySelectList = ({
 }: CountrySelectListProps) => {
   const ctx = useCountrySelect();
   return (
-    <CommandList data-slot="country-select-list" className={cn('max-h-64', className)} {...props}>
+    <CommandList id={ctx.listboxId} data-slot="country-select-list" className={cn('max-h-64', className)} {...props}>
       <CommandEmpty>{emptyLabel}</CommandEmpty>
       {ctx.priority.length > 0 && (
         <>

--- a/registry/hirael/bases/base/components/cron-editor.tsx
+++ b/registry/hirael/bases/base/components/cron-editor.tsx
@@ -680,7 +680,10 @@ const CronEditorField = ({
 /*  Expression                                                                */
 /* -------------------------------------------------------------------------- */
 
-interface CronEditorExpressionProps extends Omit<React.ComponentProps<'div'>, 'children'> {
+interface CronEditorExpressionProps extends Omit<
+  React.ComponentProps<'input'>,
+  'children' | 'value' | 'defaultValue' | 'onChange' | 'id'
+> {
   label?: string;
   placeholder?: string;
   showError?: boolean;
@@ -699,12 +702,7 @@ const CronEditorExpression = ({
   const invalid = !ctx.parsed.valid;
 
   return (
-    <Field
-      data-slot="cron-editor-expression"
-      data-invalid={invalid || undefined}
-      className={cn('gap-1.5', className)}
-      {...props}
-    >
+    <Field data-slot="cron-editor-expression" data-invalid={invalid || undefined} className={cn('gap-1.5', className)}>
       <FieldLabel
         htmlFor={inputId}
         className="font-mono text-[10px] font-normal uppercase tracking-[0.12em] text-muted-foreground"
@@ -725,6 +723,7 @@ const CronEditorExpression = ({
         data-slot="cron-editor-expression-input"
         className="font-mono tracking-[0.08em]"
         onChange={(e) => ctx.setValue(e.target.value)}
+        {...props}
       />
       {showError && invalid && (
         <FieldError id={errorId} data-slot="cron-editor-expression-error" className="text-[11px]">

--- a/registry/hirael/bases/base/components/currency-input.tsx
+++ b/registry/hirael/bases/base/components/currency-input.tsx
@@ -250,6 +250,7 @@ const CurrencyInputField = ({
       id={ctx.id}
       type="text"
       inputMode={inputMode}
+      dir="ltr"
       value={ctx.view}
       disabled={ctx.disabled}
       placeholder={placeholder}

--- a/registry/hirael/bases/base/components/cursor-glow.tsx
+++ b/registry/hirael/bases/base/components/cursor-glow.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { motion, useMotionTemplate, useMotionValue } from 'motion/react';
+import { motion, useMotionTemplate, useMotionValue, useReducedMotion } from 'motion/react';
 
 import { cn } from '@/lib/utils';
 
@@ -19,11 +19,13 @@ const CursorGlow = ({
   color = 'color-mix(in oklch, var(--foreground) 12%, transparent)',
   ...props
 }: CursorGlowProps) => {
+  const reduced = useReducedMotion();
   const x = useMotionValue(0);
   const y = useMotionValue(0);
   const background = useMotionTemplate`radial-gradient(${size}px circle at ${x}px ${y}px, ${color}, transparent 70%)`;
 
   const onPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (reduced) return;
     const rect = event.currentTarget.getBoundingClientRect();
     x.set(event.clientX - rect.left);
     y.set(event.clientY - rect.top);

--- a/registry/hirael/bases/base/components/data-table/data-table-column-header.tsx
+++ b/registry/hirael/bases/base/components/data-table/data-table-column-header.tsx
@@ -27,7 +27,11 @@ export const DataTableColumnHeader = <TData extends RowData, TValue extends Cell
   ...props
 }: DataTableColumnHeaderProps<TData, TValue>) => {
   if (!column.getCanSort() && !column.getCanHide()) {
-    return <div className={cn(className)}>{label}</div>;
+    return (
+      <div data-slot="data-table-column-header" className={cn(className)} {...(props as React.ComponentProps<'div'>)}>
+        {label}
+      </div>
+    );
   }
 
   return (

--- a/registry/hirael/bases/base/components/data-table/data-table-toolbar.tsx
+++ b/registry/hirael/bases/base/components/data-table/data-table-toolbar.tsx
@@ -72,6 +72,7 @@ const DataTableToolbarFilter = <TData extends RowData>({ column }: DataTableTool
       case 'text':
         return (
           <Input
+            aria-label={columnMeta.label ?? column.id}
             placeholder={columnMeta.placeholder ?? columnMeta.label}
             value={(column.getFilterValue() as string) ?? ''}
             onChange={(event) => column.setFilterValue(event.target.value)}
@@ -85,6 +86,7 @@ const DataTableToolbarFilter = <TData extends RowData>({ column }: DataTableTool
             <Input
               type="number"
               inputMode="numeric"
+              aria-label={columnMeta.label ?? column.id}
               placeholder={columnMeta.placeholder ?? columnMeta.label}
               value={(column.getFilterValue() as string) ?? ''}
               onChange={(event) => column.setFilterValue(event.target.value)}

--- a/registry/hirael/bases/base/components/data-table/use-data-table.ts
+++ b/registry/hirael/bases/base/components/data-table/use-data-table.ts
@@ -161,6 +161,10 @@ interface UseDataTableProps<TData extends RowData> extends Omit<
   initialState?: Omit<Partial<TableState<DataTableFeatures>>, 'sorting'> & {
     sorting?: ExtendedColumnSort<TData>[];
   };
+  /** Controlled row selection. Pair with `onRowSelectionChange`. */
+  rowSelection?: RowSelectionState;
+  /** Controlled column visibility. Pair with `onColumnVisibilityChange`. */
+  columnVisibility?: ColumnVisibilityState;
   prefix?: string;
   history?: 'push' | 'replace';
   debounceMs?: number;
@@ -177,6 +181,10 @@ export const useDataTable = <TData extends RowData>(props: UseDataTableProps<TDa
     pageCount,
     manual = pageCount != null,
     initialState,
+    rowSelection: rowSelectionProp,
+    columnVisibility: columnVisibilityProp,
+    onRowSelectionChange: onRowSelectionChangeProp,
+    onColumnVisibilityChange: onColumnVisibilityChangeProp,
     prefix = '',
     history = 'replace',
     debounceMs = DEBOUNCE_MS,
@@ -205,9 +213,30 @@ export const useDataTable = <TData extends RowData>(props: UseDataTableProps<TDa
     [history, scroll, shallow, throttleMs, debounceMs, clearOnDefault, startTransition],
   );
 
-  const [rowSelection, setRowSelection] = React.useState<RowSelectionState>(initialState?.rowSelection ?? {});
-  const [columnVisibility, setColumnVisibility] = React.useState<ColumnVisibilityState>(
+  const [internalRowSelection, setInternalRowSelection] = React.useState<RowSelectionState>(
+    initialState?.rowSelection ?? {},
+  );
+  const rowSelection = rowSelectionProp ?? internalRowSelection;
+
+  const [internalColumnVisibility, setInternalColumnVisibility] = React.useState<ColumnVisibilityState>(
     initialState?.columnVisibility ?? {},
+  );
+  const columnVisibility = columnVisibilityProp ?? internalColumnVisibility;
+
+  const onRowSelectionChange = React.useCallback(
+    (updaterOrValue: Updater<RowSelectionState>) => {
+      if (rowSelectionProp === undefined) setInternalRowSelection(updaterOrValue);
+      onRowSelectionChangeProp?.(updaterOrValue);
+    },
+    [rowSelectionProp, onRowSelectionChangeProp],
+  );
+
+  const onColumnVisibilityChange = React.useCallback(
+    (updaterOrValue: Updater<ColumnVisibilityState>) => {
+      if (columnVisibilityProp === undefined) setInternalColumnVisibility(updaterOrValue);
+      onColumnVisibilityChangeProp?.(updaterOrValue);
+    },
+    [columnVisibilityProp, onColumnVisibilityChangeProp],
   );
 
   const [page, setPage] = useQueryState(pageKey, parseAsInteger.withOptions(queryStateOptions).withDefault(1));
@@ -304,7 +333,9 @@ export const useDataTable = <TData extends RowData>(props: UseDataTableProps<TDa
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(queryColumnFilters);
 
   const columnFiltersRef = React.useRef(columnFilters);
-  columnFiltersRef.current = columnFilters;
+  React.useEffect(() => {
+    columnFiltersRef.current = columnFilters;
+  }, [columnFilters]);
 
   React.useEffect(() => {
     setColumnFilters((prev) => (areFiltersEqual(prev, queryColumnFilters) ? prev : queryColumnFilters));
@@ -353,11 +384,11 @@ export const useDataTable = <TData extends RowData>(props: UseDataTableProps<TDa
       enableColumnFilter: false,
     },
     enableRowSelection: true,
-    onRowSelectionChange: setRowSelection,
+    onRowSelectionChange,
     onPaginationChange,
     onSortingChange,
     onColumnFiltersChange,
-    onColumnVisibilityChange: setColumnVisibility,
+    onColumnVisibilityChange,
     manualPagination: manual,
     manualSorting: manual,
     manualFiltering: manual,

--- a/registry/hirael/bases/base/components/date-picker.tsx
+++ b/registry/hirael/bases/base/components/date-picker.tsx
@@ -6,6 +6,7 @@ import { CalendarIcon, ChevronLeft, ChevronRight, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/registry/hirael/bases/base/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/registry/hirael/bases/base/ui/popover';
+import { composeRefs } from '@/registry/hirael/bases/base/components/compose-refs';
 import {
   clampDate,
   gridKeyToDate,
@@ -42,6 +43,7 @@ const DateCalendar = ({
   locale,
   weekStartsOn = 1,
   className,
+  ref: refProp,
   ...props
 }: DateCalendarProps) => {
   const [internal, setInternal] = React.useState<Date | null>(defaultValue);
@@ -97,6 +99,7 @@ const DateCalendar = ({
   const stepMonth = (n: number) => setViewMonth(new Date(viewMonth.getFullYear(), viewMonth.getMonth() + n, 1));
 
   const rootRef = React.useRef<HTMLDivElement>(null);
+  const composedRef = React.useMemo(() => composeRefs(rootRef, refProp), [refProp]);
   const focusDay = (d: Date) => {
     const doFocus = () => {
       rootRef.current?.querySelector<HTMLButtonElement>(`[data-day="${d.getTime()}"]`)?.focus();
@@ -121,12 +124,9 @@ const DateCalendar = ({
     focusDay(clampDate(next, min, max));
   };
 
-  const monthFmt = new Intl.DateTimeFormat(locale, {
-    month: 'long',
-    year: 'numeric',
-  });
-  const weekdayFmt = new Intl.DateTimeFormat(locale, { weekday: 'short' });
-  const dayLabelFmt = new Intl.DateTimeFormat(locale, { dateStyle: 'full' });
+  const monthFmt = React.useMemo(() => new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric' }), [locale]);
+  const weekdayFmt = React.useMemo(() => new Intl.DateTimeFormat(locale, { weekday: 'short' }), [locale]);
+  const dayLabelFmt = React.useMemo(() => new Intl.DateTimeFormat(locale, { dateStyle: 'full' }), [locale]);
   const weekdays = Array.from({ length: 7 }, (_, i) =>
     weekdayFmt.format(new Date(2021, 7, 1 + ((weekStartsOn + i) % 7))),
   );
@@ -140,7 +140,12 @@ const DateCalendar = ({
   const tabbable = selected && isMonthVisible(selected) ? selected : isMonthVisible(today) ? today : viewMonth;
 
   return (
-    <div ref={rootRef} data-slot="date-picker-calendar" className={cn('w-60', className)} {...props}>
+    <div
+      ref={composedRef}
+      data-slot="date-picker-calendar"
+      className={cn('w-60', className)}
+      {...props}
+    >
       <div data-slot="date-picker-calendar-header" className="mb-2 flex items-center justify-between">
         <Button
           type="button"

--- a/registry/hirael/bases/base/components/date-range-picker.tsx
+++ b/registry/hirael/bases/base/components/date-range-picker.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/utils';
 import { Button } from '@/registry/hirael/bases/base/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/registry/hirael/bases/base/ui/popover';
 import { Separator } from '@/registry/hirael/bases/base/ui/separator';
+import { composeRefs } from '@/registry/hirael/bases/base/components/compose-refs';
 import {
   addDays,
   clampDate,
@@ -77,7 +78,9 @@ const DEFAULT_PRESETS: DateRangePreset[] = [
   },
 ];
 
-export interface DateRangeCalendarProps {
+const EMPTY_RANGE: DateRange = {};
+
+export interface DateRangeCalendarProps extends Omit<React.ComponentProps<'div'>, 'defaultValue'> {
   value?: DateRange;
   defaultValue?: DateRange;
   onValueChange?: (range: DateRange | undefined) => void;
@@ -87,7 +90,6 @@ export interface DateRangeCalendarProps {
   locale?: string;
   weekStartsOn?: 0 | 1;
   numberOfMonths?: 1 | 2;
-  className?: string;
 }
 
 const DateRangeCalendar = ({
@@ -101,6 +103,8 @@ const DateRangeCalendar = ({
   weekStartsOn = 1,
   numberOfMonths = 2,
   className,
+  ref: refProp,
+  ...props
 }: DateRangeCalendarProps) => {
   const [internal, setInternal] = React.useState<DateRange | undefined>(defaultValue);
   const range = valueProp !== undefined ? valueProp : internal;
@@ -171,6 +175,7 @@ const DateRangeCalendar = ({
   const stepMonth = (n: number) => setViewMonth(new Date(viewMonth.getFullYear(), viewMonth.getMonth() + n, 1));
 
   const rootRef = React.useRef<HTMLDivElement>(null);
+  const composedRef = React.useMemo(() => composeRefs(rootRef, refProp), [refProp]);
   const focusDay = (d: Date) => {
     const doFocus = () => {
       rootRef.current?.querySelector<HTMLButtonElement>(`[data-day="${d.getTime()}"]`)?.focus();
@@ -209,7 +214,12 @@ const DateRangeCalendar = ({
     range?.from && isMonthVisible(range.from) ? startOfDay(range.from) : isMonthVisible(today) ? today : viewMonth;
 
   return (
-    <div ref={rootRef} data-slot="date-range-calendar" className={cn('flex gap-4', className)}>
+    <div
+      ref={composedRef}
+      data-slot="date-range-calendar"
+      className={cn('flex gap-4', className)}
+      {...props}
+    >
       {months.map((month, mi) => {
         const last = mi === numberOfMonths - 1;
         const cells = monthCells(month, weekStartsOn);
@@ -538,7 +548,7 @@ const DateRangePickerContent = ({
         )}
         <div data-slot="date-range-picker-content-calendar" className="flex flex-col gap-2">
           <DateRangeCalendar
-            value={ctx.range ?? {}}
+            value={ctx.range ?? EMPTY_RANGE}
             onValueChange={ctx.setRange}
             min={ctx.min}
             max={ctx.max}

--- a/registry/hirael/bases/base/components/diff-viewer.tsx
+++ b/registry/hirael/bases/base/components/diff-viewer.tsx
@@ -420,6 +420,7 @@ export interface DiffViewerContentProps extends Omit<React.ComponentProps<'div'>
 const DiffViewerContent = ({ showLineNumbers = true, gapLabel, className, ...props }: DiffViewerContentProps) => {
   const { items, mode, expandGap } = useDiffViewer();
   const label = gapLabel ?? ((count: number) => `Expand ${count} lines`);
+  const rows = React.useMemo(() => (mode === 'split' ? toSplitRows(items) : []), [items, mode]);
 
   const gap = (item: GapItem) => (
     <button
@@ -438,7 +439,6 @@ const DiffViewerContent = ({ showLineNumbers = true, gapLabel, className, ...pro
   );
 
   if (mode === 'split') {
-    const rows = toSplitRows(items);
     return (
       <div
         dir="ltr"

--- a/registry/hirael/bases/base/components/dock.tsx
+++ b/registry/hirael/bases/base/components/dock.tsx
@@ -13,6 +13,7 @@ import {
 } from 'motion/react';
 
 import { cn } from '@/lib/utils';
+import { composeRefs } from '@/registry/hirael/bases/base/components/compose-refs';
 
 interface DockContextValue {
   mouseX: MotionValue<number>;
@@ -84,8 +85,9 @@ const Dock = ({ baseSize = 44, magnification = 72, distance = 140, className, ch
 
 type DockItemProps = HTMLMotionProps<'button'>;
 
-const DockItem = ({ className, children, ...props }: DockItemProps) => {
+const DockItem = ({ className, children, ref: consumerRef, ...props }: DockItemProps) => {
   const ref = React.useRef<HTMLButtonElement>(null);
+  const composedRef = React.useMemo(() => composeRefs(ref, consumerRef), [consumerRef]);
   const { mouseX, baseSize, magnification, distance } = useDock();
   const [hovered, setHovered] = React.useState(false);
   const reducedMotion = useReducedMotion();
@@ -102,11 +104,13 @@ const DockItem = ({ className, children, ...props }: DockItemProps) => {
     damping: 14,
   });
 
+  const itemCtx = React.useMemo(() => ({ hovered }), [hovered]);
+
   return (
-    <DockItemContext.Provider value={{ hovered }}>
+    <DockItemContext.Provider value={itemCtx}>
       <motion.button
         {...props}
-        ref={ref}
+        ref={composedRef}
         type="button"
         data-slot="dock-item"
         style={reducedMotion ? { width: baseSize, height: baseSize } : { width, height: width }}

--- a/registry/hirael/bases/base/components/emoji-picker.tsx
+++ b/registry/hirael/bases/base/components/emoji-picker.tsx
@@ -17,6 +17,7 @@ import {
 
 import { cn } from '@/lib/utils';
 import { Input } from '@/registry/hirael/bases/base/ui/input';
+import { composeRefs } from '@/registry/hirael/bases/base/components/compose-refs';
 
 /* -------------------------------------------------------------------------- */
 /*  Data                                                                      */
@@ -676,9 +677,7 @@ interface EmojiPickerContextValue {
   hasRecent: boolean;
   skinTone: EmojiSkinTone;
   setSkinTone: (next: EmojiSkinTone) => void;
-  hovered: EmojiItem | null;
   setHovered: (next: EmojiItem | null) => void;
-  activeIndex: number;
   setActiveIndex: (next: number) => void;
   columns: number;
   select: (item: EmojiItem) => void;
@@ -696,6 +695,13 @@ const useEmojiPicker = () => {
   }
   return ctx;
 };
+
+const EmojiPickerHoverContext = React.createContext<EmojiItem | null>(null);
+
+// Its own context, not the main one: activeIndex changes on every arrow key. The
+// list reads it and hands each item a boolean `active`, so the memoized items
+// re-render only when their own flag flips.
+const EmojiPickerActiveIndexContext = React.createContext(-1);
 
 const readRecent = (key: string): string[] => {
   try {
@@ -830,9 +836,7 @@ const EmojiPicker = ({
       hasRecent: Boolean(recentKey),
       skinTone,
       setSkinTone,
-      hovered,
       setHovered,
-      activeIndex,
       setActiveIndex,
       columns,
       select,
@@ -852,8 +856,6 @@ const EmojiPicker = ({
       recentKey,
       skinTone,
       setSkinTone,
-      hovered,
-      activeIndex,
       columns,
       select,
       display,
@@ -864,16 +866,20 @@ const EmojiPicker = ({
 
   return (
     <EmojiPickerContext.Provider value={ctx}>
-      <div
-        data-slot="emoji-picker"
-        className={cn(
-          'flex w-80 max-w-full flex-col gap-2 rounded-md border border-border bg-popover p-2 text-popover-foreground',
-          className,
-        )}
-        {...props}
-      >
-        {children}
-      </div>
+      <EmojiPickerHoverContext.Provider value={hovered}>
+        <EmojiPickerActiveIndexContext.Provider value={activeIndex}>
+          <div
+            data-slot="emoji-picker"
+            className={cn(
+              'flex w-80 max-w-full flex-col gap-2 rounded-md border border-border bg-popover p-2 text-popover-foreground',
+              className,
+            )}
+            {...props}
+          >
+            {children}
+          </div>
+        </EmojiPickerActiveIndexContext.Provider>
+      </EmojiPickerHoverContext.Provider>
     </EmojiPickerContext.Provider>
   );
 };
@@ -891,6 +897,7 @@ const EmojiPickerSearch = ({
   ...props
 }: EmojiPickerSearchProps) => {
   const ctx = useEmojiPicker();
+  const activeIndex = React.useContext(EmojiPickerActiveIndexContext);
   return (
     <div data-slot="emoji-picker-search" className="relative">
       <Search
@@ -910,7 +917,7 @@ const EmojiPickerSearch = ({
         onKeyDown={(e) => {
           if (e.key === 'ArrowDown') {
             e.preventDefault();
-            ctx.focusItem(ctx.activeIndex);
+            ctx.focusItem(activeIndex);
           } else if (e.key === 'Enter' && ctx.visible[0]) {
             e.preventDefault();
             ctx.select(ctx.visible[0]);
@@ -941,7 +948,7 @@ const EmojiPickerCategories = ({ labels, className, ...props }: EmojiPickerCateg
 
   return (
     <div
-      role="tablist"
+      role="group"
       aria-label="Emoji categories"
       data-slot="emoji-picker-categories"
       className={cn('flex items-center gap-0.5', className)}
@@ -965,8 +972,7 @@ const EmojiPickerCategories = ({ labels, className, ...props }: EmojiPickerCateg
           <button
             key={tab.id}
             type="button"
-            role="tab"
-            aria-selected={active}
+            aria-pressed={active}
             aria-label={label}
             title={label}
             tabIndex={active ? 0 : -1}
@@ -997,9 +1003,10 @@ interface EmojiPickerListProps extends Omit<React.ComponentProps<'div'>, 'childr
   children?: React.ReactNode;
 }
 
-const EmojiPickerList = ({ className, children, ...props }: EmojiPickerListProps) => {
+const EmojiPickerList = ({ className, children, ref, ...props }: EmojiPickerListProps) => {
   const ctx = useEmojiPicker();
-  const { visible, columns, activeIndex } = ctx;
+  const { visible, columns, registerList } = ctx;
+  const activeIndex = React.useContext(EmojiPickerActiveIndexContext);
 
   const focusIndex = (index: number) => {
     const clamped = Math.max(0, Math.min(visible.length - 1, index));
@@ -1041,9 +1048,11 @@ const EmojiPickerList = ({ className, children, ...props }: EmojiPickerListProps
     e.preventDefault();
   };
 
+  const listRef = React.useMemo(() => composeRefs(registerList, ref), [registerList, ref]);
+
   return (
     <div
-      ref={(el) => ctx.registerList(el)}
+      ref={listRef}
       id={`${ctx.id}-grid`}
       role="group"
       aria-label="Emoji"
@@ -1062,7 +1071,7 @@ const EmojiPickerList = ({ className, children, ...props }: EmojiPickerListProps
             }}
           >
             {visible.map((item, index) => (
-              <EmojiPickerItem key={item.emoji} item={item} index={index} />
+              <EmojiPickerItem key={item.emoji} item={item} index={index} active={index === activeIndex} />
             ))}
           </div>
           <EmojiPickerEmpty />
@@ -1075,19 +1084,21 @@ const EmojiPickerList = ({ className, children, ...props }: EmojiPickerListProps
 interface EmojiPickerItemProps extends Omit<React.ComponentProps<'button'>, 'children' | 'type'> {
   item: EmojiItem;
   index: number;
+  /** Roving-tabindex target. `EmojiPickerList` passes it; custom lists should too. */
+  active?: boolean;
 }
 
-const EmojiPickerItem = ({
+const EmojiPickerItem = React.memo(function EmojiPickerItem({
   item,
   index,
+  active = false,
   className,
   onClick,
   onFocus,
   onMouseEnter,
   ...props
-}: EmojiPickerItemProps) => {
+}: EmojiPickerItemProps) {
   const ctx = useEmojiPicker();
-  const active = ctx.activeIndex === index;
   return (
     <button
       type="button"
@@ -1121,7 +1132,7 @@ const EmojiPickerItem = ({
       {ctx.display(item)}
     </button>
   );
-};
+});
 
 /* -------------------------------------------------------------------------- */
 /*  Empty, footer, skin tone                                                  */
@@ -1158,7 +1169,7 @@ const EmojiPickerFooter = ({
   ...props
 }: EmojiPickerFooterProps) => {
   const ctx = useEmojiPicker();
-  const item = ctx.hovered;
+  const item = React.useContext(EmojiPickerHoverContext);
   return (
     <div
       data-slot="emoji-picker-footer"

--- a/registry/hirael/bases/base/components/file-dropzone.tsx
+++ b/registry/hirael/bases/base/components/file-dropzone.tsx
@@ -71,7 +71,7 @@ const useFileDropzone = () => {
   return ctx;
 };
 
-export interface FileDropzoneProps {
+export interface FileDropzoneProps extends Omit<React.ComponentProps<'div'>, 'defaultValue'> {
   value?: File[];
   defaultValue?: File[];
   onValueChange?: (files: File[]) => void;
@@ -79,7 +79,6 @@ export interface FileDropzoneProps {
   maxSize?: number;
   multiple?: boolean;
   disabled?: boolean;
-  children?: React.ReactNode;
 }
 
 const FileDropzone = ({
@@ -90,7 +89,9 @@ const FileDropzone = ({
   maxSize,
   multiple = false,
   disabled,
+  className,
   children,
+  ...props
 }: FileDropzoneProps) => {
   const [internalFiles, setInternalFiles] = React.useState<File[]>(defaultValue ?? []);
   const files = valueProp ?? internalFiles;
@@ -165,7 +166,13 @@ const FileDropzone = ({
     [files, setFiles, accept, maxSize, multiple, disabled, errors, addFiles, removeAt],
   );
 
-  return <FileDropzoneContext.Provider value={ctx}>{children}</FileDropzoneContext.Provider>;
+  return (
+    <FileDropzoneContext.Provider value={ctx}>
+      <div data-slot="file-dropzone" className={className} {...props}>
+        {children}
+      </div>
+    </FileDropzoneContext.Provider>
+  );
 };
 
 interface FileDropzoneZoneProps extends Omit<
@@ -265,6 +272,8 @@ const FileDropzoneZone = ({
         multiple={ctx.multiple}
         disabled={ctx.disabled}
         className="sr-only"
+        tabIndex={-1}
+        aria-hidden
         onChange={(e) => {
           const list = e.target.files;
           if (list && list.length > 0) ctx.addFiles(list);
@@ -303,6 +312,7 @@ const FileDropzoneList = ({ className, ...props }: FileDropzoneListProps) => {
         return (
           <li
             key={`${file.name}-${file.lastModified}-${index}`}
+            data-slot="file-dropzone-item"
             className="flex min-w-0 items-center gap-2 rounded-sm border border-border bg-card px-2.5 py-1.5 text-sm"
           >
             <Icon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
@@ -344,7 +354,11 @@ const FileDropzoneErrors = ({ className, ...props }: FileDropzoneErrorsProps) =>
       {...props}
     >
       {ctx.errors.map((err, i) => (
-        <li key={`${err.file.name}-${i}`} className="break-words text-[11px] text-destructive">
+        <li
+          key={`${err.file.name}-${i}`}
+          data-slot="file-dropzone-error"
+          className="break-words text-[11px] text-destructive"
+        >
           {err.message}
         </li>
       ))}

--- a/registry/hirael/bases/base/components/image-compare.tsx
+++ b/registry/hirael/bases/base/components/image-compare.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { ChevronsLeftRight } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
+import { composeRefs } from '@/registry/hirael/bases/base/components/compose-refs';
 
 interface ImageCompareContextValue {
   position: number;
@@ -50,6 +51,7 @@ const ImageCompare = ({
   disabled = false,
   className,
   children,
+  ref,
   ...props
 }: ImageCompareProps) => {
   const containerRef = React.useRef<HTMLDivElement | null>(null);
@@ -106,21 +108,26 @@ const ImageCompare = ({
     if (next !== null) setPosition(next);
   };
 
+  const ctx = React.useMemo<ImageCompareContextValue>(
+    () => ({
+      position,
+      setPosition,
+      orientation,
+      disabled,
+      dragging,
+      setDragging,
+      rtl,
+      positionFromPointer,
+    }),
+    [position, setPosition, orientation, disabled, dragging, rtl, positionFromPointer],
+  );
+
+  const composedRef = React.useMemo(() => composeRefs(containerRef, ref), [ref]);
+
   return (
-    <ImageCompareContext.Provider
-      value={{
-        position,
-        setPosition,
-        orientation,
-        disabled,
-        dragging,
-        setDragging,
-        rtl,
-        positionFromPointer,
-      }}
-    >
+    <ImageCompareContext.Provider value={ctx}>
       <div
-        ref={containerRef}
+        ref={composedRef}
         data-slot="image-compare"
         data-orientation={orientation}
         data-dragging={dragging || undefined}

--- a/registry/hirael/bases/base/components/image-cropper.tsx
+++ b/registry/hirael/bases/base/components/image-cropper.tsx
@@ -431,7 +431,9 @@ const ImageCropperZoom = ({ className, ...props }: ImageCropperZoomProps) => {
       max={ctx.maxZoom}
       step={0.01}
       value={[ctx.zoom]}
-      onValueChange={([v]) => ctx.setZoom(v)}
+      onValueChange={([v]) => {
+        if (v !== undefined) ctx.setZoom(v);
+      }}
       disabled={ctx.disabled}
       data-slot="image-cropper-zoom"
       className={cn('w-full', className)}

--- a/registry/hirael/bases/base/components/inline-edit.tsx
+++ b/registry/hirael/bases/base/components/inline-edit.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/registry/hirael/bases/base/ui/button';
 import { Input } from '@/registry/hirael/bases/base/ui/input';
 import { Spinner } from '@/registry/hirael/bases/base/components/spinner';
 import { Textarea } from '@/registry/hirael/bases/base/ui/textarea';
+import { composeRefs } from '@/registry/hirael/bases/base/components/compose-refs';
 
 interface InlineEditCtx {
   value: string;
@@ -26,6 +27,7 @@ interface InlineEditCtx {
   startEditing: () => void;
   submit: () => void;
   cancel: () => void;
+  previewRef: React.RefObject<HTMLSpanElement | null>;
 }
 
 const InlineEditContext = React.createContext<InlineEditCtx | null>(null);
@@ -154,6 +156,21 @@ const InlineEdit = ({
     onCancel?.();
   }, [pending, value, setEditing, onCancel]);
 
+  const previewRef = React.useRef<HTMLSpanElement | null>(null);
+  const wasEditingRef = React.useRef(editing);
+
+  // The editor unmounts when editing ends, dropping focus to <body>; return it
+  // to the preview unless the user already moved focus elsewhere (blur-submit).
+  React.useEffect(() => {
+    const wasEditing = wasEditingRef.current;
+    wasEditingRef.current = editing;
+    if (!wasEditing || editing) return;
+    const active = document.activeElement;
+    if (active === null || active === document.body) {
+      previewRef.current?.focus({ preventScroll: true });
+    }
+  }, [editing]);
+
   const ctx = React.useMemo<InlineEditCtx>(
     () => ({
       value,
@@ -170,6 +187,7 @@ const InlineEdit = ({
       startEditing,
       submit,
       cancel,
+      previewRef,
     }),
     [
       value,
@@ -211,8 +229,8 @@ const InlineEdit = ({
 /** Content is always the current value; swap the element with `render` (e.g. `render={<h2 />}`). */
 export type InlineEditPreviewProps = Omit<useRender.ComponentProps<'span'>, 'children'>;
 
-const InlineEditPreview = ({ render, className, ...props }: InlineEditPreviewProps) => {
-  const { value, editing, disabled, placeholder, startEditing } = useInlineEdit();
+const InlineEditPreview = ({ render, className, ref, ...props }: InlineEditPreviewProps) => {
+  const { value, editing, disabled, placeholder, startEditing, previewRef } = useInlineEdit();
 
   const content = (
     <>
@@ -228,6 +246,7 @@ const InlineEditPreview = ({ render, className, ...props }: InlineEditPreviewPro
   const element = useRender({
     defaultTagName: 'span',
     render,
+    ref: [previewRef, ref ?? null],
     props: mergeProps<'span'>(
       {
         role: 'button',
@@ -258,7 +277,14 @@ const InlineEditPreview = ({ render, className, ...props }: InlineEditPreviewPro
   return element;
 };
 
-const InlineEditInput = ({ className, onKeyDown, onBlur, ...props }: React.ComponentProps<typeof Input>) => {
+const InlineEditInput = ({
+  className,
+  onKeyDown,
+  onBlur,
+  onChange,
+  ref,
+  ...props
+}: React.ComponentProps<typeof Input>) => {
   const {
     draft,
     setDraft,
@@ -274,17 +300,21 @@ const InlineEditInput = ({ className, onKeyDown, onBlur, ...props }: React.Compo
     cancel,
   } = useInlineEdit();
 
-  // Stable callback ref: focus/select run once when the input mounts. An inline
-  // ref would be re-invoked on every render, re-selecting the text mid-typing.
+  // Focus/select once per mounted node. A consumer's inline callback ref gives
+  // the composed ref a new identity every render, so React re-invokes it, and
+  // re-selecting mid-typing would swallow the next keystroke.
+  const focusedRef = React.useRef<HTMLInputElement | null>(null);
   const focusOnMount = React.useCallback(
     (node: HTMLInputElement | null) => {
-      if (node) {
-        node.focus();
-        if (selectOnFocus) node.select();
-      }
+      if (!node || node === focusedRef.current) return;
+      focusedRef.current = node;
+      node.focus();
+      if (selectOnFocus) node.select();
     },
     [selectOnFocus],
   );
+
+  const composedRef = React.useMemo(() => composeRefs(focusOnMount, ref), [focusOnMount, ref]);
 
   if (!editing) return null;
 
@@ -296,7 +326,11 @@ const InlineEditInput = ({ className, onKeyDown, onBlur, ...props }: React.Compo
       disabled={disabled || pending}
       aria-invalid={error ? true : undefined}
       aria-describedby={error ? errorId : undefined}
-      onChange={(event) => setDraft(event.target.value)}
+      onChange={(event) => {
+        onChange?.(event);
+        if (event.defaultPrevented) return;
+        setDraft(event.target.value);
+      }}
       onKeyDown={(event) => {
         onKeyDown?.(event);
         if (event.key === 'Enter') {
@@ -314,12 +348,19 @@ const InlineEditInput = ({ className, onKeyDown, onBlur, ...props }: React.Compo
       }}
       className={cn('h-8', className)}
       {...props}
-      ref={focusOnMount}
+      ref={composedRef}
     />
   );
 };
 
-const InlineEditTextarea = ({ className, onKeyDown, onBlur, ...props }: React.ComponentProps<typeof Textarea>) => {
+const InlineEditTextarea = ({
+  className,
+  onKeyDown,
+  onBlur,
+  onChange,
+  ref,
+  ...props
+}: React.ComponentProps<typeof Textarea>) => {
   const {
     draft,
     setDraft,
@@ -335,17 +376,19 @@ const InlineEditTextarea = ({ className, onKeyDown, onBlur, ...props }: React.Co
     cancel,
   } = useInlineEdit();
 
-  // Stable callback ref: focus/select run once when the textarea mounts. An
-  // inline ref would re-run every render, re-selecting the text mid-typing.
+  // Focus/select once per mounted node; see InlineEditInput.
+  const focusedRef = React.useRef<HTMLTextAreaElement | null>(null);
   const focusOnMount = React.useCallback(
     (node: HTMLTextAreaElement | null) => {
-      if (node) {
-        node.focus();
-        if (selectOnFocus) node.select();
-      }
+      if (!node || node === focusedRef.current) return;
+      focusedRef.current = node;
+      node.focus();
+      if (selectOnFocus) node.select();
     },
     [selectOnFocus],
   );
+
+  const composedRef = React.useMemo(() => composeRefs(focusOnMount, ref), [focusOnMount, ref]);
 
   if (!editing) return null;
 
@@ -357,7 +400,11 @@ const InlineEditTextarea = ({ className, onKeyDown, onBlur, ...props }: React.Co
       disabled={disabled || pending}
       aria-invalid={error ? true : undefined}
       aria-describedby={error ? errorId : undefined}
-      onChange={(event) => setDraft(event.target.value)}
+      onChange={(event) => {
+        onChange?.(event);
+        if (event.defaultPrevented) return;
+        setDraft(event.target.value);
+      }}
       onKeyDown={(event) => {
         onKeyDown?.(event);
         if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
@@ -375,7 +422,7 @@ const InlineEditTextarea = ({ className, onKeyDown, onBlur, ...props }: React.Co
       }}
       className={className}
       {...props}
-      ref={focusOnMount}
+      ref={composedRef}
     />
   );
 };

--- a/registry/hirael/bases/base/components/lazy-select.tsx
+++ b/registry/hirael/bases/base/components/lazy-select.tsx
@@ -60,6 +60,7 @@ export interface LazySelectProps {
   hasMore?: boolean;
   disabled?: boolean;
   clearable?: boolean;
+  name?: string;
   children?: React.ReactNode;
 }
 
@@ -78,6 +79,7 @@ const LazySelect = ({
   hasMore,
   disabled,
   clearable = true,
+  name,
   children,
 }: LazySelectProps) => {
   const [internalValue, setInternalValue] = React.useState<string | undefined>(defaultValue);
@@ -180,6 +182,7 @@ const LazySelect = ({
       <Popover open={open} onOpenChange={setOpen}>
         {children}
       </Popover>
+      {name && <input type="hidden" name={name} value={value ?? ''} />}
     </LazySelectContext.Provider>
   );
 };
@@ -192,58 +195,70 @@ interface LazySelectTriggerProps extends Omit<React.ComponentProps<'button'>, 'c
 
 const LazySelectTrigger = ({ placeholder = 'Select…', className, children, ...props }: LazySelectTriggerProps) => {
   const ctx = useLazySelect();
+  const showClear = !children && ctx.clearable && ctx.value !== undefined && !ctx.disabled;
 
   return (
-    <PopoverTrigger
-      render={
+    <div data-slot="lazy-select-trigger-wrapper" className="relative w-full">
+      <PopoverTrigger
+        render={
+          <button
+            type="button"
+            role="combobox"
+            aria-controls={ctx.listboxId}
+            aria-expanded={ctx.open}
+            aria-haspopup="listbox"
+            disabled={ctx.disabled}
+            data-slot="lazy-select-trigger"
+            data-state={ctx.open ? 'open' : 'closed'}
+            className={cn(
+              'group flex h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-2.5 text-start text-sm outline-none transition-colors',
+              'hover:border-ring/60 focus-visible:border-ring',
+              'data-open:border-ring',
+              'disabled:cursor-not-allowed disabled:opacity-50',
+              className,
+            )}
+            {...props}
+          />
+        }
+      >
+        {typeof children === 'function' ? (
+          children(ctx)
+        ) : children ? (
+          children
+        ) : (
+          <>
+            <span
+              className={cn(
+                'min-w-0 flex-1 truncate',
+                ctx.selectedLabel === undefined && 'text-muted-foreground',
+                // Reserve room for the overlaid clear button.
+                showClear && 'pe-5',
+              )}
+            >
+              {ctx.selectedLabel ?? placeholder}
+            </span>
+            <span className="flex shrink-0 items-center gap-1 text-muted-foreground">
+              <ChevronDown className={cn('size-3.5 transition-transform duration-150', ctx.open && 'rotate-180')} />
+            </span>
+          </>
+        )}
+      </PopoverTrigger>
+      {showClear && (
         <button
           type="button"
-          role="combobox"
-          aria-controls={ctx.listboxId}
-          aria-expanded={ctx.open}
-          aria-haspopup="listbox"
-          disabled={ctx.disabled}
-          data-slot="lazy-select-trigger"
-          data-state={ctx.open ? 'open' : 'closed'}
-          className={cn(
-            'group flex h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-2.5 text-start text-sm outline-none transition-colors',
-            'hover:border-ring/60 focus-visible:border-ring',
-            'data-open:border-ring',
-            'disabled:cursor-not-allowed disabled:opacity-50',
-            className,
-          )}
-          {...props}
-        />
-      }
-    >
-      {typeof children === 'function' ? (
-        children(ctx)
-      ) : children ? (
-        children
-      ) : (
-        <>
-          <span className={cn('min-w-0 flex-1 truncate', ctx.selectedLabel === undefined && 'text-muted-foreground')}>
-            {ctx.selectedLabel ?? placeholder}
-          </span>
-          <span className="flex shrink-0 items-center gap-1 text-muted-foreground">
-            {ctx.clearable && ctx.value !== undefined && !ctx.disabled && (
-              <span
-                aria-hidden
-                onPointerDown={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  ctx.setValue(undefined);
-                }}
-                className="inline-flex size-4 items-center justify-center rounded-[2px] hover:bg-accent hover:text-foreground"
-              >
-                <X className="size-3" />
-              </span>
-            )}
-            <ChevronDown className={cn('size-3.5 transition-transform duration-150', ctx.open && 'rotate-180')} />
-          </span>
-        </>
+          aria-label="Clear"
+          data-slot="lazy-select-clear"
+          onClick={(e) => {
+            e.stopPropagation();
+            ctx.setValue(undefined);
+          }}
+          // Overlaid because a button cannot nest a button; `end-7` sits it inside the chevron.
+          className="absolute end-7 top-1/2 inline-flex size-4 -translate-y-1/2 items-center justify-center rounded-[2px] text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <X className="size-3" />
+        </button>
       )}
-    </PopoverTrigger>
+    </div>
   );
 };
 
@@ -268,6 +283,7 @@ const LazySelectContent = ({
 }: LazySelectContentProps) => {
   const ctx = useLazySelect();
   const sentinelRef = React.useRef<HTMLDivElement>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
   const onLoadMore = ctx.onLoadMore;
 
   // Lazy-load the next page when the bottom sentinel scrolls into view. Re-run
@@ -294,11 +310,11 @@ const LazySelectContent = ({
       sideOffset={6}
       data-slot="lazy-select-content"
       className={cn('w-(--anchor-width) min-w-[14rem] p-0', className)}
-      initialFocus={false}
+      initialFocus={() => inputRef.current}
       {...props}
     >
       <Command shouldFilter={false} loop>
-        <CommandInput placeholder={searchPlaceholder} value={ctx.search} onValueChange={ctx.setSearch} />
+        <CommandInput ref={inputRef} placeholder={searchPlaceholder} value={ctx.search} onValueChange={ctx.setSearch} />
         <CommandList id={ctx.listboxId}>
           {ctx.loading ? (
             <div className="flex items-center justify-center gap-2 py-6 text-xs text-muted-foreground">

--- a/registry/hirael/bases/base/components/media-input.tsx
+++ b/registry/hirael/bases/base/components/media-input.tsx
@@ -38,6 +38,8 @@ export interface MediaInputProps extends Omit<React.ComponentProps<'div'>, 'onEr
   accept?: string;
   /** Maximum file size in bytes. Larger picks are rejected with an error. */
   maxSize?: number;
+  /** Field name for the native input, so the picked file can join form submission. */
+  name?: string;
   disabled?: boolean;
   value?: MediaInputValue | null;
   defaultValue?: MediaInputValue | null;
@@ -48,6 +50,7 @@ export interface MediaInputProps extends Omit<React.ComponentProps<'div'>, 'onEr
 const MediaInput = ({
   accept,
   maxSize,
+  name,
   disabled = false,
   value: valueProp,
   defaultValue = null,
@@ -123,6 +126,7 @@ const MediaInput = ({
           ref={inputRef}
           data-slot="media-input-input"
           type="file"
+          name={name}
           accept={accept}
           disabled={disabled}
           className="sr-only"
@@ -182,6 +186,7 @@ const MediaInputTrigger = ({ variant = 'outline', onClick, ...props }: React.Com
 
   return (
     <Button
+      type="button"
       data-slot="media-input-trigger"
       variant={variant}
       disabled={disabled || props.disabled}
@@ -218,6 +223,7 @@ const MediaInputClear = ({ onClick, className, children, ...props }: React.Compo
 
   return (
     <Button
+      type="button"
       data-slot="media-input-clear"
       variant="ghost"
       size="icon"

--- a/registry/hirael/bases/base/components/mention-input.tsx
+++ b/registry/hirael/bases/base/components/mention-input.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 import { Spinner } from '@/registry/hirael/bases/base/components/spinner';
+import { composeRefs } from '@/registry/hirael/bases/base/components/compose-refs';
 
 export interface MentionItem {
   id: string;
@@ -121,6 +122,47 @@ const segmentValue = (value: string, triggers: string[], known: Set<string>): Se
   return segments;
 };
 
+const metrics = 'min-h-16 w-full rounded-sm border px-3 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words';
+
+interface MentionInputCtx {
+  id: string;
+  listboxId: string;
+  open: boolean;
+  loading: boolean;
+  filteredItems: MentionItem[];
+  activeIndex: number;
+  activeTrigger: string | undefined;
+  pos: { top: number; left: number };
+  value: string;
+  segments: Segment[];
+  disabled?: boolean;
+  placeholder?: string;
+  name?: string;
+  emptyMessage: string;
+  loadingMessage: string;
+  listLabel: string;
+  popupRef: React.RefObject<HTMLDivElement | null>;
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  backdropRef: React.RefObject<HTMLDivElement | null>;
+  select: (item: MentionItem) => void;
+  setActiveIndex: (index: number) => void;
+  /**
+   * Caret, scroll sync and suggestion keys all read state from here, so the
+   * handlers stay put and travel as one bundle for the textarea to spread.
+   */
+  textareaProps: Pick<React.ComponentProps<'textarea'>, 'onChange' | 'onSelect' | 'onScroll' | 'onKeyDown' | 'onBlur'>;
+}
+
+const MentionInputContext = React.createContext<MentionInputCtx | null>(null);
+
+export const useMentionInput = () => {
+  const ctx = React.useContext(MentionInputContext);
+  if (!ctx) {
+    throw new Error('MentionInput compound parts must be used inside <MentionInput>');
+  }
+  return ctx;
+};
+
 export interface MentionInputProps extends Omit<React.ComponentProps<'div'>, 'defaultValue' | 'onChange'> {
   value?: string;
   defaultValue?: string;
@@ -133,6 +175,8 @@ export interface MentionInputProps extends Omit<React.ComponentProps<'div'>, 'de
   maxRows?: number;
   onMention?: (item: MentionItem) => void;
   emptyMessage?: string;
+  loadingMessage?: string;
+  listLabel?: string;
   name?: string;
 }
 
@@ -148,8 +192,12 @@ const MentionInput = ({
   maxRows,
   onMention,
   emptyMessage = 'No results.',
+  loadingMessage = 'Searching…',
+  listLabel = 'Mention suggestions',
   name,
   className,
+  children,
+  ref,
   ...props
 }: MentionInputProps) => {
   const id = React.useId();
@@ -178,6 +226,7 @@ const MentionInput = ({
   });
 
   const wrapperRef = React.useRef<HTMLDivElement | null>(null);
+  const composedWrapperRef = React.useMemo(() => composeRefs(wrapperRef, ref), [ref]);
   const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
   const backdropRef = React.useRef<HTMLDivElement | null>(null);
   const popupRef = React.useRef<HTMLDivElement | null>(null);
@@ -337,43 +386,188 @@ const MentionInput = ({
     [mention, value, setValue, onMention],
   );
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (!open) return;
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      setActiveIndex(filtered.length ? (active + 1) % filtered.length : 0);
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      setActiveIndex(filtered.length ? (active - 1 + filtered.length) % filtered.length : 0);
-    } else if (e.key === 'Enter' || e.key === 'Tab') {
-      const item = filtered[active];
-      if (item) {
+  const handleKeyDown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (!open) return;
+      if (e.key === 'ArrowDown') {
         e.preventDefault();
-        select(item);
+        setActiveIndex(filtered.length ? (active + 1) % filtered.length : 0);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveIndex(filtered.length ? (active - 1 + filtered.length) % filtered.length : 0);
+      } else if (e.key === 'Enter' || e.key === 'Tab') {
+        const item = filtered[active];
+        if (item) {
+          e.preventDefault();
+          select(item);
+        }
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        dismissedRef.current = true;
+        setMention(null);
       }
-    } else if (e.key === 'Escape') {
-      e.preventDefault();
-      dismissedRef.current = true;
-      setMention(null);
-    }
-  };
+    },
+    [open, filtered, active, select],
+  );
 
-  const metrics = 'min-h-16 w-full rounded-sm border px-3 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words';
+  const handleChange = React.useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      dismissedRef.current = false;
+      setValue(e.target.value);
+      detect(e.target.value, e.target.selectionStart);
+    },
+    [setValue, detect],
+  );
+
+  const handleSelect = React.useCallback(
+    (e: React.SyntheticEvent<HTMLTextAreaElement>) => {
+      detect(e.currentTarget.value, e.currentTarget.selectionStart);
+    },
+    [detect],
+  );
+
+  const handleScroll = React.useCallback(
+    (e: React.UIEvent<HTMLTextAreaElement>) => {
+      const backdrop = backdropRef.current;
+      if (backdrop) {
+        backdrop.scrollTop = e.currentTarget.scrollTop;
+        backdrop.scrollLeft = e.currentTarget.scrollLeft;
+      }
+      if (open) setMention(null);
+    },
+    [open],
+  );
+
+  const handleBlur = React.useCallback(() => setMention(null), []);
+
+  const textareaProps = React.useMemo<MentionInputCtx['textareaProps']>(
+    () => ({
+      onChange: handleChange,
+      onSelect: handleSelect,
+      onScroll: handleScroll,
+      onKeyDown: handleKeyDown,
+      onBlur: handleBlur,
+    }),
+    [handleChange, handleSelect, handleScroll, handleKeyDown, handleBlur],
+  );
+
+  const ctx = React.useMemo<MentionInputCtx>(
+    () => ({
+      id,
+      listboxId,
+      open,
+      loading,
+      filteredItems: filtered,
+      activeIndex: active,
+      activeTrigger,
+      pos,
+      value,
+      segments,
+      disabled,
+      placeholder,
+      name,
+      emptyMessage,
+      loadingMessage,
+      listLabel,
+      popupRef,
+      textareaRef,
+      backdropRef,
+      select,
+      setActiveIndex,
+      textareaProps,
+    }),
+    [
+      id,
+      listboxId,
+      open,
+      loading,
+      filtered,
+      active,
+      activeTrigger,
+      pos,
+      value,
+      segments,
+      disabled,
+      placeholder,
+      name,
+      emptyMessage,
+      loadingMessage,
+      listLabel,
+      select,
+      textareaProps,
+    ],
+  );
 
   return (
-    <div
-      ref={wrapperRef}
-      data-slot="mention-input"
-      data-disabled={disabled || undefined}
-      className={cn('relative w-full', className)}
-      {...props}
-    >
+    <MentionInputContext.Provider value={ctx}>
+      <div
+        ref={composedWrapperRef}
+        data-slot="mention-input"
+        data-disabled={disabled || undefined}
+        className={cn('relative w-full', className)}
+        {...props}
+      >
+        {children ?? (
+          <>
+            <MentionInputTextarea />
+            <MentionInputList />
+          </>
+        )}
+      </div>
+    </MentionInputContext.Provider>
+  );
+};
+
+type MentionInputTextareaProps = Omit<
+  React.ComponentProps<'textarea'>,
+  'value' | 'defaultValue' | 'name' | 'placeholder' | 'disabled'
+>;
+
+/** The consumer's handler runs first; the part's own is skipped once the event is default-prevented. */
+const chainHandlers =
+  <E extends React.SyntheticEvent>(theirs: ((event: E) => void) | undefined, ours: ((event: E) => void) | undefined) =>
+  (event: E) => {
+    theirs?.(event);
+    if (!event.defaultPrevented) ours?.(event);
+  };
+
+const MentionInputTextarea = ({
+  className,
+  ref,
+  onChange,
+  onSelect,
+  onScroll,
+  onKeyDown,
+  onBlur,
+  ...props
+}: MentionInputTextareaProps) => {
+  const {
+    id,
+    listboxId,
+    open,
+    filteredItems,
+    activeIndex,
+    value,
+    segments,
+    disabled,
+    placeholder,
+    name,
+    backdropRef,
+    textareaRef,
+    textareaProps,
+  } = useMentionInput();
+  const composedRef = React.useMemo(() => composeRefs(textareaRef, ref), [textareaRef, ref]);
+  return (
+    <>
       <div
         ref={backdropRef}
         aria-hidden
         data-slot="mention-input-backdrop"
+        // The consumer's className lands on both layers so padding and font metrics
+        // stay aligned; the transparent overrides come last and win.
         className={cn(
           metrics,
+          className,
           'pointer-events-none absolute inset-0 overflow-hidden border-transparent text-transparent',
         )}
       >
@@ -393,7 +587,7 @@ const MentionInput = ({
         {'​'}
       </div>
       <textarea
-        ref={textareaRef}
+        ref={composedRef}
         rows={1}
         name={name}
         value={value}
@@ -404,85 +598,127 @@ const MentionInput = ({
         aria-haspopup="listbox"
         aria-autocomplete="list"
         aria-controls={listboxId}
-        aria-activedescendant={open && filtered[active] ? `${id}-option-${active}` : undefined}
+        aria-activedescendant={open && filteredItems[activeIndex] ? `${id}-option-${activeIndex}` : undefined}
         data-slot="mention-input-textarea"
-        onChange={(e) => {
-          dismissedRef.current = false;
-          setValue(e.target.value);
-          detect(e.target.value, e.target.selectionStart);
-        }}
-        onSelect={(e) => {
-          detect(e.currentTarget.value, e.currentTarget.selectionStart);
-        }}
-        onScroll={(e) => {
-          const backdrop = backdropRef.current;
-          if (backdrop) {
-            backdrop.scrollTop = e.currentTarget.scrollTop;
-            backdrop.scrollLeft = e.currentTarget.scrollLeft;
-          }
-          if (open) setMention(null);
-        }}
-        onKeyDown={handleKeyDown}
-        onBlur={() => setMention(null)}
+        {...props}
+        onChange={chainHandlers(onChange, textareaProps.onChange)}
+        onSelect={chainHandlers(onSelect, textareaProps.onSelect)}
+        onScroll={chainHandlers(onScroll, textareaProps.onScroll)}
+        onKeyDown={chainHandlers(onKeyDown, textareaProps.onKeyDown)}
+        onBlur={chainHandlers(onBlur, textareaProps.onBlur)}
         className={cn(
           metrics,
           'relative resize-none border-input bg-transparent outline-none transition-colors',
           'placeholder:text-muted-foreground',
           'focus-visible:border-ring',
           'disabled:cursor-not-allowed disabled:opacity-50',
+          className,
         )}
       />
-      {open && (
-        <div
-          ref={popupRef}
-          id={listboxId}
-          role="listbox"
-          aria-label="Mention suggestions"
-          data-slot="mention-input-list"
-          style={{ top: pos.top, left: pos.left }}
-          className="absolute z-50 max-h-60 w-64 overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
-        >
-          {loading ? (
-            <div
-              data-slot="mention-input-loading"
-              className="flex items-center gap-2 px-2 py-2 text-xs text-muted-foreground"
-            >
-              <Spinner size="sm" />
-              Searching…
-            </div>
-          ) : filtered.length === 0 ? (
-            <div data-slot="mention-input-empty" className="px-2 py-2 text-xs text-muted-foreground">
-              {emptyMessage}
-            </div>
-          ) : (
-            filtered.map((item, i) => (
-              <div
-                key={item.id}
-                id={`${id}-option-${i}`}
-                role="option"
-                aria-selected={i === active}
-                data-slot="mention-input-item"
-                data-active={i === active || undefined}
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => select(item)}
-                onMouseMove={() => setActiveIndex(i)}
-                className={cn(
-                  'flex cursor-default flex-col gap-0.5 rounded-sm px-2 py-1.5',
-                  i === active && 'bg-accent text-accent-foreground',
-                )}
-              >
-                <span className="text-sm leading-none">
-                  {mention?.trigger}
-                  {item.label}
-                </span>
-                {item.description && <span className="truncate text-xs text-muted-foreground">{item.description}</span>}
-              </div>
-            ))
-          )}
-        </div>
+    </>
+  );
+};
+
+const MentionInputList = ({ className, style, children, ref, ...props }: React.ComponentProps<'div'>) => {
+  const ctx = useMentionInput();
+  const composedRef = React.useMemo(() => composeRefs(ctx.popupRef, ref), [ctx.popupRef, ref]);
+
+  if (!ctx.open) return null;
+
+  return (
+    <div
+      ref={composedRef}
+      id={ctx.listboxId}
+      role="listbox"
+      aria-label={ctx.listLabel}
+      data-slot="mention-input-list"
+      style={{ ...style, top: ctx.pos.top, left: ctx.pos.left }}
+      className={cn(
+        'absolute z-50 max-h-60 w-64 overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md',
+        className,
+      )}
+      {...props}
+    >
+      {children ??
+        (ctx.loading ? (
+          <div
+            data-slot="mention-input-loading"
+            className="flex items-center gap-2 px-2 py-2 text-xs text-muted-foreground"
+          >
+            <Spinner size="sm" />
+            {ctx.loadingMessage}
+          </div>
+        ) : ctx.filteredItems.length === 0 ? (
+          <div data-slot="mention-input-empty" className="px-2 py-2 text-xs text-muted-foreground">
+            {ctx.emptyMessage}
+          </div>
+        ) : (
+          ctx.filteredItems.map((item, i) => <MentionInputItem key={item.id} item={item} index={i} />)
+        ))}
+    </div>
+  );
+};
+
+interface MentionInputItemProps extends Omit<React.ComponentProps<'div'>, 'children'> {
+  item: MentionItem;
+  index: number;
+  children?: React.ReactNode;
+}
+
+const MentionInputItem = ({
+  item,
+  index,
+  className,
+  children,
+  onMouseDown,
+  onClick,
+  onMouseMove,
+  ...props
+}: MentionInputItemProps) => {
+  const ctx = useMentionInput();
+  const active = index === ctx.activeIndex;
+  return (
+    <div
+      id={`${ctx.id}-option-${index}`}
+      role="option"
+      aria-selected={active}
+      data-slot="mention-input-item"
+      data-active={active || undefined}
+      onMouseDown={(e) => {
+        onMouseDown?.(e);
+        if (e.defaultPrevented) return;
+        // Keep focus in the textarea so the caret position survives the click.
+        e.preventDefault();
+      }}
+      onClick={(e) => {
+        onClick?.(e);
+        if (e.defaultPrevented) return;
+        ctx.select(item);
+      }}
+      onMouseMove={(e) => {
+        onMouseMove?.(e);
+        if (e.defaultPrevented) return;
+        ctx.setActiveIndex(index);
+      }}
+      className={cn(
+        'flex cursor-default flex-col gap-0.5 rounded-sm px-2 py-1.5',
+        active && 'bg-accent text-accent-foreground',
+        className,
+      )}
+      {...props}
+    >
+      {children ?? (
+        <>
+          {/* bdi keeps the trigger glued to the handle in RTL text */}
+          <bdi className="text-sm leading-none">
+            {ctx.activeTrigger}
+            {item.label}
+          </bdi>
+          {item.description && <span className="truncate text-xs text-muted-foreground">{item.description}</span>}
+        </>
       )}
     </div>
   );
 };
 
-export { MentionInput };
+export { MentionInput, MentionInputTextarea, MentionInputList, MentionInputItem };

--- a/registry/hirael/bases/base/components/morphing-dialog.tsx
+++ b/registry/hirael/bases/base/components/morphing-dialog.tsx
@@ -55,11 +55,14 @@ const MorphingDialog = ({ children, open: openProp, defaultOpen, onOpenChange }:
     [openProp, onOpenChange],
   );
 
+  const open = React.useCallback(() => setOpen(true), [setOpen]);
+  const close = React.useCallback(() => setOpen(false), [setOpen]);
+
   const value = React.useMemo<MorphingDialogContextValue>(
     () => ({
       isOpen,
-      open: () => setOpen(true),
-      close: () => setOpen(false),
+      open,
+      close,
       uniqueId: reactId,
       titleId: `${reactId}-title`,
       descriptionId: `${reactId}-description`,
@@ -69,7 +72,7 @@ const MorphingDialog = ({ children, open: openProp, defaultOpen, onOpenChange }:
       setHasDescription,
       triggerRef,
     }),
-    [isOpen, setOpen, reactId, hasTitle, hasDescription],
+    [isOpen, open, close, reactId, hasTitle, hasDescription],
   );
 
   return (

--- a/registry/hirael/bases/base/components/multi-select.tsx
+++ b/registry/hirael/bases/base/components/multi-select.tsx
@@ -5,7 +5,7 @@ import { Check, ChevronDown, X, Loader2 } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { Badge } from '@/registry/hirael/bases/base/ui/badge';
-import { Popover, PopoverContent, PopoverTrigger } from '@/registry/hirael/bases/base/ui/popover';
+import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from '@/registry/hirael/bases/base/ui/popover';
 import {
   Command,
   CommandEmpty,
@@ -38,6 +38,7 @@ interface MultiSelectContextValue {
   toggle: (v: string) => void;
   remove: (v: string) => void;
   clear: () => void;
+  listboxId: string;
 }
 
 const MultiSelectContext = React.createContext<MultiSelectContextValue | null>(null);
@@ -61,6 +62,7 @@ export interface MultiSelectProps {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
+  name?: string;
   children?: React.ReactNode;
 }
 
@@ -75,6 +77,7 @@ const MultiSelect = ({
   open: openProp,
   defaultOpen = false,
   onOpenChange,
+  name,
   children,
 }: MultiSelectProps) => {
   const [internalValue, setInternalValue] = React.useState<string[]>(defaultValue ?? []);
@@ -119,6 +122,8 @@ const MultiSelect = ({
 
   const clear = React.useCallback(() => setValue([]), [setValue]);
 
+  const listboxId = React.useId();
+
   const ctx = React.useMemo<MultiSelectContextValue>(
     () => ({
       value,
@@ -135,8 +140,9 @@ const MultiSelect = ({
       toggle,
       remove,
       clear,
+      listboxId,
     }),
-    [value, setValue, options, open, setOpen, search, maxCount, disabled, loading, toggle, remove, clear],
+    [value, setValue, options, open, setOpen, search, maxCount, disabled, loading, toggle, remove, clear, listboxId],
   );
 
   return (
@@ -144,10 +150,16 @@ const MultiSelect = ({
       <Popover open={open} onOpenChange={setOpen}>
         {children}
       </Popover>
+      {name && <input type="hidden" name={name} value={value.join(',')} />}
     </MultiSelectContext.Provider>
   );
 };
 
+/**
+ * Chips carry remove buttons, so they cannot sit inside the trigger button. The
+ * bordered box is a wrapper (`multi-select-trigger`) taking `className`; the
+ * button inside it (`multi-select-trigger-button`) takes every other prop.
+ */
 interface MultiSelectTriggerProps extends Omit<React.ComponentProps<'button'>, 'children'> {
   placeholder?: string;
   className?: string;
@@ -158,68 +170,80 @@ const MultiSelectTrigger = ({ placeholder = 'Select…', className, children, ..
   const ctx = useMultiSelect();
   const selected = ctx.options.filter((o) => ctx.value.includes(o.value));
 
+  // The popover anchors to the whole box, not the inner button that shrinks as chips fill the row.
   return (
-    <PopoverTrigger
-      render={
-        <button
-          type="button"
-          role="combobox"
-          aria-expanded={ctx.open}
-          aria-haspopup="listbox"
-          disabled={ctx.disabled}
-          data-slot="multi-select-trigger"
-          data-state={ctx.open ? 'open' : 'closed'}
-          className={cn(
-            'group flex min-h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-2 py-1 text-start text-sm outline-none transition-colors',
-            'hover:border-ring/60 focus-visible:border-ring',
-            'data-open:border-ring',
-            'disabled:cursor-not-allowed disabled:opacity-50',
-            className,
-          )}
-          {...props}
-        />
-      }
-    >
-      {typeof children === 'function' ? (
-        children(ctx)
-      ) : children ? (
-        children
-      ) : (
-        <>
-          <span className="flex flex-1 flex-wrap items-center gap-1">
-            {selected.length === 0 ? (
-              <span className="px-1 text-muted-foreground">{placeholder}</span>
-            ) : (
-              selected.map((opt) => (
-                <Badge key={opt.value} variant="default" className="gap-1 pe-1">
-                  {opt.label}
-                  <span
-                    aria-hidden
-                    onPointerDown={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      ctx.remove(opt.value);
-                    }}
-                    className="ms-0.5 inline-flex size-3.5 items-center justify-center rounded-[2px] text-primary-foreground/70 hover:bg-primary-foreground/20 hover:text-primary-foreground"
-                  >
-                    <X className="size-2.5" />
-                  </span>
-                </Badge>
-              ))
-            )}
-          </span>
-          <span className="flex shrink-0 items-center gap-1.5 text-muted-foreground">
-            {selected.length > 0 && (
-              <span className="font-mono text-[10px] tabular-nums">
-                {selected.length}
-                {ctx.maxCount ? `/${ctx.maxCount}` : ''}
-              </span>
-            )}
-            <ChevronDown className={cn('size-3.5 transition-transform duration-150', ctx.open && 'rotate-180')} />
-          </span>
-        </>
+    <PopoverAnchor
+      data-slot="multi-select-trigger"
+      data-open={ctx.open || undefined}
+      className={cn(
+        'group flex min-h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-2 py-1 text-start text-sm transition-colors',
+        'hover:border-ring/60 focus-within:border-ring',
+        'data-open:border-ring',
+        ctx.disabled && 'cursor-not-allowed opacity-50',
+        className,
       )}
-    </PopoverTrigger>
+    >
+      {!children && selected.length > 0 && (
+        <span data-slot="multi-select-chips" className="flex flex-wrap items-center gap-1">
+          {selected.map((opt) => (
+            <Badge key={opt.value} variant="default" data-slot="multi-select-chip" className="gap-1 pe-1">
+              {opt.label}
+              {!ctx.disabled && (
+                <button
+                  type="button"
+                  data-slot="multi-select-chip-remove"
+                  aria-label={`Remove ${opt.label}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    ctx.remove(opt.value);
+                  }}
+                  className="ms-0.5 inline-flex size-3.5 items-center justify-center rounded-[2px] text-primary-foreground/70 hover:bg-primary-foreground/20 hover:text-primary-foreground"
+                >
+                  <X className="size-2.5" />
+                </button>
+              )}
+            </Badge>
+          ))}
+        </span>
+      )}
+      <PopoverTrigger
+        render={
+          <button
+            type="button"
+            role="combobox"
+            aria-controls={ctx.listboxId}
+            aria-expanded={ctx.open}
+            aria-haspopup="listbox"
+            disabled={ctx.disabled}
+            data-slot="multi-select-trigger-button"
+            data-state={ctx.open ? 'open' : 'closed'}
+            className="flex grow items-center justify-between gap-2 self-stretch text-start outline-none disabled:cursor-not-allowed"
+            {...props}
+          />
+        }
+      >
+        {typeof children === 'function' ? (
+          children(ctx)
+        ) : children ? (
+          children
+        ) : (
+          <>
+            <span className="flex flex-1 flex-wrap items-center gap-1">
+              {selected.length === 0 && <span className="px-1 text-muted-foreground">{placeholder}</span>}
+            </span>
+            <span className="flex shrink-0 items-center gap-1.5 text-muted-foreground">
+              {selected.length > 0 && (
+                <span className="font-mono text-[10px] tabular-nums">
+                  {selected.length}
+                  {ctx.maxCount ? `/${ctx.maxCount}` : ''}
+                </span>
+              )}
+              <ChevronDown className={cn('size-3.5 transition-transform duration-150', ctx.open && 'rotate-180')} />
+            </span>
+          </>
+        )}
+      </PopoverTrigger>
+    </PopoverAnchor>
   );
 };
 
@@ -245,6 +269,7 @@ const MultiSelectContent = ({
   ...props
 }: MultiSelectContentProps) => {
   const ctx = useMultiSelect();
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
   const enabled = ctx.options.filter((o) => !o.disabled);
   const allSelected = enabled.length > 0 && enabled.every((o) => ctx.value.includes(o.value));
@@ -267,12 +292,12 @@ const MultiSelectContent = ({
       sideOffset={6}
       data-slot="multi-select-content"
       className={cn('w-(--anchor-width) min-w-[14rem] p-0', className)}
-      initialFocus={false}
+      initialFocus={() => inputRef.current}
       {...props}
     >
       <Command shouldFilter loop>
-        <CommandInput placeholder={searchPlaceholder} value={ctx.search} onValueChange={ctx.setSearch} />
-        <CommandList>
+        <CommandInput ref={inputRef} placeholder={searchPlaceholder} value={ctx.search} onValueChange={ctx.setSearch} />
+        <CommandList id={ctx.listboxId}>
           {ctx.loading ? (
             <div className="flex items-center justify-center gap-2 py-6 text-xs text-muted-foreground">
               <Loader2 className="size-3.5 animate-spin" />

--- a/registry/hirael/bases/base/components/number-range.tsx
+++ b/registry/hirael/bases/base/components/number-range.tsx
@@ -169,6 +169,7 @@ const NumberRangeInput = ({ bound, className, ...props }: NumberRangeInputProps)
       )}
       <Input
         inputMode="decimal"
+        dir="ltr"
         value={draft}
         disabled={ctx.disabled}
         onFocus={() => setEditing(true)}
@@ -189,8 +190,10 @@ const NumberRangeInput = ({ bound, className, ...props }: NumberRangeInputProps)
                 ? ([ctx.value[0] + delta * mult, ctx.value[1]] as NumberRangeValue)
                 : ([ctx.value[0], ctx.value[1] + delta * mult] as NumberRangeValue);
             ctx.setValue(next);
+            setDraft(format(next[i]));
           }
         }}
+        data-slot="number-range-field"
         className={cn('font-mono tabular-nums', ctx.prefix && 'ps-6', ctx.suffix && 'pe-8', className)}
         {...props}
       />

--- a/registry/hirael/bases/base/components/password-input.tsx
+++ b/registry/hirael/bases/base/components/password-input.tsx
@@ -63,7 +63,7 @@ const usePasswordContext = () => {
   return ctx;
 };
 
-export interface PasswordInputProps {
+export interface PasswordInputProps extends React.ComponentProps<'div'> {
   id?: string;
   value?: string;
   defaultValue?: string;
@@ -80,7 +80,9 @@ const PasswordInput = ({
   onValueChange,
   disabled,
   scorer = defaultPasswordScorer,
+  className,
   children,
+  ...props
 }: PasswordInputProps) => {
   const reactId = React.useId();
   const fieldId = id ?? reactId;
@@ -112,7 +114,13 @@ const PasswordInput = ({
     [fieldId, value, setValue, visible, disabled, strength],
   );
 
-  return <PasswordContext.Provider value={ctx}>{children}</PasswordContext.Provider>;
+  return (
+    <PasswordContext.Provider value={ctx}>
+      <div data-slot="password-input" className={cn('flex flex-col gap-2', className)} {...props}>
+        {children}
+      </div>
+    </PasswordContext.Provider>
+  );
 };
 
 interface PasswordInputFieldProps extends Omit<

--- a/registry/hirael/bases/base/components/phone-input.tsx
+++ b/registry/hirael/bases/base/components/phone-input.tsx
@@ -108,6 +108,7 @@ export interface PhoneInputProps extends Omit<React.ComponentProps<'div'>, 'chil
   onValueChange?: (e164: string) => void;
   defaultCountry?: string;
   disabled?: boolean;
+  name?: string;
   children?: React.ReactNode;
 }
 
@@ -118,6 +119,7 @@ const PhoneInput = ({
   onValueChange,
   defaultCountry = 'US',
   disabled,
+  name,
   className,
   children,
   ...props
@@ -187,6 +189,9 @@ const PhoneInput = ({
     [fieldId, country, setCountry, national, setNational, disabled, open],
   );
 
+  const nationalDigits = digitsOnly(national);
+  const e164 = nationalDigits ? `${country.dialCode}${nationalDigits}` : '';
+
   return (
     <PhoneInputContext.Provider value={ctx}>
       <InputGroup
@@ -196,6 +201,7 @@ const PhoneInput = ({
         {...props}
       >
         {children}
+        {name && <input type="hidden" name={name} value={e164} />}
       </InputGroup>
     </PhoneInputContext.Provider>
   );
@@ -205,6 +211,7 @@ type PhoneInputCountrySelectProps = Omit<React.ComponentProps<'button'>, 'childr
 
 const PhoneInputCountrySelect = ({ className, ...props }: PhoneInputCountrySelectProps) => {
   const ctx = usePhoneInput();
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
   return (
     <InputGroupAddon align="inline-start" data-slot="phone-input-country-select" className="cursor-pointer">
@@ -231,9 +238,9 @@ const PhoneInputCountrySelect = ({ className, ...props }: PhoneInputCountrySelec
             className={cn('size-3 text-muted-foreground transition-transform duration-150', ctx.open && 'rotate-180')}
           />
         </PopoverTrigger>
-        <PopoverContent align="start" sideOffset={6} className="w-64 p-0" initialFocus={false}>
+        <PopoverContent align="start" sideOffset={6} className="w-64 p-0" initialFocus={() => inputRef.current}>
           <Command loop>
-            <CommandInput placeholder="Search countries…" />
+            <CommandInput ref={inputRef} placeholder="Search countries…" />
             <CommandList>
               <CommandEmpty>No country found.</CommandEmpty>
               <CommandGroup>

--- a/registry/hirael/bases/base/components/qr-code.tsx
+++ b/registry/hirael/bases/base/components/qr-code.tsx
@@ -498,7 +498,7 @@ const encodeQR = (value: string, level: QRCodeLevel = 'M'): boolean[][] => {
   return modules;
 };
 
-export interface QRCodeProps extends Omit<React.ComponentProps<'svg'>, 'children'> {
+export interface QRCodeProps extends Omit<React.ComponentProps<'svg'>, 'children' | 'onError'> {
   /** Text encoded into the QR symbol. */
   value: string;
   /** Error correction level. */
@@ -509,10 +509,12 @@ export interface QRCodeProps extends Omit<React.ComponentProps<'svg'>, 'children
   margin?: number;
   /** Accessible title announced by screen readers. */
   title?: string;
+  /** Called when the value fails to encode; an empty svg is still rendered. */
+  onError?: (error: unknown) => void;
 }
 
-const QRCode = ({ value, level = 'M', size = 128, margin = 2, title, className, ...props }: QRCodeProps) => {
-  const { d, dim } = React.useMemo(() => {
+const QRCode = ({ value, level = 'M', size = 128, margin = 2, title, onError, className, ...props }: QRCodeProps) => {
+  const { d, dim, error } = React.useMemo(() => {
     try {
       const matrix = encodeQR(value, level);
       let path = '';
@@ -521,24 +523,34 @@ const QRCode = ({ value, level = 'M', size = 128, margin = 2, title, className, 
           if (matrix[y][x]) path += `M${x + margin} ${y + margin}h1v1h-1z`;
         }
       }
-      return { d: path, dim: matrix.length + margin * 2 };
-    } catch {
-      return { d: '', dim: margin * 2 };
+      return { d: path, dim: matrix.length + margin * 2, error: null };
+    } catch (err) {
+      return { d: '', dim: margin * 2, error: err };
     }
   }, [value, level, margin]);
+
+  // Latest-ref: an inline `onError` changes identity every parent render and
+  // must not re-report the same failure each time.
+  const onErrorRef = React.useRef(onError);
+  React.useEffect(() => {
+    onErrorRef.current = onError;
+  }, [onError]);
+  React.useEffect(() => {
+    if (error !== null) onErrorRef.current?.(error);
+  }, [error]);
 
   return (
     <svg
       data-slot="qr-code"
       role="img"
-      aria-label={title ?? value}
+      data-error={error !== null || undefined}
       viewBox={`0 0 ${dim} ${dim}`}
       width={size}
       height={size}
       className={cn('shrink-0 text-foreground', className)}
       {...props}
     >
-      {title ? <title>{title}</title> : null}
+      <title>{title ?? `QR code for ${value}`}</title>
       <path data-slot="qr-code-path" d={d} fill="currentColor" shapeRendering="crispEdges" />
     </svg>
   );

--- a/registry/hirael/bases/base/components/resizable-panels.tsx
+++ b/registry/hirael/bases/base/components/resizable-panels.tsx
@@ -3,18 +3,35 @@
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
+import { composeRefs } from '@/registry/hirael/bases/base/components/compose-refs';
 
 type ResizableDirection = 'horizontal' | 'vertical';
 
-const ResizableContext = React.createContext<ResizableDirection>('horizontal');
+interface ResizableContextValue {
+  direction: ResizableDirection;
+  resizeEpoch: number;
+  notifyResize: () => void;
+}
+
+const ResizableContext = React.createContext<ResizableContextValue>({
+  direction: 'horizontal',
+  resizeEpoch: 0,
+  notifyResize: () => {},
+});
 
 interface ResizablePanelGroupProps extends React.ComponentProps<'div'> {
   direction?: ResizableDirection;
 }
 
 const ResizablePanelGroup = ({ direction = 'horizontal', className, ...props }: ResizablePanelGroupProps) => {
+  const [resizeEpoch, setResizeEpoch] = React.useState(0);
+  const notifyResize = React.useCallback(() => setResizeEpoch((epoch) => epoch + 1), []);
+  const value = React.useMemo<ResizableContextValue>(
+    () => ({ direction, resizeEpoch, notifyResize }),
+    [direction, resizeEpoch, notifyResize],
+  );
   return (
-    <ResizableContext.Provider value={direction}>
+    <ResizableContext.Provider value={value}>
       <div
         data-slot="resizable-panel-group"
         data-direction={direction}
@@ -47,26 +64,43 @@ const ResizablePanel = ({ defaultSize = 50, minSize = 10, className, style, ...p
 type ResizableHandleProps = React.ComponentProps<'div'>;
 
 const ResizableHandle = ({ className, ref, ...props }: ResizableHandleProps) => {
-  const direction = React.useContext(ResizableContext);
+  const { direction, resizeEpoch, notifyResize } = React.useContext(ResizableContext);
   const isHorizontal = direction === 'horizontal';
   const localRef = React.useRef<HTMLDivElement | null>(null);
-  const [valueNow, setValueNow] = React.useState(50);
+  const [range, setRange] = React.useState({ now: 50, min: 0, max: 100 });
 
   const measure = React.useCallback(
     (handle: HTMLElement) => {
       const prev = handle.previousElementSibling as HTMLElement | null;
       const next = handle.nextElementSibling as HTMLElement | null;
-      if (!prev || !next) return 50;
+      if (!prev || !next) return { now: 50, min: 0, max: 100 };
       const prevSize = isHorizontal ? prev.clientWidth : prev.clientHeight;
       const nextSize = isHorizontal ? next.clientWidth : next.clientHeight;
       const totalSize = prevSize + nextSize;
-      return totalSize > 0 ? Math.round((prevSize / totalSize) * 100) : 50;
+      if (totalSize <= 0) return { now: 50, min: 0, max: 100 };
+      const group = handle.parentElement;
+      const groupSize = group ? (isHorizontal ? group.clientWidth : group.clientHeight) : totalSize;
+      const prevMin = (parseFloat(prev.dataset.minSize || '0') / 100) * groupSize;
+      const nextMin = (parseFloat(next.dataset.minSize || '0') / 100) * groupSize;
+      return {
+        now: Math.round((prevSize / totalSize) * 100),
+        min: Math.round((prevMin / totalSize) * 100),
+        max: Math.round(((totalSize - nextMin) / totalSize) * 100),
+      };
     },
     [isHorizontal],
   );
 
   React.useEffect(() => {
-    if (localRef.current) setValueNow(measure(localRef.current));
+    if (localRef.current) setRange(measure(localRef.current));
+  }, [measure, resizeEpoch]);
+
+  React.useEffect(() => {
+    const onWindowResize = () => {
+      if (localRef.current) setRange(measure(localRef.current));
+    };
+    window.addEventListener('resize', onWindowResize);
+    return () => window.removeEventListener('resize', onWindowResize);
   }, [measure]);
 
   const resize = (handle: HTMLElement, deltaPx: number) => {
@@ -88,7 +122,19 @@ const ResizableHandle = ({ className, ref, ...props }: ResizableHandleProps) => 
     const newPrevGrow = (newPrev / totalSize) * totalGrow;
     prev.style.flexGrow = String(newPrevGrow);
     next.style.flexGrow = String(totalGrow - newPrevGrow);
-    if (totalSize > 0) setValueNow(Math.round((newPrev / totalSize) * 100));
+    if (totalSize <= 0) return;
+    // Derived from the numbers already in hand: re-measuring after the style
+    // writes would force a synchronous layout on every pointermove.
+    const nextRange = {
+      now: Math.round((newPrev / totalSize) * 100),
+      min: Math.round((prevMin / totalSize) * 100),
+      max: Math.round(((totalSize - nextMin) / totalSize) * 100),
+    };
+    setRange((current) =>
+      current.now === nextRange.now && current.min === nextRange.min && current.max === nextRange.max
+        ? current
+        : nextRange,
+    );
   };
 
   const onPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
@@ -105,12 +151,18 @@ const ResizableHandle = ({ className, ref, ...props }: ResizableHandleProps) => 
       resize(handle, delta);
     };
     const onUp = (ev: PointerEvent) => {
-      handle.releasePointerCapture(ev.pointerId);
+      if (handle.hasPointerCapture(ev.pointerId)) {
+        handle.releasePointerCapture(ev.pointerId);
+      }
       handle.removeEventListener('pointermove', onMove);
       handle.removeEventListener('pointerup', onUp);
+      handle.removeEventListener('pointercancel', onUp);
+      // Siblings share the space that moved; they re-measure once, not per pointermove.
+      notifyResize();
     };
     handle.addEventListener('pointermove', onMove);
     handle.addEventListener('pointerup', onUp);
+    handle.addEventListener('pointercancel', onUp);
   };
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -132,22 +184,21 @@ const ResizableHandle = ({ className, ref, ...props }: ResizableHandleProps) => 
     if (dir !== 0) {
       event.preventDefault();
       resize(handle, dir * step * groupSize);
+      notifyResize();
     }
   };
 
+  const composedRef = React.useMemo(() => composeRefs(localRef, ref), [ref]);
+
   return (
     <div
-      ref={(node) => {
-        localRef.current = node;
-        if (typeof ref === 'function') ref(node);
-        else if (ref) ref.current = node;
-      }}
+      ref={composedRef}
       role="separator"
       tabIndex={0}
       aria-orientation={isHorizontal ? 'vertical' : 'horizontal'}
-      aria-valuenow={valueNow}
-      aria-valuemin={0}
-      aria-valuemax={100}
+      aria-valuenow={range.now}
+      aria-valuemin={range.min}
+      aria-valuemax={range.max}
       data-slot="resizable-handle"
       onPointerDown={onPointerDown}
       onKeyDown={onKeyDown}

--- a/registry/hirael/bases/base/components/rich-text-editor.tsx
+++ b/registry/hirael/bases/base/components/rich-text-editor.tsx
@@ -121,7 +121,7 @@ const contentClassName = cn(
   '[&_.ProseMirror_p.is-editor-empty:first-child]:before:pointer-events-none [&_.ProseMirror_p.is-editor-empty:first-child]:before:float-start [&_.ProseMirror_p.is-editor-empty:first-child]:before:h-0 [&_.ProseMirror_p.is-editor-empty:first-child]:before:text-muted-foreground [&_.ProseMirror_p.is-editor-empty:first-child]:before:content-[attr(data-placeholder)]',
 );
 
-export interface RichTextEditorProps {
+export interface RichTextEditorProps extends Omit<React.ComponentProps<'div'>, 'onChange'> {
   value?: string;
   onChange?: (value: string) => void;
   defaultValue?: string;
@@ -145,6 +145,7 @@ const RichTextEditor = ({
   onBlur,
   className,
   children,
+  ...props
 }: RichTextEditorProps) => {
   const isEditable = editable && !disabled;
 
@@ -241,6 +242,7 @@ const RichTextEditor = ({
           disabled && 'cursor-not-allowed opacity-50',
           className,
         )}
+        {...props}
       >
         {children ?? (
           <>
@@ -304,6 +306,7 @@ const RichTextEditorButton = ({
             pressed={pressed}
             onPressedChange={onPressedChange}
             disabled={disabled}
+            aria-label={tooltip}
             className={className}
           />
         }
@@ -376,6 +379,7 @@ const RichTextEditorLinkPopover = () => {
                   size="sm"
                   pressed={isLink}
                   onPressedChange={() => handleOpen(!open)}
+                  aria-label="Link"
                 />
               }
             />
@@ -519,11 +523,17 @@ const RichTextEditorLinkBubble = () => {
 
   React.useEffect(() => {
     if (!target) return;
-    window.addEventListener('scroll', reposition, true);
-    window.addEventListener('resize', reposition);
+    let raf = 0;
+    const scheduleReposition = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(reposition);
+    };
+    window.addEventListener('scroll', scheduleReposition, true);
+    window.addEventListener('resize', scheduleReposition);
     return () => {
-      window.removeEventListener('scroll', reposition, true);
-      window.removeEventListener('resize', reposition);
+      cancelAnimationFrame(raf);
+      window.removeEventListener('scroll', scheduleReposition, true);
+      window.removeEventListener('resize', scheduleReposition);
     };
   }, [target]);
 

--- a/registry/hirael/bases/base/components/signature-pad.tsx
+++ b/registry/hirael/bases/base/components/signature-pad.tsx
@@ -89,6 +89,7 @@ const SignaturePad = ({
   className,
   children,
   ref,
+  'aria-label': ariaLabel,
   ...props
 }: SignaturePadProps) => {
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
@@ -289,7 +290,8 @@ const SignaturePad = ({
           ref={canvasRef}
           data-slot="signature-pad-canvas"
           role="img"
-          aria-label="Signature pad"
+          aria-roledescription="signature pad"
+          aria-label={ariaLabel ?? 'Signature pad. Draw using a mouse or touch.'}
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={endStroke}
@@ -335,7 +337,7 @@ const SignaturePadClear = ({ className, children, ...props }: React.ComponentPro
       data-slot="signature-pad-clear"
       disabled={ctx.disabled || ctx.empty}
       onClick={() => ctx.clear()}
-      className={cn(className)}
+      className={className}
       {...props}
     >
       <Eraser aria-hidden />
@@ -354,7 +356,7 @@ const SignaturePadUndo = ({ className, children, ...props }: React.ComponentProp
       data-slot="signature-pad-undo"
       disabled={ctx.disabled || ctx.empty}
       onClick={() => ctx.undo()}
-      className={cn(className)}
+      className={className}
       {...props}
     >
       <Undo2 aria-hidden />

--- a/registry/hirael/bases/base/components/sortable.tsx
+++ b/registry/hirael/bases/base/components/sortable.tsx
@@ -103,9 +103,11 @@ const Sortable = ({
   const order = preview ?? committed;
 
   const orderRef = React.useRef(order);
-  orderRef.current = order;
   const committedRef = React.useRef(committed);
-  committedRef.current = committed;
+  React.useLayoutEffect(() => {
+    orderRef.current = order;
+    committedRef.current = committed;
+  }, [order, committed]);
 
   const itemsRef = React.useRef(new Map<string, ItemEntry>());
   const pressRef = React.useRef<{

--- a/registry/hirael/bases/base/components/sparkles.tsx
+++ b/registry/hirael/bases/base/components/sparkles.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
+import { composeRefs } from '@/registry/hirael/bases/base/components/compose-refs';
 
 interface SparklesProps extends React.ComponentProps<'div'> {
   /**
@@ -43,19 +44,21 @@ const Sparkles = ({
   color = 'var(--foreground)',
   opacity = 1,
   className,
+  ref,
   ...props
 }: SparklesProps) => {
   const containerRef = React.useRef<HTMLDivElement>(null);
+  const composedRef = React.useMemo(() => composeRefs(containerRef, ref), [ref]);
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
 
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     const container = containerRef.current;
     const canvas = canvasRef.current;
     const ctx = canvas?.getContext('2d');
     if (!container || !canvas || !ctx) return;
 
     const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    const fill = resolveColor(container, color);
+    let fill = resolveColor(container, color);
     let particles: Particle[] = [];
     let width = 0;
     let height = 0;
@@ -119,6 +122,7 @@ const Sparkles = ({
     };
 
     const resize = () => {
+      fill = resolveColor(container, color);
       const rect = container.getBoundingClientRect();
       const dpr = window.devicePixelRatio || 1;
       width = rect.width;
@@ -133,6 +137,14 @@ const Sparkles = ({
     resize();
     const ro = new ResizeObserver(resize);
     ro.observe(container);
+    const mo = new MutationObserver(() => {
+      fill = resolveColor(container, color);
+      if (reduced) draw(0, 0);
+    });
+    mo.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'style'],
+    });
     const io = new IntersectionObserver(([entry]) => {
       isVisible = entry.isIntersecting;
       sync();
@@ -144,6 +156,7 @@ const Sparkles = ({
     return () => {
       stop();
       ro.disconnect();
+      mo.disconnect();
       io.disconnect();
       document.removeEventListener('visibilitychange', sync);
     };
@@ -151,7 +164,7 @@ const Sparkles = ({
 
   return (
     <div
-      ref={containerRef}
+      ref={composedRef}
       data-slot="sparkles"
       aria-hidden
       className={cn('pointer-events-none absolute inset-0', className)}

--- a/registry/hirael/bases/base/components/split-view.tsx
+++ b/registry/hirael/bases/base/components/split-view.tsx
@@ -3,12 +3,15 @@
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
+import { composeRefs } from '@/registry/hirael/bases/base/components/compose-refs';
 
 type SplitOrientation = 'horizontal' | 'vertical';
 
 interface SplitViewContextValue {
   orientation: SplitOrientation;
   size: number;
+  minSize: number;
+  maxSize: number;
   dragging: boolean;
   onResizerPointerDown: (event: React.PointerEvent) => void;
   onResizerKeyDown: (event: React.KeyboardEvent) => void;
@@ -46,9 +49,11 @@ const SplitView = ({
   className,
   style,
   children,
+  ref: consumerRef,
   ...props
 }: SplitViewProps) => {
   const ref = React.useRef<HTMLDivElement>(null);
+  const composedRef = React.useMemo(() => composeRefs(ref, consumerRef), [consumerRef]);
   const [size, setSize] = React.useState(defaultSize);
   const [dragging, setDragging] = React.useState(false);
 
@@ -82,10 +87,12 @@ const SplitView = ({
         }
         handle.removeEventListener('pointermove', onMove);
         handle.removeEventListener('pointerup', onUp);
+        handle.removeEventListener('pointercancel', onUp);
         setDragging(false);
       };
       handle.addEventListener('pointermove', onMove);
       handle.addEventListener('pointerup', onUp);
+      handle.addEventListener('pointercancel', onUp);
     },
     [resizeToPointer],
   );
@@ -114,17 +121,19 @@ const SplitView = ({
     () => ({
       orientation,
       size,
+      minSize,
+      maxSize,
       dragging,
       onResizerPointerDown,
       onResizerKeyDown,
     }),
-    [orientation, size, dragging, onResizerPointerDown, onResizerKeyDown],
+    [orientation, size, minSize, maxSize, dragging, onResizerPointerDown, onResizerKeyDown],
   );
 
   return (
     <SplitViewContext.Provider value={value}>
       <div
-        ref={ref}
+        ref={composedRef}
         data-slot="split-view"
         data-orientation={orientation}
         className={cn(
@@ -153,15 +162,15 @@ const SplitViewPanel = ({ className, ...props }: SplitViewPanelProps) => {
 type SplitViewResizerProps = React.ComponentProps<'div'>;
 
 const SplitViewResizer = ({ className, ...props }: SplitViewResizerProps) => {
-  const { orientation, size, dragging, onResizerPointerDown, onResizerKeyDown } = useSplitView();
+  const { orientation, size, minSize, maxSize, dragging, onResizerPointerDown, onResizerKeyDown } = useSplitView();
   return (
     <div
       role="separator"
       tabIndex={0}
       aria-orientation={orientation === 'horizontal' ? 'vertical' : 'horizontal'}
       aria-valuenow={Math.round(size)}
-      aria-valuemin={0}
-      aria-valuemax={100}
+      aria-valuemin={minSize}
+      aria-valuemax={maxSize}
       data-slot="split-view-resizer"
       data-dragging={dragging ? '' : undefined}
       onPointerDown={onResizerPointerDown}

--- a/registry/hirael/bases/base/components/spotlight-card.tsx
+++ b/registry/hirael/bases/base/components/spotlight-card.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { motion, useMotionTemplate, useMotionValue } from 'motion/react';
+import { motion, useMotionTemplate, useMotionValue, useReducedMotion } from 'motion/react';
 
 import { cn } from '@/lib/utils';
 
@@ -11,11 +11,13 @@ interface SpotlightCardProps extends React.ComponentProps<'div'> {
 }
 
 const SpotlightCard = ({ className, children, size = 350, ...props }: SpotlightCardProps) => {
+  const reduced = useReducedMotion();
   const x = useMotionValue(0);
   const y = useMotionValue(0);
   const background = useMotionTemplate`radial-gradient(${size}px circle at ${x}px ${y}px, color-mix(in oklch, var(--foreground) 10%, transparent), transparent 70%)`;
 
   const onPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (reduced) return;
     const rect = event.currentTarget.getBoundingClientRect();
     x.set(event.clientX - rect.left);
     y.set(event.clientY - rect.top);

--- a/registry/hirael/bases/base/components/stepper.tsx
+++ b/registry/hirael/bases/base/components/stepper.tsx
@@ -72,6 +72,7 @@ const Stepper = ({
   return (
     <StepperContext.Provider value={ctx}>
       <div
+        role="list"
         data-slot="stepper"
         data-orientation={orientation}
         className={cn(
@@ -103,6 +104,7 @@ const StepperItem = ({ step, completed, disabled = false, className, ...props }:
   return (
     <StepperItemContext.Provider value={ctx}>
       <div
+        role="listitem"
         data-slot="stepper-item"
         data-state={state}
         className={cn(

--- a/registry/hirael/bases/base/components/tag-input.tsx
+++ b/registry/hirael/bases/base/components/tag-input.tsx
@@ -38,7 +38,7 @@ const useTagInput = () => {
   return ctx;
 };
 
-export interface TagInputProps {
+export interface TagInputProps extends Omit<React.ComponentProps<'div'>, 'defaultValue'> {
   value?: string[];
   defaultValue?: string[];
   onValueChange?: (value: string[]) => void;
@@ -65,7 +65,9 @@ const TagInput = ({
   validate,
   commitKeys = ['Enter', ','],
   splitOn = /[,\n\t]+/,
+  className,
   children,
+  ...props
 }: TagInputProps) => {
   const [internalValue, setInternalValue] = React.useState<string[]>(defaultValue ?? []);
   const value = valueProp ?? internalValue;
@@ -171,7 +173,13 @@ const TagInput = ({
     ],
   );
 
-  return <TagInputContext.Provider value={ctx}>{children}</TagInputContext.Provider>;
+  return (
+    <TagInputContext.Provider value={ctx}>
+      <div data-slot="tag-input" className={cn('flex flex-col gap-2', className)} {...props}>
+        {children}
+      </div>
+    </TagInputContext.Provider>
+  );
 };
 
 type TagInputContainerProps = React.ComponentProps<'div'>;

--- a/registry/hirael/bases/base/components/text-reveal.tsx
+++ b/registry/hirael/bases/base/components/text-reveal.tsx
@@ -61,9 +61,12 @@ const TextReveal = ({
 
   return (
     <Tag ref={ref} data-slot="text-reveal" className={cn(by === 'line' && 'flex flex-col', className)} {...props}>
+      {/* The split units are decorative, and a role-less element ignores aria-label. */}
+      <span className="sr-only">{children}</span>
       {units.map((unit, i) => (
         <React.Fragment key={i}>
           <span
+            aria-hidden
             data-slot="text-reveal-unit"
             className={cn('overflow-hidden pb-[0.12em]', by === 'line' ? 'flex' : 'inline-flex align-bottom')}
           >

--- a/registry/hirael/bases/base/components/time-picker.tsx
+++ b/registry/hirael/bases/base/components/time-picker.tsx
@@ -52,7 +52,9 @@ const clampStep = (value: number, step: number, max: number) => {
 export interface TimePickerProps {
   value?: TimeValue | null;
   defaultValue?: TimeValue;
-  onValueChange?: (v: TimeValue) => void;
+  /** Reports every change, including `null` when the value is cleared. */
+  onValueChange?: (v: TimeValue | null) => void;
+  /** Side-effect hook for the clear button. State still arrives via `onValueChange`. */
   onClear?: () => void;
   clearable?: boolean;
   format?: TimeFormat;
@@ -83,7 +85,7 @@ const TimePicker = ({
   children,
 }: TimePickerProps) => {
   const [openInternal, setOpenInternal] = React.useState(defaultOpen);
-  const open = openProp ?? openInternal;
+  const open = openProp !== undefined ? openProp : openInternal;
   const setOpen = React.useCallback(
     (next: boolean) => {
       if (openProp === undefined) setOpenInternal(next);
@@ -105,8 +107,9 @@ const TimePicker = ({
 
   const clearValue = React.useCallback(() => {
     if (valueProp === undefined) setInternal(null);
+    onValueChange?.(null);
     onClear?.();
-  }, [valueProp, onClear]);
+  }, [valueProp, onValueChange, onClear]);
 
   const ctx = React.useMemo<TimePickerContextValue>(
     () => ({
@@ -175,7 +178,9 @@ const TimePickerTrigger = ({
       }
     >
       <Clock className="size-3.5 shrink-0 text-muted-foreground" />
-      <span className="flex-1 truncate">{children ?? label ?? placeholder}</span>
+      <span data-slot="time-picker-trigger-label" className="flex-1 truncate">
+        {children ?? label ?? placeholder}
+      </span>
     </PopoverTrigger>
   );
 };
@@ -334,7 +339,7 @@ const TimePickerContent = ({ className, ...props }: React.ComponentProps<typeof 
 
   return (
     <PopoverContent align="start" data-slot="time-picker-content" className={cn('w-auto p-3', className)} {...props}>
-      <div className="flex items-stretch gap-2">
+      <div data-slot="time-picker-columns" className="flex items-stretch gap-2">
         <ScrollColumn values={hourValues} selected={displayHour} onSelect={setHour} ariaLabel="Hour" />
         <span aria-hidden className="flex items-center font-mono text-sm text-muted-foreground">
           :
@@ -367,7 +372,7 @@ const TimePickerContent = ({ className, ...props }: React.ComponentProps<typeof 
         </Tabs>
       )}
       {ctx.clearable && ctx.value && (
-        <div className="mt-3 flex justify-end">
+        <div data-slot="time-picker-content-footer" className="mt-3 flex justify-end">
           <Button
             type="button"
             variant="ghost"

--- a/registry/hirael/bases/base/components/toc.tsx
+++ b/registry/hirael/bases/base/components/toc.tsx
@@ -66,10 +66,11 @@ const prefersReducedMotion = () => {
 
 const TOP_OFFSET = 56;
 
-const useActiveHeading = (items: TocItem[]) => {
+const useActiveHeading = (items: TocItem[], enabled: boolean) => {
   const [activeId, setActiveId] = React.useState<string | null>(null);
 
   React.useEffect(() => {
+    if (!enabled) return;
     const headings = flattenTocItems(items);
 
     const update = () => {
@@ -106,7 +107,7 @@ const useActiveHeading = (items: TocItem[]) => {
       window.removeEventListener('scroll', onScroll);
       window.removeEventListener('resize', onScroll);
     };
-  }, [items]);
+  }, [items, enabled]);
 
   return activeId;
 };
@@ -141,8 +142,9 @@ const TableOfContents = ({
   'aria-label': ariaLabel,
   ...props
 }: TableOfContentsProps) => {
-  const trackedActiveId = useActiveHeading(controlledActiveId ? [] : (items ?? []));
+  const trackedActiveId = useActiveHeading(items ?? [], controlledActiveId === undefined);
   const activeId = controlledActiveId !== undefined ? controlledActiveId : trackedActiveId;
+  const contextValue = React.useMemo(() => ({ activeId }), [activeId]);
 
   const content =
     children ??
@@ -156,7 +158,7 @@ const TableOfContents = ({
   if (!content) return null;
 
   return (
-    <TocContext.Provider value={{ activeId }}>
+    <TocContext.Provider value={contextValue}>
       <nav
         data-slot="toc"
         aria-label={ariaLabel ?? 'On this page'}
@@ -256,7 +258,7 @@ const TableOfContentsLink = ({
       data-slot="toc-link"
       data-active={isActive ? '' : undefined}
       href={href}
-      aria-current={isActive ? 'true' : undefined}
+      aria-current={isActive ? 'location' : undefined}
       onClick={handleClick}
       className={cn(
         '-ms-px block border-s py-1 ps-4 text-sm transition-colors duration-150 ease-out',

--- a/registry/hirael/bases/base/components/tour.tsx
+++ b/registry/hirael/bases/base/components/tour.tsx
@@ -348,10 +348,11 @@ const TourOverlay = ({ steps, step, stop, next, back, scrollIntoView, padding, l
     const first = focusables[0];
     const last = focusables[focusables.length - 1];
     const active = document.activeElement;
-    if (e.shiftKey && (active === first || active === card)) {
+    const outside = active === null || !Array.from(focusables).includes(active as HTMLElement);
+    if (e.shiftKey && (active === first || outside)) {
       e.preventDefault();
       last.focus();
-    } else if (!e.shiftKey && active === last) {
+    } else if (!e.shiftKey && (active === last || outside)) {
       e.preventDefault();
       first.focus();
     }

--- a/registry/hirael/bases/base/components/tree-view.tsx
+++ b/registry/hirael/bases/base/components/tree-view.tsx
@@ -118,7 +118,10 @@ export interface TreeItemProps extends Omit<React.ComponentProps<'div'>, 'title'
   label: React.ReactNode;
   /** Override the leading icon. Pass `null` to hide it entirely. */
   icon?: React.ReactNode;
+  /** Controlled expanded state. Pair with `onExpandedChange`. */
+  expanded?: boolean;
   defaultExpanded?: boolean;
+  onExpandedChange?: (expanded: boolean) => void;
   disabled?: boolean;
 }
 
@@ -126,7 +129,9 @@ const TreeItem = ({
   value,
   label,
   icon,
+  expanded: expandedProp,
   defaultExpanded = false,
+  onExpandedChange,
   disabled = false,
   className,
   children,
@@ -136,7 +141,16 @@ const TreeItem = ({
   const depth = React.useContext(TreeDepthContext);
   const parentTriggerRef = React.useContext(TreeParentContext);
   const triggerRef = React.useRef<HTMLButtonElement>(null);
-  const [open, setOpen] = React.useState(defaultExpanded);
+  const [internalOpen, setInternalOpen] = React.useState(defaultExpanded);
+  const open = expandedProp ?? internalOpen;
+
+  const setOpen = React.useCallback(
+    (next: boolean) => {
+      if (expandedProp === undefined) setInternalOpen(next);
+      onExpandedChange?.(next);
+    },
+    [expandedProp, onExpandedChange],
+  );
 
   const hasChildren = React.Children.count(children) > 0;
   const isSelected = !hasChildren && selected === value;
@@ -146,6 +160,18 @@ const TreeItem = ({
     if (!el) return;
     return registerItem(value, el);
   }, [registerItem, value]);
+
+  // An unmounting item that holds focus (e.g. an ancestor collapsed) hands it
+  // to the parent trigger instead of dropping it to <body>. Kept apart from the
+  // registration effect, which re-runs on `value` changes while the item stays mounted.
+  React.useLayoutEffect(() => {
+    const el = triggerRef.current;
+    const parentTrigger = parentTriggerRef?.current ?? null;
+    return () => {
+      const holdsFocus = el?.closest('[data-slot="tree-item"]')?.contains(document.activeElement) ?? false;
+      if (holdsFocus) parentTrigger?.focus();
+    };
+  }, [parentTriggerRef]);
 
   const onTriggerKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
     const { key } = event;
@@ -238,7 +264,14 @@ const TreeItem = ({
     return (
       <Collapsible
         render={
-          <div data-slot="tree-item" role="treeitem" aria-selected={isSelected} aria-expanded={open} {...props} />
+          <div
+            data-slot="tree-item"
+            role="treeitem"
+            aria-selected={isSelected}
+            aria-expanded={open}
+            aria-level={depth + 1}
+            {...props}
+          />
         }
         open={open}
         onOpenChange={setOpen}
@@ -254,7 +287,7 @@ const TreeItem = ({
   }
 
   return (
-    <div data-slot="tree-item" role="treeitem" aria-selected={isSelected} {...props}>
+    <div data-slot="tree-item" role="treeitem" aria-selected={isSelected} aria-level={depth + 1} {...props}>
       <button {...triggerProps} data-state={isSelected ? 'selected' : undefined} onClick={() => setSelected(value)}>
         {labelRow}
       </button>

--- a/registry/hirael/bases/base/components/yaml-editor.tsx
+++ b/registry/hirael/bases/base/components/yaml-editor.tsx
@@ -80,7 +80,7 @@ const tokenizeLine = (line: string): Token[] => {
   return tokens;
 };
 
-const HighlightLine = ({ line }: { line: string }) => {
+const HighlightLine = React.memo(function HighlightLine({ line }: { line: string }) {
   const tokens = tokenizeLine(line);
   return (
     <span className="block min-h-[1.25rem]">
@@ -93,7 +93,7 @@ const HighlightLine = ({ line }: { line: string }) => {
           ))}
     </span>
   );
-};
+});
 
 interface YamlEditorProps extends Omit<React.ComponentProps<'div'>, 'onChange' | 'defaultValue'> {
   value?: string;
@@ -121,6 +121,9 @@ const YamlEditor = ({
 
   const preRef = React.useRef<HTMLPreElement>(null);
   const gutterRef = React.useRef<HTMLDivElement>(null);
+  const caretRafRef = React.useRef(0);
+
+  React.useEffect(() => () => cancelAnimationFrame(caretRafRef.current), []);
 
   const lines = text.split('\n');
 
@@ -148,7 +151,7 @@ const YamlEditor = ({
     const next = text.slice(0, start) + '  ' + text.slice(end);
     if (!isControlled) setInternal(next);
     onValueChange?.(next);
-    requestAnimationFrame(() => {
+    caretRafRef.current = requestAnimationFrame(() => {
       el.selectionStart = el.selectionEnd = start + 2;
     });
   };
@@ -190,6 +193,7 @@ const YamlEditor = ({
         </pre>
         <textarea
           data-slot="yaml-editor-input"
+          aria-label="YAML editor"
           spellCheck={false}
           autoComplete="off"
           autoCapitalize="off"

--- a/registry/hirael/bases/base/components/year-picker.tsx
+++ b/registry/hirael/bases/base/components/year-picker.tsx
@@ -121,8 +121,9 @@ const YearPicker = (props: YearPickerProps) => {
   const [singleInternal, setSingleInternal] = React.useState<number | undefined>(singleDefaultValue);
   const [rangeInternal, setRangeInternal] = React.useState<YearRange | undefined>(rangeDefaultValue);
 
-  const singleValue = mode === 'single' ? (singleValueProp ?? singleInternal) : undefined;
-  const rangeValue = mode === 'range' ? (rangeValueProp ?? rangeInternal) : undefined;
+  const singleValue =
+    mode === 'single' ? (singleValueProp !== undefined ? singleValueProp : singleInternal) : undefined;
+  const rangeValue = mode === 'range' ? (rangeValueProp !== undefined ? rangeValueProp : rangeInternal) : undefined;
 
   const anchorYear = (mode === 'single' ? singleValue : rangeValue?.from) ?? new Date().getFullYear();
   const [decadeStart, setDecadeStart] = React.useState<number>(viewStartFor(anchorYear));
@@ -317,10 +318,10 @@ const YearPickerContent = ({ className, ...props }: React.ComponentProps<typeof 
         next = year + (3 - ((year - ctx.decadeStart) % 4));
         break;
       case 'PageUp':
-        ctx.setDecadeStart(ctx.decadeStart - YEARS_PER_VIEW);
+        ctx.setDecadeStart(Math.max(ctx.minYear - 1, ctx.decadeStart - YEARS_PER_VIEW));
         return;
       case 'PageDown':
-        ctx.setDecadeStart(ctx.decadeStart + YEARS_PER_VIEW);
+        ctx.setDecadeStart(Math.min(ctx.maxYear + 1 - YEARS_PER_VIEW, ctx.decadeStart + YEARS_PER_VIEW));
         return;
       default:
         return;

--- a/registry/hirael/bases/base/examples/time-picker-demo.tsx
+++ b/registry/hirael/bases/base/examples/time-picker-demo.tsx
@@ -13,8 +13,8 @@ import {
 
 const TimePickerDemo = () => {
   const t = useT();
-  const [t24, setT24] = React.useState<TimeValue>({ hour: 14, minute: 30 });
-  const [t12, setT12] = React.useState<TimeValue>({
+  const [t24, setT24] = React.useState<TimeValue | null>({ hour: 14, minute: 30 });
+  const [t12, setT12] = React.useState<TimeValue | null>({
     hour: 9,
     minute: 15,
     second: 0,
@@ -29,7 +29,7 @@ const TimePickerDemo = () => {
           <TimePickerContent />
         </TimePicker>
         <p className="font-mono text-[10px] tracking-[0.08em] text-muted-foreground uppercase">
-          {`${t24.hour}:${t24.minute.toString().padStart(2, '0')}`}
+          {t24 ? `${t24.hour}:${t24.minute.toString().padStart(2, '0')}` : t({ en: 'Not set', ar: 'غير محدد' })}
         </p>
       </Field>
 
@@ -42,7 +42,9 @@ const TimePickerDemo = () => {
           <TimePickerContent />
         </TimePicker>
         <p className="font-mono text-[10px] tracking-[0.08em] text-muted-foreground uppercase">
-          {`${t12.hour}:${t12.minute.toString().padStart(2, '0')}:${(t12.second ?? 0).toString().padStart(2, '0')}`}
+          {t12
+            ? `${t12.hour}:${t12.minute.toString().padStart(2, '0')}:${(t12.second ?? 0).toString().padStart(2, '0')}`
+            : t({ en: 'Not set', ar: 'غير محدد' })}
         </p>
       </Field>
     </FieldGroup>

--- a/registry/hirael/bases/radix/components/avatar-upload.tsx
+++ b/registry/hirael/bases/radix/components/avatar-upload.tsx
@@ -5,6 +5,7 @@ import { Camera, X } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { Button } from '@/registry/hirael/bases/radix/ui/button';
+import { composeRefs } from '@/registry/hirael/bases/radix/components/compose-refs';
 import {
   Dialog,
   DialogContent,
@@ -438,11 +439,12 @@ const AvatarUploadTrigger = ({
 
 type AvatarUploadInputProps = Omit<React.ComponentProps<'input'>, 'type' | 'accept' | 'onChange' | 'multiple'>;
 
-const AvatarUploadInput = ({ className, ...props }: AvatarUploadInputProps) => {
+const AvatarUploadInput = ({ className, ref, ...props }: AvatarUploadInputProps) => {
   const ctx = useAvatarUpload();
+  const composedRef = React.useMemo(() => composeRefs(ctx.registerInput, ref), [ctx.registerInput, ref]);
   return (
     <input
-      ref={(el) => ctx.registerInput(el)}
+      ref={composedRef}
       id={`${ctx.id}-input`}
       type="file"
       accept={ctx.accept}
@@ -508,6 +510,8 @@ const AvatarUploadCropDialog = ({
   ...props
 }: AvatarUploadCropDialogProps) => {
   const ctx = useAvatarUpload();
+  // Destructured: `ctx.registerCropper` at a ref site makes the compiler read every ctx.* as a ref.
+  const { registerCropper } = ctx;
   return (
     <Dialog
       open={ctx.pending !== null}
@@ -522,7 +526,7 @@ const AvatarUploadCropDialog = ({
         </DialogHeader>
         {ctx.pending && (
           <ImageCropper
-            ref={(ref) => ctx.registerCropper(ref)}
+            ref={registerCropper}
             src={ctx.pending}
             alt={title}
             aspect={1}

--- a/registry/hirael/bases/radix/components/callout.tsx
+++ b/registry/hirael/bases/radix/components/callout.tsx
@@ -44,23 +44,32 @@ const Callout = ({ title, icon, className, variant = 'info', children, ...props 
     if (icon === false) return null;
     if (React.isValidElement(icon)) return icon;
     const IconComponent = (icon as React.ElementType | undefined) ?? variantIcons[variantKey];
-    return <IconComponent className="size-5 shrink-0" aria-hidden />;
+    return <IconComponent data-slot="callout-icon" className="size-5 shrink-0" aria-hidden />;
   };
 
   return (
     <div
       data-slot="callout"
       data-variant={variantKey}
+      role={variantKey === 'error' ? 'alert' : undefined}
       className={cn(calloutVariants({ variant }), className)}
       {...props}
     >
       {(title || icon !== false) && (
         <div className="flex items-start gap-2">
           {renderIcon()}
-          {title && <span className="font-semibold leading-5">{title}</span>}
+          {title && (
+            <span data-slot="callout-title" className="font-semibold leading-5">
+              {title}
+            </span>
+          )}
         </div>
       )}
-      {children && <div className="text-sm leading-relaxed [&_a]:underline [&_a]:underline-offset-2">{children}</div>}
+      {children && (
+        <div data-slot="callout-content" className="text-sm leading-relaxed [&_a]:underline [&_a]:underline-offset-2">
+          {children}
+        </div>
+      )}
     </div>
   );
 };

--- a/registry/hirael/bases/radix/components/color-picker.tsx
+++ b/registry/hirael/bases/radix/components/color-picker.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { Pipette } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
+import { composeRefs } from '@/registry/hirael/bases/radix/components/compose-refs';
 import { Button } from '@/registry/hirael/bases/radix/ui/button';
 import { Input } from '@/registry/hirael/bases/radix/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/registry/hirael/bases/radix/ui/popover';
@@ -315,6 +316,8 @@ const ColorPickerTrigger = ({
         disabled={ctx.disabled}
         data-slot="color-picker-trigger"
         data-state={ctx.open ? 'open' : 'closed'}
+        aria-haspopup="dialog"
+        aria-expanded={ctx.open}
         className={cn(
           'inline-flex h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-3 text-start text-sm font-mono tabular-nums uppercase outline-none transition-colors',
           'hover:border-ring/60 focus-visible:border-ring data-[state=open]:border-ring',
@@ -338,9 +341,10 @@ const ColorPickerTrigger = ({
   );
 };
 
-const ColorPickerArea = ({ className, ...props }: React.ComponentProps<'div'>) => {
+const ColorPickerArea = ({ className, ref, ...props }: React.ComponentProps<'div'>) => {
   const ctx = useColorPicker();
   const areaRef = React.useRef<HTMLDivElement>(null);
+  const composedRef = React.useMemo(() => composeRefs(areaRef, ref), [ref]);
   const draggingRef = React.useRef(false);
 
   const updateFromPointer = (clientX: number, clientY: number) => {
@@ -384,23 +388,27 @@ const ColorPickerArea = ({ className, ...props }: React.ComponentProps<'div'>) =
 
   return (
     <div
-      {...props}
-      ref={areaRef}
+      ref={composedRef}
       data-slot="color-picker-area"
       role="slider"
-      aria-label="Saturation and brightness"
       aria-valuetext={`saturation ${Math.round(ctx.hsv.s)}%, brightness ${Math.round(ctx.hsv.v)}%`}
       aria-valuenow={Math.round(ctx.hsv.s)}
       aria-valuemin={0}
       aria-valuemax={100}
       tabIndex={0}
+      {...props}
+      aria-label={props['aria-label'] ?? 'Saturation and brightness'}
       onPointerDown={(e) => {
+        props.onPointerDown?.(e);
+        if (e.defaultPrevented) return;
         e.preventDefault();
         (e.target as HTMLElement).setPointerCapture(e.pointerId);
         draggingRef.current = true;
         updateFromPointer(e.clientX, e.clientY);
       }}
       onKeyDown={(e) => {
+        props.onKeyDown?.(e);
+        if (e.defaultPrevented) return;
         const step = e.shiftKey ? 10 : 2;
         let { s, v } = ctx.hsv;
         switch (e.key) {
@@ -446,9 +454,10 @@ const ColorPickerArea = ({ className, ...props }: React.ComponentProps<'div'>) =
   );
 };
 
-const ColorPickerHueSlider = ({ className, ...props }: React.ComponentProps<'div'>) => {
+const ColorPickerHueSlider = ({ className, ref, ...props }: React.ComponentProps<'div'>) => {
   const ctx = useColorPicker();
   const trackRef = React.useRef<HTMLDivElement>(null);
+  const composedRef = React.useMemo(() => composeRefs(trackRef, ref), [ref]);
   const draggingRef = React.useRef(false);
 
   const updateFromPointer = (clientX: number) => {
@@ -489,22 +498,26 @@ const ColorPickerHueSlider = ({ className, ...props }: React.ComponentProps<'div
 
   return (
     <div
-      {...props}
-      ref={trackRef}
+      ref={composedRef}
       data-slot="color-picker-hue-slider"
       role="slider"
-      aria-label="Hue"
       aria-valuemin={0}
       aria-valuemax={360}
       aria-valuenow={Math.round(ctx.hsv.h)}
       tabIndex={0}
+      {...props}
+      aria-label={props['aria-label'] ?? 'Hue'}
       onPointerDown={(e) => {
+        props.onPointerDown?.(e);
+        if (e.defaultPrevented) return;
         e.preventDefault();
         (e.target as HTMLElement).setPointerCapture(e.pointerId);
         draggingRef.current = true;
         updateFromPointer(e.clientX);
       }}
       onKeyDown={(e) => {
+        props.onKeyDown?.(e);
+        if (e.defaultPrevented) return;
         const step = e.shiftKey ? 24 : 6;
         let h = ctx.hsv.h;
         if (e.key === 'ArrowLeft') h -= step;

--- a/registry/hirael/bases/radix/components/combobox.tsx
+++ b/registry/hirael/bases/radix/components/combobox.tsx
@@ -20,7 +20,7 @@ const Combobox = <Value, Multiple extends boolean | undefined = false>(
 };
 
 const ComboboxValue = (props: ComboboxPrimitive.Value.Props) => {
-  return <ComboboxPrimitive.Value {...props} />;
+  return <ComboboxPrimitive.Value data-slot="combobox-value" {...props} />;
 };
 
 /**
@@ -34,10 +34,11 @@ const useComboboxAnchor = () => {
 
 const ComboboxInput = ({
   className,
+  inputClassName,
   children,
   showClear = false,
   ...props
-}: WithClassName<ComboboxPrimitive.Input.Props> & { showClear?: boolean }) => {
+}: WithClassName<ComboboxPrimitive.Input.Props> & { showClear?: boolean; inputClassName?: string }) => {
   return (
     <InputGroup
       className={cn(
@@ -48,12 +49,16 @@ const ComboboxInput = ({
       {children}
       <ComboboxPrimitive.Input
         data-slot="combobox-input"
-        className="flex-1 rounded-none border-0 bg-transparent px-2 text-sm shadow-none outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+        className={cn(
+          'flex-1 rounded-none border-0 bg-transparent px-2 text-sm shadow-none outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
+          inputClassName,
+        )}
         {...props}
       />
       <InputGroupAddon align="inline-end">
         {showClear && <ComboboxClear />}
         <ComboboxPrimitive.Trigger
+          data-slot="combobox-trigger"
           aria-label="Toggle"
           className="flex size-6 shrink-0 items-center justify-center rounded-[calc(var(--radius)-5px)] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
         >
@@ -112,6 +117,7 @@ const ComboboxChip = ({ className, children, ...props }: WithClassName<ComboboxP
     >
       {children}
       <ComboboxPrimitive.ChipRemove
+        data-slot="combobox-chip-remove"
         aria-label="Remove"
         className="flex size-3.5 items-center justify-center rounded-[3px] text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
       >
@@ -219,7 +225,7 @@ const ComboboxItem = ({ className, children, ...props }: WithClassName<ComboboxP
       {...props}
     >
       <span className="min-w-0 flex-1 truncate">{children}</span>
-      <ComboboxPrimitive.ItemIndicator className="flex shrink-0 items-center">
+      <ComboboxPrimitive.ItemIndicator data-slot="combobox-item-indicator" className="flex shrink-0 items-center">
         <CheckIcon className="size-4" strokeWidth={3} />
       </ComboboxPrimitive.ItemIndicator>
     </ComboboxPrimitive.Item>

--- a/registry/hirael/bases/radix/components/compose-refs.ts
+++ b/registry/hirael/bases/radix/components/compose-refs.ts
@@ -1,0 +1,24 @@
+import type * as React from 'react';
+
+const setRef = <T>(ref: React.Ref<T> | undefined, node: T | null) => {
+  if (typeof ref === 'function') return ref(node);
+  if (ref) ref.current = node;
+};
+
+/**
+ * Fans one node out to several refs: a part's own, plus whatever the consumer
+ * passed. Cleanup functions returned by callback refs (React 19) are kept, so
+ * a consumer ref that observes the node is torn down instead of called with null.
+ */
+export const composeRefs =
+  <T>(...refs: (React.Ref<T> | undefined)[]): React.RefCallback<T> =>
+  (node) => {
+    const cleanups = refs.map((ref) => setRef(ref, node));
+    if (!cleanups.some((cleanup) => typeof cleanup === 'function')) return;
+    return () => {
+      cleanups.forEach((cleanup, i) => {
+        if (typeof cleanup === 'function') cleanup();
+        else setRef(refs[i], null);
+      });
+    };
+  };

--- a/registry/hirael/bases/radix/components/confirm.tsx
+++ b/registry/hirael/bases/radix/components/confirm.tsx
@@ -85,6 +85,7 @@ const ConfirmProvider = ({ children, defaultOptions }: ConfirmProviderProps) => 
   const activeRef = React.useRef<ConfirmRequest | null>(null);
   const queueRef = React.useRef<ConfirmRequest[]>([]);
   const closingRef = React.useRef(false);
+  const closeTimerRef = React.useRef<number | undefined>(undefined);
 
   const confirm = React.useCallback<ConfirmFn>((options = {}) => {
     return new Promise<boolean>((resolve) => {
@@ -106,7 +107,7 @@ const ConfirmProvider = ({ children, defaultOptions }: ConfirmProviderProps) => 
     current.resolve(value);
     setPending(false);
     setOpen(false);
-    window.setTimeout(() => {
+    closeTimerRef.current = window.setTimeout(() => {
       closingRef.current = false;
       const next = queueRef.current.shift() ?? null;
       activeRef.current = next;
@@ -114,6 +115,16 @@ const ConfirmProvider = ({ children, defaultOptions }: ConfirmProviderProps) => 
       setOpen(next !== null);
     }, CLOSE_DURATION);
   }, []);
+
+  React.useEffect(
+    () => () => {
+      window.clearTimeout(closeTimerRef.current);
+      activeRef.current?.resolve(false);
+      for (const queued of queueRef.current) queued.resolve(false);
+      queueRef.current = [];
+    },
+    [],
+  );
 
   const handleConfirm = React.useCallback(() => {
     if (closingRef.current) return;
@@ -127,10 +138,8 @@ const ConfirmProvider = ({ children, defaultOptions }: ConfirmProviderProps) => 
       .then(onConfirm)
       .then(
         () => settle(true),
-        (error) => {
-          setPending(false);
-          throw error;
-        },
+        // Back to idle so the user can retry; per onConfirm's contract the error is theirs to surface.
+        () => setPending(false),
       );
   }, [settle]);
 

--- a/registry/hirael/bases/radix/components/copy-button.tsx
+++ b/registry/hirael/bases/radix/components/copy-button.tsx
@@ -38,6 +38,7 @@ const CopyButton = ({
   size = 'md',
   timeout = 1500,
   onCopy,
+  onClick,
   className,
   children,
   ...props
@@ -47,17 +48,22 @@ const CopyButton = ({
 
   React.useEffect(() => () => clearTimeout(timer.current), []);
 
-  const handleCopy = async () => {
-    try {
-      await writeClipboard(value);
-      setCopied(true);
-      onCopy?.(value);
-      clearTimeout(timer.current);
-      timer.current = setTimeout(() => setCopied(false), timeout);
-    } catch {
-      setCopied(false);
-    }
-  };
+  const handleCopy = React.useCallback(
+    async (event: React.MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      if (event.defaultPrevented) return;
+      try {
+        await writeClipboard(value);
+        setCopied(true);
+        onCopy?.(value);
+        clearTimeout(timer.current);
+        timer.current = setTimeout(() => setCopied(false), timeout);
+      } catch {
+        setCopied(false);
+      }
+    },
+    [value, onCopy, timeout, onClick],
+  );
 
   const hasLabel = children != null;
 

--- a/registry/hirael/bases/radix/components/country-select.tsx
+++ b/registry/hirael/bases/radix/components/country-select.tsx
@@ -117,6 +117,7 @@ interface CountrySelectContextValue {
   open: boolean;
   setOpen: (next: boolean) => void;
   find: (iso2: string) => Country | undefined;
+  listboxId: string;
 }
 
 const CountrySelectContext = React.createContext<CountrySelectContextValue | null>(null);
@@ -143,6 +144,7 @@ interface CountrySelectBaseProps {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
+  name?: string;
   children?: React.ReactNode;
 }
 
@@ -179,6 +181,7 @@ const CountrySelect = (props: CountrySelectProps) => {
     open: openProp,
     defaultOpen = false,
     onOpenChange,
+    name,
     children,
     multiple = false,
     value: valueProp,
@@ -187,6 +190,7 @@ const CountrySelect = (props: CountrySelectProps) => {
 
   const reactId = React.useId();
   const selectId = id ?? reactId;
+  const listboxId = React.useId();
 
   const [internal, setInternal] = React.useState<string[]>(() => toList(defaultValue));
   const selected = React.useMemo(() => (valueProp === undefined ? internal : toList(valueProp)), [valueProp, internal]);
@@ -248,8 +252,22 @@ const CountrySelect = (props: CountrySelectProps) => {
       open,
       setOpen,
       find: (iso2) => countries.find((c) => c.iso2 === iso2.toUpperCase()),
+      listboxId,
     }),
-    [selectId, countries, priorityList, rest, selected, select, multiple, showDialCode, disabled, open, setOpen],
+    [
+      selectId,
+      countries,
+      priorityList,
+      rest,
+      selected,
+      select,
+      multiple,
+      showDialCode,
+      disabled,
+      open,
+      setOpen,
+      listboxId,
+    ],
   );
 
   return (
@@ -257,6 +275,7 @@ const CountrySelect = (props: CountrySelectProps) => {
       <Popover open={open} onOpenChange={setOpen}>
         {children}
       </Popover>
+      {name && <input type="hidden" name={name} value={selected.join(',')} />}
     </CountrySelectContext.Provider>
   );
 };
@@ -297,6 +316,7 @@ const CountrySelectTrigger = ({ className, children, variant = 'outline', ...pro
         variant={variant}
         role="combobox"
         id={ctx.id}
+        aria-controls={ctx.listboxId}
         aria-expanded={ctx.open}
         aria-haspopup="listbox"
         disabled={ctx.disabled}
@@ -428,7 +448,7 @@ const CountrySelectList = ({
 }: CountrySelectListProps) => {
   const ctx = useCountrySelect();
   return (
-    <CommandList data-slot="country-select-list" className={cn('max-h-64', className)} {...props}>
+    <CommandList id={ctx.listboxId} data-slot="country-select-list" className={cn('max-h-64', className)} {...props}>
       <CommandEmpty>{emptyLabel}</CommandEmpty>
       {ctx.priority.length > 0 && (
         <>

--- a/registry/hirael/bases/radix/components/cron-editor.tsx
+++ b/registry/hirael/bases/radix/components/cron-editor.tsx
@@ -680,7 +680,10 @@ const CronEditorField = ({
 /*  Expression                                                                */
 /* -------------------------------------------------------------------------- */
 
-interface CronEditorExpressionProps extends Omit<React.ComponentProps<'div'>, 'children'> {
+interface CronEditorExpressionProps extends Omit<
+  React.ComponentProps<'input'>,
+  'children' | 'value' | 'defaultValue' | 'onChange' | 'id'
+> {
   label?: string;
   placeholder?: string;
   showError?: boolean;
@@ -699,12 +702,7 @@ const CronEditorExpression = ({
   const invalid = !ctx.parsed.valid;
 
   return (
-    <Field
-      data-slot="cron-editor-expression"
-      data-invalid={invalid || undefined}
-      className={cn('gap-1.5', className)}
-      {...props}
-    >
+    <Field data-slot="cron-editor-expression" data-invalid={invalid || undefined} className={cn('gap-1.5', className)}>
       <FieldLabel
         htmlFor={inputId}
         className="font-mono text-[10px] font-normal uppercase tracking-[0.12em] text-muted-foreground"
@@ -725,6 +723,7 @@ const CronEditorExpression = ({
         data-slot="cron-editor-expression-input"
         className="font-mono tracking-[0.08em]"
         onChange={(e) => ctx.setValue(e.target.value)}
+        {...props}
       />
       {showError && invalid && (
         <FieldError id={errorId} data-slot="cron-editor-expression-error" className="text-[11px]">

--- a/registry/hirael/bases/radix/components/currency-input.tsx
+++ b/registry/hirael/bases/radix/components/currency-input.tsx
@@ -250,6 +250,7 @@ const CurrencyInputField = ({
       id={ctx.id}
       type="text"
       inputMode={inputMode}
+      dir="ltr"
       value={ctx.view}
       disabled={ctx.disabled}
       placeholder={placeholder}

--- a/registry/hirael/bases/radix/components/cursor-glow.tsx
+++ b/registry/hirael/bases/radix/components/cursor-glow.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { motion, useMotionTemplate, useMotionValue } from 'motion/react';
+import { motion, useMotionTemplate, useMotionValue, useReducedMotion } from 'motion/react';
 
 import { cn } from '@/lib/utils';
 
@@ -19,11 +19,13 @@ const CursorGlow = ({
   color = 'color-mix(in oklch, var(--foreground) 12%, transparent)',
   ...props
 }: CursorGlowProps) => {
+  const reduced = useReducedMotion();
   const x = useMotionValue(0);
   const y = useMotionValue(0);
   const background = useMotionTemplate`radial-gradient(${size}px circle at ${x}px ${y}px, ${color}, transparent 70%)`;
 
   const onPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (reduced) return;
     const rect = event.currentTarget.getBoundingClientRect();
     x.set(event.clientX - rect.left);
     y.set(event.clientY - rect.top);

--- a/registry/hirael/bases/radix/components/data-table/data-table-column-header.tsx
+++ b/registry/hirael/bases/radix/components/data-table/data-table-column-header.tsx
@@ -27,7 +27,11 @@ export const DataTableColumnHeader = <TData extends RowData, TValue extends Cell
   ...props
 }: DataTableColumnHeaderProps<TData, TValue>) => {
   if (!column.getCanSort() && !column.getCanHide()) {
-    return <div className={cn(className)}>{label}</div>;
+    return (
+      <div data-slot="data-table-column-header" className={cn(className)} {...(props as React.ComponentProps<'div'>)}>
+        {label}
+      </div>
+    );
   }
 
   return (

--- a/registry/hirael/bases/radix/components/data-table/data-table-toolbar.tsx
+++ b/registry/hirael/bases/radix/components/data-table/data-table-toolbar.tsx
@@ -72,6 +72,7 @@ const DataTableToolbarFilter = <TData extends RowData>({ column }: DataTableTool
       case 'text':
         return (
           <Input
+            aria-label={columnMeta.label ?? column.id}
             placeholder={columnMeta.placeholder ?? columnMeta.label}
             value={(column.getFilterValue() as string) ?? ''}
             onChange={(event) => column.setFilterValue(event.target.value)}
@@ -85,6 +86,7 @@ const DataTableToolbarFilter = <TData extends RowData>({ column }: DataTableTool
             <Input
               type="number"
               inputMode="numeric"
+              aria-label={columnMeta.label ?? column.id}
               placeholder={columnMeta.placeholder ?? columnMeta.label}
               value={(column.getFilterValue() as string) ?? ''}
               onChange={(event) => column.setFilterValue(event.target.value)}

--- a/registry/hirael/bases/radix/components/data-table/use-data-table.ts
+++ b/registry/hirael/bases/radix/components/data-table/use-data-table.ts
@@ -161,6 +161,10 @@ interface UseDataTableProps<TData extends RowData> extends Omit<
   initialState?: Omit<Partial<TableState<DataTableFeatures>>, 'sorting'> & {
     sorting?: ExtendedColumnSort<TData>[];
   };
+  /** Controlled row selection. Pair with `onRowSelectionChange`. */
+  rowSelection?: RowSelectionState;
+  /** Controlled column visibility. Pair with `onColumnVisibilityChange`. */
+  columnVisibility?: ColumnVisibilityState;
   prefix?: string;
   history?: 'push' | 'replace';
   debounceMs?: number;
@@ -177,6 +181,10 @@ export const useDataTable = <TData extends RowData>(props: UseDataTableProps<TDa
     pageCount,
     manual = pageCount != null,
     initialState,
+    rowSelection: rowSelectionProp,
+    columnVisibility: columnVisibilityProp,
+    onRowSelectionChange: onRowSelectionChangeProp,
+    onColumnVisibilityChange: onColumnVisibilityChangeProp,
     prefix = '',
     history = 'replace',
     debounceMs = DEBOUNCE_MS,
@@ -205,9 +213,30 @@ export const useDataTable = <TData extends RowData>(props: UseDataTableProps<TDa
     [history, scroll, shallow, throttleMs, debounceMs, clearOnDefault, startTransition],
   );
 
-  const [rowSelection, setRowSelection] = React.useState<RowSelectionState>(initialState?.rowSelection ?? {});
-  const [columnVisibility, setColumnVisibility] = React.useState<ColumnVisibilityState>(
+  const [internalRowSelection, setInternalRowSelection] = React.useState<RowSelectionState>(
+    initialState?.rowSelection ?? {},
+  );
+  const rowSelection = rowSelectionProp ?? internalRowSelection;
+
+  const [internalColumnVisibility, setInternalColumnVisibility] = React.useState<ColumnVisibilityState>(
     initialState?.columnVisibility ?? {},
+  );
+  const columnVisibility = columnVisibilityProp ?? internalColumnVisibility;
+
+  const onRowSelectionChange = React.useCallback(
+    (updaterOrValue: Updater<RowSelectionState>) => {
+      if (rowSelectionProp === undefined) setInternalRowSelection(updaterOrValue);
+      onRowSelectionChangeProp?.(updaterOrValue);
+    },
+    [rowSelectionProp, onRowSelectionChangeProp],
+  );
+
+  const onColumnVisibilityChange = React.useCallback(
+    (updaterOrValue: Updater<ColumnVisibilityState>) => {
+      if (columnVisibilityProp === undefined) setInternalColumnVisibility(updaterOrValue);
+      onColumnVisibilityChangeProp?.(updaterOrValue);
+    },
+    [columnVisibilityProp, onColumnVisibilityChangeProp],
   );
 
   const [page, setPage] = useQueryState(pageKey, parseAsInteger.withOptions(queryStateOptions).withDefault(1));
@@ -304,7 +333,9 @@ export const useDataTable = <TData extends RowData>(props: UseDataTableProps<TDa
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(queryColumnFilters);
 
   const columnFiltersRef = React.useRef(columnFilters);
-  columnFiltersRef.current = columnFilters;
+  React.useEffect(() => {
+    columnFiltersRef.current = columnFilters;
+  }, [columnFilters]);
 
   React.useEffect(() => {
     setColumnFilters((prev) => (areFiltersEqual(prev, queryColumnFilters) ? prev : queryColumnFilters));
@@ -353,11 +384,11 @@ export const useDataTable = <TData extends RowData>(props: UseDataTableProps<TDa
       enableColumnFilter: false,
     },
     enableRowSelection: true,
-    onRowSelectionChange: setRowSelection,
+    onRowSelectionChange,
     onPaginationChange,
     onSortingChange,
     onColumnFiltersChange,
-    onColumnVisibilityChange: setColumnVisibility,
+    onColumnVisibilityChange,
     manualPagination: manual,
     manualSorting: manual,
     manualFiltering: manual,

--- a/registry/hirael/bases/radix/components/date-picker.tsx
+++ b/registry/hirael/bases/radix/components/date-picker.tsx
@@ -6,6 +6,7 @@ import { CalendarIcon, ChevronLeft, ChevronRight, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/registry/hirael/bases/radix/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/registry/hirael/bases/radix/ui/popover';
+import { composeRefs } from '@/registry/hirael/bases/radix/components/compose-refs';
 import {
   clampDate,
   gridKeyToDate,
@@ -42,6 +43,7 @@ const DateCalendar = ({
   locale,
   weekStartsOn = 1,
   className,
+  ref: refProp,
   ...props
 }: DateCalendarProps) => {
   const [internal, setInternal] = React.useState<Date | null>(defaultValue);
@@ -97,6 +99,7 @@ const DateCalendar = ({
   const stepMonth = (n: number) => setViewMonth(new Date(viewMonth.getFullYear(), viewMonth.getMonth() + n, 1));
 
   const rootRef = React.useRef<HTMLDivElement>(null);
+  const composedRef = React.useMemo(() => composeRefs(rootRef, refProp), [refProp]);
   const focusDay = (d: Date) => {
     const doFocus = () => {
       rootRef.current?.querySelector<HTMLButtonElement>(`[data-day="${d.getTime()}"]`)?.focus();
@@ -121,12 +124,9 @@ const DateCalendar = ({
     focusDay(clampDate(next, min, max));
   };
 
-  const monthFmt = new Intl.DateTimeFormat(locale, {
-    month: 'long',
-    year: 'numeric',
-  });
-  const weekdayFmt = new Intl.DateTimeFormat(locale, { weekday: 'short' });
-  const dayLabelFmt = new Intl.DateTimeFormat(locale, { dateStyle: 'full' });
+  const monthFmt = React.useMemo(() => new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric' }), [locale]);
+  const weekdayFmt = React.useMemo(() => new Intl.DateTimeFormat(locale, { weekday: 'short' }), [locale]);
+  const dayLabelFmt = React.useMemo(() => new Intl.DateTimeFormat(locale, { dateStyle: 'full' }), [locale]);
   const weekdays = Array.from({ length: 7 }, (_, i) =>
     weekdayFmt.format(new Date(2021, 7, 1 + ((weekStartsOn + i) % 7))),
   );
@@ -140,7 +140,12 @@ const DateCalendar = ({
   const tabbable = selected && isMonthVisible(selected) ? selected : isMonthVisible(today) ? today : viewMonth;
 
   return (
-    <div ref={rootRef} data-slot="date-picker-calendar" className={cn('w-60', className)} {...props}>
+    <div
+      ref={composedRef}
+      data-slot="date-picker-calendar"
+      className={cn('w-60', className)}
+      {...props}
+    >
       <div data-slot="date-picker-calendar-header" className="mb-2 flex items-center justify-between">
         <Button
           type="button"

--- a/registry/hirael/bases/radix/components/date-range-picker.tsx
+++ b/registry/hirael/bases/radix/components/date-range-picker.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/utils';
 import { Button } from '@/registry/hirael/bases/radix/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/registry/hirael/bases/radix/ui/popover';
 import { Separator } from '@/registry/hirael/bases/radix/ui/separator';
+import { composeRefs } from '@/registry/hirael/bases/radix/components/compose-refs';
 import {
   addDays,
   clampDate,
@@ -77,7 +78,9 @@ const DEFAULT_PRESETS: DateRangePreset[] = [
   },
 ];
 
-export interface DateRangeCalendarProps {
+const EMPTY_RANGE: DateRange = {};
+
+export interface DateRangeCalendarProps extends Omit<React.ComponentProps<'div'>, 'defaultValue'> {
   value?: DateRange;
   defaultValue?: DateRange;
   onValueChange?: (range: DateRange | undefined) => void;
@@ -87,7 +90,6 @@ export interface DateRangeCalendarProps {
   locale?: string;
   weekStartsOn?: 0 | 1;
   numberOfMonths?: 1 | 2;
-  className?: string;
 }
 
 const DateRangeCalendar = ({
@@ -101,6 +103,8 @@ const DateRangeCalendar = ({
   weekStartsOn = 1,
   numberOfMonths = 2,
   className,
+  ref: refProp,
+  ...props
 }: DateRangeCalendarProps) => {
   const [internal, setInternal] = React.useState<DateRange | undefined>(defaultValue);
   const range = valueProp !== undefined ? valueProp : internal;
@@ -171,6 +175,7 @@ const DateRangeCalendar = ({
   const stepMonth = (n: number) => setViewMonth(new Date(viewMonth.getFullYear(), viewMonth.getMonth() + n, 1));
 
   const rootRef = React.useRef<HTMLDivElement>(null);
+  const composedRef = React.useMemo(() => composeRefs(rootRef, refProp), [refProp]);
   const focusDay = (d: Date) => {
     const doFocus = () => {
       rootRef.current?.querySelector<HTMLButtonElement>(`[data-day="${d.getTime()}"]`)?.focus();
@@ -209,7 +214,12 @@ const DateRangeCalendar = ({
     range?.from && isMonthVisible(range.from) ? startOfDay(range.from) : isMonthVisible(today) ? today : viewMonth;
 
   return (
-    <div ref={rootRef} data-slot="date-range-calendar" className={cn('flex gap-4', className)}>
+    <div
+      ref={composedRef}
+      data-slot="date-range-calendar"
+      className={cn('flex gap-4', className)}
+      {...props}
+    >
       {months.map((month, mi) => {
         const last = mi === numberOfMonths - 1;
         const cells = monthCells(month, weekStartsOn);
@@ -536,7 +546,7 @@ const DateRangePickerContent = ({
         )}
         <div data-slot="date-range-picker-content-calendar" className="flex flex-col gap-2">
           <DateRangeCalendar
-            value={ctx.range ?? {}}
+            value={ctx.range ?? EMPTY_RANGE}
             onValueChange={ctx.setRange}
             min={ctx.min}
             max={ctx.max}

--- a/registry/hirael/bases/radix/components/diff-viewer.tsx
+++ b/registry/hirael/bases/radix/components/diff-viewer.tsx
@@ -420,6 +420,7 @@ export interface DiffViewerContentProps extends Omit<React.ComponentProps<'div'>
 const DiffViewerContent = ({ showLineNumbers = true, gapLabel, className, ...props }: DiffViewerContentProps) => {
   const { items, mode, expandGap } = useDiffViewer();
   const label = gapLabel ?? ((count: number) => `Expand ${count} lines`);
+  const rows = React.useMemo(() => (mode === 'split' ? toSplitRows(items) : []), [items, mode]);
 
   const gap = (item: GapItem) => (
     <button
@@ -438,7 +439,6 @@ const DiffViewerContent = ({ showLineNumbers = true, gapLabel, className, ...pro
   );
 
   if (mode === 'split') {
-    const rows = toSplitRows(items);
     return (
       <div
         dir="ltr"

--- a/registry/hirael/bases/radix/components/dock.tsx
+++ b/registry/hirael/bases/radix/components/dock.tsx
@@ -13,6 +13,7 @@ import {
 } from 'motion/react';
 
 import { cn } from '@/lib/utils';
+import { composeRefs } from '@/registry/hirael/bases/radix/components/compose-refs';
 
 interface DockContextValue {
   mouseX: MotionValue<number>;
@@ -84,8 +85,9 @@ const Dock = ({ baseSize = 44, magnification = 72, distance = 140, className, ch
 
 type DockItemProps = HTMLMotionProps<'button'>;
 
-const DockItem = ({ className, children, ...props }: DockItemProps) => {
+const DockItem = ({ className, children, ref: consumerRef, ...props }: DockItemProps) => {
   const ref = React.useRef<HTMLButtonElement>(null);
+  const composedRef = React.useMemo(() => composeRefs(ref, consumerRef), [consumerRef]);
   const { mouseX, baseSize, magnification, distance } = useDock();
   const [hovered, setHovered] = React.useState(false);
   const reducedMotion = useReducedMotion();
@@ -102,11 +104,13 @@ const DockItem = ({ className, children, ...props }: DockItemProps) => {
     damping: 14,
   });
 
+  const itemCtx = React.useMemo(() => ({ hovered }), [hovered]);
+
   return (
-    <DockItemContext.Provider value={{ hovered }}>
+    <DockItemContext.Provider value={itemCtx}>
       <motion.button
         {...props}
-        ref={ref}
+        ref={composedRef}
         type="button"
         data-slot="dock-item"
         style={reducedMotion ? { width: baseSize, height: baseSize } : { width, height: width }}

--- a/registry/hirael/bases/radix/components/emoji-picker.tsx
+++ b/registry/hirael/bases/radix/components/emoji-picker.tsx
@@ -17,6 +17,7 @@ import {
 
 import { cn } from '@/lib/utils';
 import { Input } from '@/registry/hirael/bases/radix/ui/input';
+import { composeRefs } from '@/registry/hirael/bases/radix/components/compose-refs';
 
 /* -------------------------------------------------------------------------- */
 /*  Data                                                                      */
@@ -676,9 +677,7 @@ interface EmojiPickerContextValue {
   hasRecent: boolean;
   skinTone: EmojiSkinTone;
   setSkinTone: (next: EmojiSkinTone) => void;
-  hovered: EmojiItem | null;
   setHovered: (next: EmojiItem | null) => void;
-  activeIndex: number;
   setActiveIndex: (next: number) => void;
   columns: number;
   select: (item: EmojiItem) => void;
@@ -696,6 +695,13 @@ const useEmojiPicker = () => {
   }
   return ctx;
 };
+
+const EmojiPickerHoverContext = React.createContext<EmojiItem | null>(null);
+
+// Its own context, not the main one: activeIndex changes on every arrow key. The
+// list reads it and hands each item a boolean `active`, so the memoized items
+// re-render only when their own flag flips.
+const EmojiPickerActiveIndexContext = React.createContext(-1);
 
 const readRecent = (key: string): string[] => {
   try {
@@ -830,9 +836,7 @@ const EmojiPicker = ({
       hasRecent: Boolean(recentKey),
       skinTone,
       setSkinTone,
-      hovered,
       setHovered,
-      activeIndex,
       setActiveIndex,
       columns,
       select,
@@ -852,8 +856,6 @@ const EmojiPicker = ({
       recentKey,
       skinTone,
       setSkinTone,
-      hovered,
-      activeIndex,
       columns,
       select,
       display,
@@ -864,16 +866,20 @@ const EmojiPicker = ({
 
   return (
     <EmojiPickerContext.Provider value={ctx}>
-      <div
-        data-slot="emoji-picker"
-        className={cn(
-          'flex w-80 max-w-full flex-col gap-2 rounded-md border border-border bg-popover p-2 text-popover-foreground',
-          className,
-        )}
-        {...props}
-      >
-        {children}
-      </div>
+      <EmojiPickerHoverContext.Provider value={hovered}>
+        <EmojiPickerActiveIndexContext.Provider value={activeIndex}>
+          <div
+            data-slot="emoji-picker"
+            className={cn(
+              'flex w-80 max-w-full flex-col gap-2 rounded-md border border-border bg-popover p-2 text-popover-foreground',
+              className,
+            )}
+            {...props}
+          >
+            {children}
+          </div>
+        </EmojiPickerActiveIndexContext.Provider>
+      </EmojiPickerHoverContext.Provider>
     </EmojiPickerContext.Provider>
   );
 };
@@ -891,6 +897,7 @@ const EmojiPickerSearch = ({
   ...props
 }: EmojiPickerSearchProps) => {
   const ctx = useEmojiPicker();
+  const activeIndex = React.useContext(EmojiPickerActiveIndexContext);
   return (
     <div data-slot="emoji-picker-search" className="relative">
       <Search
@@ -910,7 +917,7 @@ const EmojiPickerSearch = ({
         onKeyDown={(e) => {
           if (e.key === 'ArrowDown') {
             e.preventDefault();
-            ctx.focusItem(ctx.activeIndex);
+            ctx.focusItem(activeIndex);
           } else if (e.key === 'Enter' && ctx.visible[0]) {
             e.preventDefault();
             ctx.select(ctx.visible[0]);
@@ -941,7 +948,7 @@ const EmojiPickerCategories = ({ labels, className, ...props }: EmojiPickerCateg
 
   return (
     <div
-      role="tablist"
+      role="group"
       aria-label="Emoji categories"
       data-slot="emoji-picker-categories"
       className={cn('flex items-center gap-0.5', className)}
@@ -965,8 +972,7 @@ const EmojiPickerCategories = ({ labels, className, ...props }: EmojiPickerCateg
           <button
             key={tab.id}
             type="button"
-            role="tab"
-            aria-selected={active}
+            aria-pressed={active}
             aria-label={label}
             title={label}
             tabIndex={active ? 0 : -1}
@@ -997,9 +1003,10 @@ interface EmojiPickerListProps extends Omit<React.ComponentProps<'div'>, 'childr
   children?: React.ReactNode;
 }
 
-const EmojiPickerList = ({ className, children, ...props }: EmojiPickerListProps) => {
+const EmojiPickerList = ({ className, children, ref, ...props }: EmojiPickerListProps) => {
   const ctx = useEmojiPicker();
-  const { visible, columns, activeIndex } = ctx;
+  const { visible, columns, registerList } = ctx;
+  const activeIndex = React.useContext(EmojiPickerActiveIndexContext);
 
   const focusIndex = (index: number) => {
     const clamped = Math.max(0, Math.min(visible.length - 1, index));
@@ -1041,9 +1048,11 @@ const EmojiPickerList = ({ className, children, ...props }: EmojiPickerListProps
     e.preventDefault();
   };
 
+  const listRef = React.useMemo(() => composeRefs(registerList, ref), [registerList, ref]);
+
   return (
     <div
-      ref={(el) => ctx.registerList(el)}
+      ref={listRef}
       id={`${ctx.id}-grid`}
       role="group"
       aria-label="Emoji"
@@ -1062,7 +1071,7 @@ const EmojiPickerList = ({ className, children, ...props }: EmojiPickerListProps
             }}
           >
             {visible.map((item, index) => (
-              <EmojiPickerItem key={item.emoji} item={item} index={index} />
+              <EmojiPickerItem key={item.emoji} item={item} index={index} active={index === activeIndex} />
             ))}
           </div>
           <EmojiPickerEmpty />
@@ -1075,19 +1084,21 @@ const EmojiPickerList = ({ className, children, ...props }: EmojiPickerListProps
 interface EmojiPickerItemProps extends Omit<React.ComponentProps<'button'>, 'children' | 'type'> {
   item: EmojiItem;
   index: number;
+  /** Roving-tabindex target. `EmojiPickerList` passes it; custom lists should too. */
+  active?: boolean;
 }
 
-const EmojiPickerItem = ({
+const EmojiPickerItem = React.memo(function EmojiPickerItem({
   item,
   index,
+  active = false,
   className,
   onClick,
   onFocus,
   onMouseEnter,
   ...props
-}: EmojiPickerItemProps) => {
+}: EmojiPickerItemProps) {
   const ctx = useEmojiPicker();
-  const active = ctx.activeIndex === index;
   return (
     <button
       type="button"
@@ -1121,7 +1132,7 @@ const EmojiPickerItem = ({
       {ctx.display(item)}
     </button>
   );
-};
+});
 
 /* -------------------------------------------------------------------------- */
 /*  Empty, footer, skin tone                                                  */
@@ -1158,7 +1169,7 @@ const EmojiPickerFooter = ({
   ...props
 }: EmojiPickerFooterProps) => {
   const ctx = useEmojiPicker();
-  const item = ctx.hovered;
+  const item = React.useContext(EmojiPickerHoverContext);
   return (
     <div
       data-slot="emoji-picker-footer"

--- a/registry/hirael/bases/radix/components/file-dropzone.tsx
+++ b/registry/hirael/bases/radix/components/file-dropzone.tsx
@@ -71,7 +71,7 @@ const useFileDropzone = () => {
   return ctx;
 };
 
-export interface FileDropzoneProps {
+export interface FileDropzoneProps extends Omit<React.ComponentProps<'div'>, 'defaultValue'> {
   value?: File[];
   defaultValue?: File[];
   onValueChange?: (files: File[]) => void;
@@ -79,7 +79,6 @@ export interface FileDropzoneProps {
   maxSize?: number;
   multiple?: boolean;
   disabled?: boolean;
-  children?: React.ReactNode;
 }
 
 const FileDropzone = ({
@@ -90,7 +89,9 @@ const FileDropzone = ({
   maxSize,
   multiple = false,
   disabled,
+  className,
   children,
+  ...props
 }: FileDropzoneProps) => {
   const [internalFiles, setInternalFiles] = React.useState<File[]>(defaultValue ?? []);
   const files = valueProp ?? internalFiles;
@@ -165,7 +166,13 @@ const FileDropzone = ({
     [files, setFiles, accept, maxSize, multiple, disabled, errors, addFiles, removeAt],
   );
 
-  return <FileDropzoneContext.Provider value={ctx}>{children}</FileDropzoneContext.Provider>;
+  return (
+    <FileDropzoneContext.Provider value={ctx}>
+      <div data-slot="file-dropzone" className={className} {...props}>
+        {children}
+      </div>
+    </FileDropzoneContext.Provider>
+  );
 };
 
 interface FileDropzoneZoneProps extends Omit<
@@ -265,6 +272,8 @@ const FileDropzoneZone = ({
         multiple={ctx.multiple}
         disabled={ctx.disabled}
         className="sr-only"
+        tabIndex={-1}
+        aria-hidden
         onChange={(e) => {
           const list = e.target.files;
           if (list && list.length > 0) ctx.addFiles(list);
@@ -303,6 +312,7 @@ const FileDropzoneList = ({ className, ...props }: FileDropzoneListProps) => {
         return (
           <li
             key={`${file.name}-${file.lastModified}-${index}`}
+            data-slot="file-dropzone-item"
             className="flex min-w-0 items-center gap-2 rounded-sm border border-border bg-card px-2.5 py-1.5 text-sm"
           >
             <Icon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
@@ -344,7 +354,11 @@ const FileDropzoneErrors = ({ className, ...props }: FileDropzoneErrorsProps) =>
       {...props}
     >
       {ctx.errors.map((err, i) => (
-        <li key={`${err.file.name}-${i}`} className="break-words text-[11px] text-destructive">
+        <li
+          key={`${err.file.name}-${i}`}
+          data-slot="file-dropzone-error"
+          className="break-words text-[11px] text-destructive"
+        >
           {err.message}
         </li>
       ))}

--- a/registry/hirael/bases/radix/components/icon-stack.tsx
+++ b/registry/hirael/bases/radix/components/icon-stack.tsx
@@ -65,10 +65,7 @@ const IconStack = ({ className, children, style, layers = 3, ...props }: IconSta
   return (
     <div
       data-slot="icon-stack"
-      className={cn(
-        'relative aspect-9/10 w-18 text-foreground **:data-[slot=icon-stack-layer]:fill-muted',
-        className,
-      )}
+      className={cn('relative aspect-9/10 w-18 text-foreground **:data-[slot=icon-stack-layer]:fill-muted', className)}
       style={
         {
           '--icon-stack-face-x': `${(faceX / VIEW_WIDTH) * 100}%`,

--- a/registry/hirael/bases/radix/components/image-compare.tsx
+++ b/registry/hirael/bases/radix/components/image-compare.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { ChevronsLeftRight } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
+import { composeRefs } from '@/registry/hirael/bases/radix/components/compose-refs';
 
 interface ImageCompareContextValue {
   position: number;
@@ -50,6 +51,7 @@ const ImageCompare = ({
   disabled = false,
   className,
   children,
+  ref,
   ...props
 }: ImageCompareProps) => {
   const containerRef = React.useRef<HTMLDivElement | null>(null);
@@ -106,21 +108,26 @@ const ImageCompare = ({
     if (next !== null) setPosition(next);
   };
 
+  const ctx = React.useMemo<ImageCompareContextValue>(
+    () => ({
+      position,
+      setPosition,
+      orientation,
+      disabled,
+      dragging,
+      setDragging,
+      rtl,
+      positionFromPointer,
+    }),
+    [position, setPosition, orientation, disabled, dragging, rtl, positionFromPointer],
+  );
+
+  const composedRef = React.useMemo(() => composeRefs(containerRef, ref), [ref]);
+
   return (
-    <ImageCompareContext.Provider
-      value={{
-        position,
-        setPosition,
-        orientation,
-        disabled,
-        dragging,
-        setDragging,
-        rtl,
-        positionFromPointer,
-      }}
-    >
+    <ImageCompareContext.Provider value={ctx}>
       <div
-        ref={containerRef}
+        ref={composedRef}
         data-slot="image-compare"
         data-orientation={orientation}
         data-dragging={dragging || undefined}

--- a/registry/hirael/bases/radix/components/image-cropper.tsx
+++ b/registry/hirael/bases/radix/components/image-cropper.tsx
@@ -431,7 +431,9 @@ const ImageCropperZoom = ({ className, ...props }: ImageCropperZoomProps) => {
       max={ctx.maxZoom}
       step={0.01}
       value={[ctx.zoom]}
-      onValueChange={([v]) => ctx.setZoom(v)}
+      onValueChange={([v]) => {
+        if (v !== undefined) ctx.setZoom(v);
+      }}
       disabled={ctx.disabled}
       data-slot="image-cropper-zoom"
       className={cn('w-full', className)}

--- a/registry/hirael/bases/radix/components/inline-edit.tsx
+++ b/registry/hirael/bases/radix/components/inline-edit.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/registry/hirael/bases/radix/ui/button';
 import { Input } from '@/registry/hirael/bases/radix/ui/input';
 import { Spinner } from '@/registry/hirael/bases/radix/components/spinner';
 import { Textarea } from '@/registry/hirael/bases/radix/ui/textarea';
+import { composeRefs } from '@/registry/hirael/bases/radix/components/compose-refs';
 
 interface InlineEditCtx {
   value: string;
@@ -24,6 +25,7 @@ interface InlineEditCtx {
   startEditing: () => void;
   submit: () => void;
   cancel: () => void;
+  previewRef: React.RefObject<HTMLSpanElement | null>;
 }
 
 const InlineEditContext = React.createContext<InlineEditCtx | null>(null);
@@ -152,6 +154,21 @@ const InlineEdit = ({
     onCancel?.();
   }, [pending, value, setEditing, onCancel]);
 
+  const previewRef = React.useRef<HTMLSpanElement | null>(null);
+  const wasEditingRef = React.useRef(editing);
+
+  // The editor unmounts when editing ends, dropping focus to <body>; return it
+  // to the preview unless the user already moved focus elsewhere (blur-submit).
+  React.useEffect(() => {
+    const wasEditing = wasEditingRef.current;
+    wasEditingRef.current = editing;
+    if (!wasEditing || editing) return;
+    const active = document.activeElement;
+    if (active === null || active === document.body) {
+      previewRef.current?.focus({ preventScroll: true });
+    }
+  }, [editing]);
+
   const ctx = React.useMemo<InlineEditCtx>(
     () => ({
       value,
@@ -168,6 +185,7 @@ const InlineEdit = ({
       startEditing,
       submit,
       cancel,
+      previewRef,
     }),
     [
       value,
@@ -210,8 +228,15 @@ export interface InlineEditPreviewProps extends React.ComponentProps<'span'> {
   asChild?: boolean;
 }
 
-const InlineEditPreview = ({ asChild = false, className, children, ...props }: InlineEditPreviewProps) => {
-  const { value, editing, disabled, placeholder, startEditing } = useInlineEdit();
+const InlineEditPreview = ({ asChild = false, className, children, ref, ...props }: InlineEditPreviewProps) => {
+  const { value, editing, disabled, placeholder, startEditing, previewRef } = useInlineEdit();
+
+  // Composed in the callback, not during render: previewRef arrives through context,
+  // where the ref lint rule can't see that composeRefs never reads it.
+  const composedRef = React.useCallback(
+    (node: HTMLSpanElement | null) => composeRefs(previewRef, ref)(node),
+    [previewRef, ref],
+  );
 
   if (editing) return null;
 
@@ -237,6 +262,7 @@ const InlineEditPreview = ({ asChild = false, className, children, ...props }: I
         startEditing();
       }
     },
+    ref: composedRef,
     ...props,
   };
 
@@ -264,7 +290,14 @@ const InlineEditPreview = ({ asChild = false, className, children, ...props }: I
   );
 };
 
-const InlineEditInput = ({ className, onKeyDown, onBlur, ...props }: React.ComponentProps<typeof Input>) => {
+const InlineEditInput = ({
+  className,
+  onKeyDown,
+  onBlur,
+  onChange,
+  ref,
+  ...props
+}: React.ComponentProps<typeof Input>) => {
   const {
     draft,
     setDraft,
@@ -280,17 +313,21 @@ const InlineEditInput = ({ className, onKeyDown, onBlur, ...props }: React.Compo
     cancel,
   } = useInlineEdit();
 
-  // Stable callback ref: focus/select run once when the input mounts. An inline
-  // ref would be re-invoked on every render, re-selecting the text mid-typing.
+  // Focus/select once per mounted node. A consumer's inline callback ref gives
+  // the composed ref a new identity every render, so React re-invokes it, and
+  // re-selecting mid-typing would swallow the next keystroke.
+  const focusedRef = React.useRef<HTMLInputElement | null>(null);
   const focusOnMount = React.useCallback(
     (node: HTMLInputElement | null) => {
-      if (node) {
-        node.focus();
-        if (selectOnFocus) node.select();
-      }
+      if (!node || node === focusedRef.current) return;
+      focusedRef.current = node;
+      node.focus();
+      if (selectOnFocus) node.select();
     },
     [selectOnFocus],
   );
+
+  const composedRef = React.useMemo(() => composeRefs(focusOnMount, ref), [focusOnMount, ref]);
 
   if (!editing) return null;
 
@@ -302,7 +339,11 @@ const InlineEditInput = ({ className, onKeyDown, onBlur, ...props }: React.Compo
       disabled={disabled || pending}
       aria-invalid={error ? true : undefined}
       aria-describedby={error ? errorId : undefined}
-      onChange={(event) => setDraft(event.target.value)}
+      onChange={(event) => {
+        onChange?.(event);
+        if (event.defaultPrevented) return;
+        setDraft(event.target.value);
+      }}
       onKeyDown={(event) => {
         onKeyDown?.(event);
         if (event.key === 'Enter') {
@@ -320,12 +361,19 @@ const InlineEditInput = ({ className, onKeyDown, onBlur, ...props }: React.Compo
       }}
       className={cn('h-8', className)}
       {...props}
-      ref={focusOnMount}
+      ref={composedRef}
     />
   );
 };
 
-const InlineEditTextarea = ({ className, onKeyDown, onBlur, ...props }: React.ComponentProps<typeof Textarea>) => {
+const InlineEditTextarea = ({
+  className,
+  onKeyDown,
+  onBlur,
+  onChange,
+  ref,
+  ...props
+}: React.ComponentProps<typeof Textarea>) => {
   const {
     draft,
     setDraft,
@@ -341,17 +389,19 @@ const InlineEditTextarea = ({ className, onKeyDown, onBlur, ...props }: React.Co
     cancel,
   } = useInlineEdit();
 
-  // Stable callback ref: focus/select run once when the textarea mounts. An
-  // inline ref would re-run every render, re-selecting the text mid-typing.
+  // Focus/select once per mounted node; see InlineEditInput.
+  const focusedRef = React.useRef<HTMLTextAreaElement | null>(null);
   const focusOnMount = React.useCallback(
     (node: HTMLTextAreaElement | null) => {
-      if (node) {
-        node.focus();
-        if (selectOnFocus) node.select();
-      }
+      if (!node || node === focusedRef.current) return;
+      focusedRef.current = node;
+      node.focus();
+      if (selectOnFocus) node.select();
     },
     [selectOnFocus],
   );
+
+  const composedRef = React.useMemo(() => composeRefs(focusOnMount, ref), [focusOnMount, ref]);
 
   if (!editing) return null;
 
@@ -363,7 +413,11 @@ const InlineEditTextarea = ({ className, onKeyDown, onBlur, ...props }: React.Co
       disabled={disabled || pending}
       aria-invalid={error ? true : undefined}
       aria-describedby={error ? errorId : undefined}
-      onChange={(event) => setDraft(event.target.value)}
+      onChange={(event) => {
+        onChange?.(event);
+        if (event.defaultPrevented) return;
+        setDraft(event.target.value);
+      }}
       onKeyDown={(event) => {
         onKeyDown?.(event);
         if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
@@ -381,7 +435,7 @@ const InlineEditTextarea = ({ className, onKeyDown, onBlur, ...props }: React.Co
       }}
       className={className}
       {...props}
-      ref={focusOnMount}
+      ref={composedRef}
     />
   );
 };

--- a/registry/hirael/bases/radix/components/lazy-select.tsx
+++ b/registry/hirael/bases/radix/components/lazy-select.tsx
@@ -66,6 +66,7 @@ export interface LazySelectProps {
   hasMore?: boolean;
   disabled?: boolean;
   clearable?: boolean;
+  name?: string;
   children?: React.ReactNode;
 }
 
@@ -84,6 +85,7 @@ const LazySelect = ({
   hasMore,
   disabled,
   clearable = true,
+  name,
   children,
 }: LazySelectProps) => {
   const [internalValue, setInternalValue] = React.useState<string | undefined>(defaultValue);
@@ -186,6 +188,7 @@ const LazySelect = ({
       <Popover open={open} onOpenChange={setOpen}>
         {children}
       </Popover>
+      {name && <input type="hidden" name={name} value={value ?? ''} />}
     </LazySelectContext.Provider>
   );
 };
@@ -198,56 +201,68 @@ interface LazySelectTriggerProps extends Omit<React.ComponentProps<'button'>, 'c
 
 const LazySelectTrigger = ({ placeholder = 'Select…', className, children, ...props }: LazySelectTriggerProps) => {
   const ctx = useLazySelect();
+  const showClear = !children && ctx.clearable && ctx.value !== undefined && !ctx.disabled;
 
   return (
-    <PopoverTrigger asChild>
-      <button
-        type="button"
-        role="combobox"
-        aria-controls={ctx.listboxId}
-        aria-expanded={ctx.open}
-        aria-haspopup="listbox"
-        disabled={ctx.disabled}
-        data-slot="lazy-select-trigger"
-        data-state={ctx.open ? 'open' : 'closed'}
-        className={cn(
-          'group flex h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-2.5 text-start text-sm outline-none transition-colors',
-          'hover:border-ring/60 focus-visible:border-ring',
-          'data-[state=open]:border-ring',
-          'disabled:cursor-not-allowed disabled:opacity-50',
-          className,
-        )}
-        {...props}
-      >
-        {typeof children === 'function' ? (
-          children(ctx)
-        ) : children ? (
-          children
-        ) : (
-          <>
-            <span className={cn('min-w-0 flex-1 truncate', ctx.selectedLabel === undefined && 'text-muted-foreground')}>
-              {ctx.selectedLabel ?? placeholder}
-            </span>
-            <span className="flex shrink-0 items-center gap-1 text-muted-foreground">
-              {ctx.clearable && ctx.value !== undefined && !ctx.disabled && (
-                <span
-                  aria-hidden
-                  onPointerDown={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    ctx.setValue(undefined);
-                  }}
-                  className="inline-flex size-4 items-center justify-center rounded-[2px] hover:bg-accent hover:text-foreground"
-                >
-                  <X className="size-3" />
-                </span>
-              )}
-              <ChevronDown className={cn('size-3.5 transition-transform duration-150', ctx.open && 'rotate-180')} />
-            </span>
-          </>
-        )}
-      </button>
-    </PopoverTrigger>
+    <div data-slot="lazy-select-trigger-wrapper" className="relative w-full">
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          role="combobox"
+          aria-controls={ctx.listboxId}
+          aria-expanded={ctx.open}
+          aria-haspopup="listbox"
+          disabled={ctx.disabled}
+          data-slot="lazy-select-trigger"
+          data-state={ctx.open ? 'open' : 'closed'}
+          className={cn(
+            'group flex h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-2.5 text-start text-sm outline-none transition-colors',
+            'hover:border-ring/60 focus-visible:border-ring',
+            'data-[state=open]:border-ring',
+            'disabled:cursor-not-allowed disabled:opacity-50',
+            className,
+          )}
+          {...props}
+        >
+          {typeof children === 'function' ? (
+            children(ctx)
+          ) : children ? (
+            children
+          ) : (
+            <>
+              <span
+                className={cn(
+                  'min-w-0 flex-1 truncate',
+                  ctx.selectedLabel === undefined && 'text-muted-foreground',
+                  // Reserve room for the overlaid clear button.
+                  showClear && 'pe-5',
+                )}
+              >
+                {ctx.selectedLabel ?? placeholder}
+              </span>
+              <span className="flex shrink-0 items-center gap-1 text-muted-foreground">
+                <ChevronDown className={cn('size-3.5 transition-transform duration-150', ctx.open && 'rotate-180')} />
+              </span>
+            </>
+          )}
+        </button>
+      </PopoverTrigger>
+      {showClear && (
+        <button
+          type="button"
+          aria-label="Clear"
+          data-slot="lazy-select-clear"
+          onClick={(e) => {
+            e.stopPropagation();
+            ctx.setValue(undefined);
+          }}
+          // Overlaid because a button cannot nest a button; `end-7` sits it inside the chevron.
+          className="absolute end-7 top-1/2 inline-flex size-4 -translate-y-1/2 items-center justify-center rounded-[2px] text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <X className="size-3" />
+        </button>
+      )}
+    </div>
   );
 };
 
@@ -272,6 +287,7 @@ const LazySelectContent = ({
 }: LazySelectContentProps) => {
   const ctx = useLazySelect();
   const sentinelRef = React.useRef<HTMLDivElement>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
   const onLoadMore = ctx.onLoadMore;
 
   // Lazy-load the next page when the bottom sentinel scrolls into view. Re-run
@@ -298,11 +314,14 @@ const LazySelectContent = ({
       sideOffset={6}
       data-slot="lazy-select-content"
       className={cn('w-(--radix-popover-trigger-width) min-w-[14rem] p-0', className)}
-      onOpenAutoFocus={(e) => e.preventDefault()}
+      onOpenAutoFocus={(e) => {
+        e.preventDefault();
+        inputRef.current?.focus();
+      }}
       {...props}
     >
       <Command shouldFilter={false} loop>
-        <CommandInput placeholder={searchPlaceholder} value={ctx.search} onValueChange={ctx.setSearch} />
+        <CommandInput ref={inputRef} placeholder={searchPlaceholder} value={ctx.search} onValueChange={ctx.setSearch} />
         <CommandList id={ctx.listboxId}>
           {ctx.loading ? (
             <div className="flex items-center justify-center gap-2 py-6 text-xs text-muted-foreground">

--- a/registry/hirael/bases/radix/components/media-input.tsx
+++ b/registry/hirael/bases/radix/components/media-input.tsx
@@ -38,6 +38,8 @@ export interface MediaInputProps extends Omit<React.ComponentProps<'div'>, 'onEr
   accept?: string;
   /** Maximum file size in bytes. Larger picks are rejected with an error. */
   maxSize?: number;
+  /** Field name for the native input, so the picked file can join form submission. */
+  name?: string;
   disabled?: boolean;
   value?: MediaInputValue | null;
   defaultValue?: MediaInputValue | null;
@@ -48,6 +50,7 @@ export interface MediaInputProps extends Omit<React.ComponentProps<'div'>, 'onEr
 const MediaInput = ({
   accept,
   maxSize,
+  name,
   disabled = false,
   value: valueProp,
   defaultValue = null,
@@ -123,6 +126,7 @@ const MediaInput = ({
           ref={inputRef}
           data-slot="media-input-input"
           type="file"
+          name={name}
           accept={accept}
           disabled={disabled}
           className="sr-only"
@@ -182,6 +186,7 @@ const MediaInputTrigger = ({ variant = 'outline', onClick, ...props }: React.Com
 
   return (
     <Button
+      type="button"
       data-slot="media-input-trigger"
       variant={variant}
       disabled={disabled || props.disabled}
@@ -218,6 +223,7 @@ const MediaInputClear = ({ onClick, className, children, ...props }: React.Compo
 
   return (
     <Button
+      type="button"
       data-slot="media-input-clear"
       variant="ghost"
       size="icon"

--- a/registry/hirael/bases/radix/components/mention-input.tsx
+++ b/registry/hirael/bases/radix/components/mention-input.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 import { Spinner } from '@/registry/hirael/bases/radix/components/spinner';
+import { composeRefs } from '@/registry/hirael/bases/radix/components/compose-refs';
 
 export interface MentionItem {
   id: string;
@@ -121,6 +122,47 @@ const segmentValue = (value: string, triggers: string[], known: Set<string>): Se
   return segments;
 };
 
+const metrics = 'min-h-16 w-full rounded-sm border px-3 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words';
+
+interface MentionInputCtx {
+  id: string;
+  listboxId: string;
+  open: boolean;
+  loading: boolean;
+  filteredItems: MentionItem[];
+  activeIndex: number;
+  activeTrigger: string | undefined;
+  pos: { top: number; left: number };
+  value: string;
+  segments: Segment[];
+  disabled?: boolean;
+  placeholder?: string;
+  name?: string;
+  emptyMessage: string;
+  loadingMessage: string;
+  listLabel: string;
+  popupRef: React.RefObject<HTMLDivElement | null>;
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  backdropRef: React.RefObject<HTMLDivElement | null>;
+  select: (item: MentionItem) => void;
+  setActiveIndex: (index: number) => void;
+  /**
+   * Caret, scroll sync and suggestion keys all read state from here, so the
+   * handlers stay put and travel as one bundle for the textarea to spread.
+   */
+  textareaProps: Pick<React.ComponentProps<'textarea'>, 'onChange' | 'onSelect' | 'onScroll' | 'onKeyDown' | 'onBlur'>;
+}
+
+const MentionInputContext = React.createContext<MentionInputCtx | null>(null);
+
+export const useMentionInput = () => {
+  const ctx = React.useContext(MentionInputContext);
+  if (!ctx) {
+    throw new Error('MentionInput compound parts must be used inside <MentionInput>');
+  }
+  return ctx;
+};
+
 export interface MentionInputProps extends Omit<React.ComponentProps<'div'>, 'defaultValue' | 'onChange'> {
   value?: string;
   defaultValue?: string;
@@ -133,6 +175,8 @@ export interface MentionInputProps extends Omit<React.ComponentProps<'div'>, 'de
   maxRows?: number;
   onMention?: (item: MentionItem) => void;
   emptyMessage?: string;
+  loadingMessage?: string;
+  listLabel?: string;
   name?: string;
 }
 
@@ -148,8 +192,12 @@ const MentionInput = ({
   maxRows,
   onMention,
   emptyMessage = 'No results.',
+  loadingMessage = 'Searching…',
+  listLabel = 'Mention suggestions',
   name,
   className,
+  children,
+  ref,
   ...props
 }: MentionInputProps) => {
   const id = React.useId();
@@ -178,6 +226,7 @@ const MentionInput = ({
   });
 
   const wrapperRef = React.useRef<HTMLDivElement | null>(null);
+  const composedWrapperRef = React.useMemo(() => composeRefs(wrapperRef, ref), [ref]);
   const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
   const backdropRef = React.useRef<HTMLDivElement | null>(null);
   const popupRef = React.useRef<HTMLDivElement | null>(null);
@@ -337,43 +386,188 @@ const MentionInput = ({
     [mention, value, setValue, onMention],
   );
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (!open) return;
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      setActiveIndex(filtered.length ? (active + 1) % filtered.length : 0);
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      setActiveIndex(filtered.length ? (active - 1 + filtered.length) % filtered.length : 0);
-    } else if (e.key === 'Enter' || e.key === 'Tab') {
-      const item = filtered[active];
-      if (item) {
+  const handleKeyDown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (!open) return;
+      if (e.key === 'ArrowDown') {
         e.preventDefault();
-        select(item);
+        setActiveIndex(filtered.length ? (active + 1) % filtered.length : 0);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveIndex(filtered.length ? (active - 1 + filtered.length) % filtered.length : 0);
+      } else if (e.key === 'Enter' || e.key === 'Tab') {
+        const item = filtered[active];
+        if (item) {
+          e.preventDefault();
+          select(item);
+        }
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        dismissedRef.current = true;
+        setMention(null);
       }
-    } else if (e.key === 'Escape') {
-      e.preventDefault();
-      dismissedRef.current = true;
-      setMention(null);
-    }
-  };
+    },
+    [open, filtered, active, select],
+  );
 
-  const metrics = 'min-h-16 w-full rounded-sm border px-3 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words';
+  const handleChange = React.useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      dismissedRef.current = false;
+      setValue(e.target.value);
+      detect(e.target.value, e.target.selectionStart);
+    },
+    [setValue, detect],
+  );
+
+  const handleSelect = React.useCallback(
+    (e: React.SyntheticEvent<HTMLTextAreaElement>) => {
+      detect(e.currentTarget.value, e.currentTarget.selectionStart);
+    },
+    [detect],
+  );
+
+  const handleScroll = React.useCallback(
+    (e: React.UIEvent<HTMLTextAreaElement>) => {
+      const backdrop = backdropRef.current;
+      if (backdrop) {
+        backdrop.scrollTop = e.currentTarget.scrollTop;
+        backdrop.scrollLeft = e.currentTarget.scrollLeft;
+      }
+      if (open) setMention(null);
+    },
+    [open],
+  );
+
+  const handleBlur = React.useCallback(() => setMention(null), []);
+
+  const textareaProps = React.useMemo<MentionInputCtx['textareaProps']>(
+    () => ({
+      onChange: handleChange,
+      onSelect: handleSelect,
+      onScroll: handleScroll,
+      onKeyDown: handleKeyDown,
+      onBlur: handleBlur,
+    }),
+    [handleChange, handleSelect, handleScroll, handleKeyDown, handleBlur],
+  );
+
+  const ctx = React.useMemo<MentionInputCtx>(
+    () => ({
+      id,
+      listboxId,
+      open,
+      loading,
+      filteredItems: filtered,
+      activeIndex: active,
+      activeTrigger,
+      pos,
+      value,
+      segments,
+      disabled,
+      placeholder,
+      name,
+      emptyMessage,
+      loadingMessage,
+      listLabel,
+      popupRef,
+      textareaRef,
+      backdropRef,
+      select,
+      setActiveIndex,
+      textareaProps,
+    }),
+    [
+      id,
+      listboxId,
+      open,
+      loading,
+      filtered,
+      active,
+      activeTrigger,
+      pos,
+      value,
+      segments,
+      disabled,
+      placeholder,
+      name,
+      emptyMessage,
+      loadingMessage,
+      listLabel,
+      select,
+      textareaProps,
+    ],
+  );
 
   return (
-    <div
-      ref={wrapperRef}
-      data-slot="mention-input"
-      data-disabled={disabled || undefined}
-      className={cn('relative w-full', className)}
-      {...props}
-    >
+    <MentionInputContext.Provider value={ctx}>
+      <div
+        ref={composedWrapperRef}
+        data-slot="mention-input"
+        data-disabled={disabled || undefined}
+        className={cn('relative w-full', className)}
+        {...props}
+      >
+        {children ?? (
+          <>
+            <MentionInputTextarea />
+            <MentionInputList />
+          </>
+        )}
+      </div>
+    </MentionInputContext.Provider>
+  );
+};
+
+type MentionInputTextareaProps = Omit<
+  React.ComponentProps<'textarea'>,
+  'value' | 'defaultValue' | 'name' | 'placeholder' | 'disabled'
+>;
+
+/** The consumer's handler runs first; the part's own is skipped once the event is default-prevented. */
+const chainHandlers =
+  <E extends React.SyntheticEvent>(theirs: ((event: E) => void) | undefined, ours: ((event: E) => void) | undefined) =>
+  (event: E) => {
+    theirs?.(event);
+    if (!event.defaultPrevented) ours?.(event);
+  };
+
+const MentionInputTextarea = ({
+  className,
+  ref,
+  onChange,
+  onSelect,
+  onScroll,
+  onKeyDown,
+  onBlur,
+  ...props
+}: MentionInputTextareaProps) => {
+  const {
+    id,
+    listboxId,
+    open,
+    filteredItems,
+    activeIndex,
+    value,
+    segments,
+    disabled,
+    placeholder,
+    name,
+    backdropRef,
+    textareaRef,
+    textareaProps,
+  } = useMentionInput();
+  const composedRef = React.useMemo(() => composeRefs(textareaRef, ref), [textareaRef, ref]);
+  return (
+    <>
       <div
         ref={backdropRef}
         aria-hidden
         data-slot="mention-input-backdrop"
+        // The consumer's className lands on both layers so padding and font metrics
+        // stay aligned; the transparent overrides come last and win.
         className={cn(
           metrics,
+          className,
           'pointer-events-none absolute inset-0 overflow-hidden border-transparent text-transparent',
         )}
       >
@@ -393,7 +587,7 @@ const MentionInput = ({
         {'​'}
       </div>
       <textarea
-        ref={textareaRef}
+        ref={composedRef}
         rows={1}
         name={name}
         value={value}
@@ -404,85 +598,127 @@ const MentionInput = ({
         aria-haspopup="listbox"
         aria-autocomplete="list"
         aria-controls={listboxId}
-        aria-activedescendant={open && filtered[active] ? `${id}-option-${active}` : undefined}
+        aria-activedescendant={open && filteredItems[activeIndex] ? `${id}-option-${activeIndex}` : undefined}
         data-slot="mention-input-textarea"
-        onChange={(e) => {
-          dismissedRef.current = false;
-          setValue(e.target.value);
-          detect(e.target.value, e.target.selectionStart);
-        }}
-        onSelect={(e) => {
-          detect(e.currentTarget.value, e.currentTarget.selectionStart);
-        }}
-        onScroll={(e) => {
-          const backdrop = backdropRef.current;
-          if (backdrop) {
-            backdrop.scrollTop = e.currentTarget.scrollTop;
-            backdrop.scrollLeft = e.currentTarget.scrollLeft;
-          }
-          if (open) setMention(null);
-        }}
-        onKeyDown={handleKeyDown}
-        onBlur={() => setMention(null)}
+        {...props}
+        onChange={chainHandlers(onChange, textareaProps.onChange)}
+        onSelect={chainHandlers(onSelect, textareaProps.onSelect)}
+        onScroll={chainHandlers(onScroll, textareaProps.onScroll)}
+        onKeyDown={chainHandlers(onKeyDown, textareaProps.onKeyDown)}
+        onBlur={chainHandlers(onBlur, textareaProps.onBlur)}
         className={cn(
           metrics,
           'relative resize-none border-input bg-transparent outline-none transition-colors',
           'placeholder:text-muted-foreground',
           'focus-visible:border-ring',
           'disabled:cursor-not-allowed disabled:opacity-50',
+          className,
         )}
       />
-      {open && (
-        <div
-          ref={popupRef}
-          id={listboxId}
-          role="listbox"
-          aria-label="Mention suggestions"
-          data-slot="mention-input-list"
-          style={{ top: pos.top, left: pos.left }}
-          className="absolute z-50 max-h-60 w-64 overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
-        >
-          {loading ? (
-            <div
-              data-slot="mention-input-loading"
-              className="flex items-center gap-2 px-2 py-2 text-xs text-muted-foreground"
-            >
-              <Spinner size="sm" />
-              Searching…
-            </div>
-          ) : filtered.length === 0 ? (
-            <div data-slot="mention-input-empty" className="px-2 py-2 text-xs text-muted-foreground">
-              {emptyMessage}
-            </div>
-          ) : (
-            filtered.map((item, i) => (
-              <div
-                key={item.id}
-                id={`${id}-option-${i}`}
-                role="option"
-                aria-selected={i === active}
-                data-slot="mention-input-item"
-                data-active={i === active || undefined}
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => select(item)}
-                onMouseMove={() => setActiveIndex(i)}
-                className={cn(
-                  'flex cursor-default flex-col gap-0.5 rounded-sm px-2 py-1.5',
-                  i === active && 'bg-accent text-accent-foreground',
-                )}
-              >
-                <span className="text-sm leading-none">
-                  {mention?.trigger}
-                  {item.label}
-                </span>
-                {item.description && <span className="truncate text-xs text-muted-foreground">{item.description}</span>}
-              </div>
-            ))
-          )}
-        </div>
+    </>
+  );
+};
+
+const MentionInputList = ({ className, style, children, ref, ...props }: React.ComponentProps<'div'>) => {
+  const ctx = useMentionInput();
+  const composedRef = React.useMemo(() => composeRefs(ctx.popupRef, ref), [ctx.popupRef, ref]);
+
+  if (!ctx.open) return null;
+
+  return (
+    <div
+      ref={composedRef}
+      id={ctx.listboxId}
+      role="listbox"
+      aria-label={ctx.listLabel}
+      data-slot="mention-input-list"
+      style={{ ...style, top: ctx.pos.top, left: ctx.pos.left }}
+      className={cn(
+        'absolute z-50 max-h-60 w-64 overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md',
+        className,
+      )}
+      {...props}
+    >
+      {children ??
+        (ctx.loading ? (
+          <div
+            data-slot="mention-input-loading"
+            className="flex items-center gap-2 px-2 py-2 text-xs text-muted-foreground"
+          >
+            <Spinner size="sm" />
+            {ctx.loadingMessage}
+          </div>
+        ) : ctx.filteredItems.length === 0 ? (
+          <div data-slot="mention-input-empty" className="px-2 py-2 text-xs text-muted-foreground">
+            {ctx.emptyMessage}
+          </div>
+        ) : (
+          ctx.filteredItems.map((item, i) => <MentionInputItem key={item.id} item={item} index={i} />)
+        ))}
+    </div>
+  );
+};
+
+interface MentionInputItemProps extends Omit<React.ComponentProps<'div'>, 'children'> {
+  item: MentionItem;
+  index: number;
+  children?: React.ReactNode;
+}
+
+const MentionInputItem = ({
+  item,
+  index,
+  className,
+  children,
+  onMouseDown,
+  onClick,
+  onMouseMove,
+  ...props
+}: MentionInputItemProps) => {
+  const ctx = useMentionInput();
+  const active = index === ctx.activeIndex;
+  return (
+    <div
+      id={`${ctx.id}-option-${index}`}
+      role="option"
+      aria-selected={active}
+      data-slot="mention-input-item"
+      data-active={active || undefined}
+      onMouseDown={(e) => {
+        onMouseDown?.(e);
+        if (e.defaultPrevented) return;
+        // Keep focus in the textarea so the caret position survives the click.
+        e.preventDefault();
+      }}
+      onClick={(e) => {
+        onClick?.(e);
+        if (e.defaultPrevented) return;
+        ctx.select(item);
+      }}
+      onMouseMove={(e) => {
+        onMouseMove?.(e);
+        if (e.defaultPrevented) return;
+        ctx.setActiveIndex(index);
+      }}
+      className={cn(
+        'flex cursor-default flex-col gap-0.5 rounded-sm px-2 py-1.5',
+        active && 'bg-accent text-accent-foreground',
+        className,
+      )}
+      {...props}
+    >
+      {children ?? (
+        <>
+          {/* bdi keeps the trigger glued to the handle in RTL text */}
+          <bdi className="text-sm leading-none">
+            {ctx.activeTrigger}
+            {item.label}
+          </bdi>
+          {item.description && <span className="truncate text-xs text-muted-foreground">{item.description}</span>}
+        </>
       )}
     </div>
   );
 };
 
-export { MentionInput };
+export { MentionInput, MentionInputTextarea, MentionInputList, MentionInputItem };

--- a/registry/hirael/bases/radix/components/morphing-dialog.tsx
+++ b/registry/hirael/bases/radix/components/morphing-dialog.tsx
@@ -55,11 +55,14 @@ const MorphingDialog = ({ children, open: openProp, defaultOpen, onOpenChange }:
     [openProp, onOpenChange],
   );
 
+  const open = React.useCallback(() => setOpen(true), [setOpen]);
+  const close = React.useCallback(() => setOpen(false), [setOpen]);
+
   const value = React.useMemo<MorphingDialogContextValue>(
     () => ({
       isOpen,
-      open: () => setOpen(true),
-      close: () => setOpen(false),
+      open,
+      close,
       uniqueId: reactId,
       titleId: `${reactId}-title`,
       descriptionId: `${reactId}-description`,
@@ -69,7 +72,7 @@ const MorphingDialog = ({ children, open: openProp, defaultOpen, onOpenChange }:
       setHasDescription,
       triggerRef,
     }),
-    [isOpen, setOpen, reactId, hasTitle, hasDescription],
+    [isOpen, open, close, reactId, hasTitle, hasDescription],
   );
 
   return (

--- a/registry/hirael/bases/radix/components/multi-select.tsx
+++ b/registry/hirael/bases/radix/components/multi-select.tsx
@@ -5,7 +5,7 @@ import { Check, ChevronDown, X, Loader2 } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { Badge } from '@/registry/hirael/bases/radix/ui/badge';
-import { Popover, PopoverContent, PopoverTrigger } from '@/registry/hirael/bases/radix/ui/popover';
+import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from '@/registry/hirael/bases/radix/ui/popover';
 import {
   Command,
   CommandEmpty,
@@ -38,6 +38,7 @@ interface MultiSelectContextValue {
   toggle: (v: string) => void;
   remove: (v: string) => void;
   clear: () => void;
+  listboxId: string;
 }
 
 const MultiSelectContext = React.createContext<MultiSelectContextValue | null>(null);
@@ -61,6 +62,7 @@ export interface MultiSelectProps {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
+  name?: string;
   children?: React.ReactNode;
 }
 
@@ -75,6 +77,7 @@ const MultiSelect = ({
   open: openProp,
   defaultOpen = false,
   onOpenChange,
+  name,
   children,
 }: MultiSelectProps) => {
   const [internalValue, setInternalValue] = React.useState<string[]>(defaultValue ?? []);
@@ -119,6 +122,8 @@ const MultiSelect = ({
 
   const clear = React.useCallback(() => setValue([]), [setValue]);
 
+  const listboxId = React.useId();
+
   const ctx = React.useMemo<MultiSelectContextValue>(
     () => ({
       value,
@@ -135,8 +140,9 @@ const MultiSelect = ({
       toggle,
       remove,
       clear,
+      listboxId,
     }),
-    [value, setValue, options, open, setOpen, search, maxCount, disabled, loading, toggle, remove, clear],
+    [value, setValue, options, open, setOpen, search, maxCount, disabled, loading, toggle, remove, clear, listboxId],
   );
 
   return (
@@ -144,10 +150,16 @@ const MultiSelect = ({
       <Popover open={open} onOpenChange={setOpen}>
         {children}
       </Popover>
+      {name && <input type="hidden" name={name} value={value.join(',')} />}
     </MultiSelectContext.Provider>
   );
 };
 
+/**
+ * Chips carry remove buttons, so they cannot sit inside the trigger button. The
+ * bordered box is a wrapper (`multi-select-trigger`) taking `className`; the
+ * button inside it (`multi-select-trigger-button`) takes every other prop.
+ */
 interface MultiSelectTriggerProps extends Omit<React.ComponentProps<'button'>, 'children'> {
   placeholder?: string;
   className?: string;
@@ -158,66 +170,78 @@ const MultiSelectTrigger = ({ placeholder = 'Select…', className, children, ..
   const ctx = useMultiSelect();
   const selected = ctx.options.filter((o) => ctx.value.includes(o.value));
 
+  // The popover anchors to the whole box, not the inner button that shrinks as chips fill the row.
   return (
-    <PopoverTrigger asChild>
-      <button
-        type="button"
-        role="combobox"
-        aria-expanded={ctx.open}
-        aria-haspopup="listbox"
-        disabled={ctx.disabled}
-        data-slot="multi-select-trigger"
-        data-state={ctx.open ? 'open' : 'closed'}
-        className={cn(
-          'group flex min-h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-2 py-1 text-start text-sm outline-none transition-colors',
-          'hover:border-ring/60 focus-visible:border-ring',
-          'data-[state=open]:border-ring',
-          'disabled:cursor-not-allowed disabled:opacity-50',
-          className,
-        )}
-        {...props}
-      >
-        {typeof children === 'function' ? (
-          children(ctx)
-        ) : children ? (
-          children
-        ) : (
-          <>
-            <span className="flex flex-1 flex-wrap items-center gap-1">
-              {selected.length === 0 ? (
-                <span className="px-1 text-muted-foreground">{placeholder}</span>
-              ) : (
-                selected.map((opt) => (
-                  <Badge key={opt.value} variant="default" className="gap-1 pe-1">
-                    {opt.label}
-                    <span
-                      aria-hidden
-                      onPointerDown={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        ctx.remove(opt.value);
-                      }}
-                      className="ms-0.5 inline-flex size-3.5 items-center justify-center rounded-[2px] text-primary-foreground/70 hover:bg-primary-foreground/20 hover:text-primary-foreground"
-                    >
-                      <X className="size-2.5" />
-                    </span>
-                  </Badge>
-                ))
+    <PopoverAnchor
+      data-slot="multi-select-trigger"
+      data-state={ctx.open ? 'open' : 'closed'}
+      className={cn(
+        'group flex min-h-9 w-full items-center justify-between gap-2 rounded-sm border border-input bg-transparent px-2 py-1 text-start text-sm transition-colors',
+        'hover:border-ring/60 focus-within:border-ring',
+        'data-[state=open]:border-ring',
+        ctx.disabled && 'cursor-not-allowed opacity-50',
+        className,
+      )}
+    >
+      {!children && selected.length > 0 && (
+        <span data-slot="multi-select-chips" className="flex flex-wrap items-center gap-1">
+          {selected.map((opt) => (
+            <Badge key={opt.value} variant="default" data-slot="multi-select-chip" className="gap-1 pe-1">
+              {opt.label}
+              {!ctx.disabled && (
+                <button
+                  type="button"
+                  data-slot="multi-select-chip-remove"
+                  aria-label={`Remove ${opt.label}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    ctx.remove(opt.value);
+                  }}
+                  className="ms-0.5 inline-flex size-3.5 items-center justify-center rounded-[2px] text-primary-foreground/70 hover:bg-primary-foreground/20 hover:text-primary-foreground"
+                >
+                  <X className="size-2.5" />
+                </button>
               )}
-            </span>
-            <span className="flex shrink-0 items-center gap-1.5 text-muted-foreground">
-              {selected.length > 0 && (
-                <span className="font-mono text-[10px] tabular-nums">
-                  {selected.length}
-                  {ctx.maxCount ? `/${ctx.maxCount}` : ''}
-                </span>
-              )}
-              <ChevronDown className={cn('size-3.5 transition-transform duration-150', ctx.open && 'rotate-180')} />
-            </span>
-          </>
-        )}
-      </button>
-    </PopoverTrigger>
+            </Badge>
+          ))}
+        </span>
+      )}
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          role="combobox"
+          aria-controls={ctx.listboxId}
+          aria-expanded={ctx.open}
+          aria-haspopup="listbox"
+          disabled={ctx.disabled}
+          data-slot="multi-select-trigger-button"
+          data-state={ctx.open ? 'open' : 'closed'}
+          className="flex grow items-center justify-between gap-2 self-stretch text-start outline-none disabled:cursor-not-allowed"
+          {...props}
+        >
+          {typeof children === 'function' ? (
+            children(ctx)
+          ) : children ? (
+            children
+          ) : (
+            <>
+              <span className="flex flex-1 flex-wrap items-center gap-1">
+                {selected.length === 0 && <span className="px-1 text-muted-foreground">{placeholder}</span>}
+              </span>
+              <span className="flex shrink-0 items-center gap-1.5 text-muted-foreground">
+                {selected.length > 0 && (
+                  <span className="font-mono text-[10px] tabular-nums">
+                    {selected.length}
+                    {ctx.maxCount ? `/${ctx.maxCount}` : ''}
+                  </span>
+                )}
+                <ChevronDown className={cn('size-3.5 transition-transform duration-150', ctx.open && 'rotate-180')} />
+              </span>
+            </>
+          )}
+        </button>
+      </PopoverTrigger>
+    </PopoverAnchor>
   );
 };
 
@@ -243,6 +267,7 @@ const MultiSelectContent = ({
   ...props
 }: MultiSelectContentProps) => {
   const ctx = useMultiSelect();
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
   const enabled = ctx.options.filter((o) => !o.disabled);
   const allSelected = enabled.length > 0 && enabled.every((o) => ctx.value.includes(o.value));
@@ -265,12 +290,15 @@ const MultiSelectContent = ({
       sideOffset={6}
       data-slot="multi-select-content"
       className={cn('w-(--radix-popover-trigger-width) min-w-[14rem] p-0', className)}
-      onOpenAutoFocus={(e) => e.preventDefault()}
+      onOpenAutoFocus={(e) => {
+        e.preventDefault();
+        inputRef.current?.focus();
+      }}
       {...props}
     >
       <Command shouldFilter loop>
-        <CommandInput placeholder={searchPlaceholder} value={ctx.search} onValueChange={ctx.setSearch} />
-        <CommandList>
+        <CommandInput ref={inputRef} placeholder={searchPlaceholder} value={ctx.search} onValueChange={ctx.setSearch} />
+        <CommandList id={ctx.listboxId}>
           {ctx.loading ? (
             <div className="flex items-center justify-center gap-2 py-6 text-xs text-muted-foreground">
               <Loader2 className="size-3.5 animate-spin" />

--- a/registry/hirael/bases/radix/components/number-range.tsx
+++ b/registry/hirael/bases/radix/components/number-range.tsx
@@ -169,6 +169,7 @@ const NumberRangeInput = ({ bound, className, ...props }: NumberRangeInputProps)
       )}
       <Input
         inputMode="decimal"
+        dir="ltr"
         value={draft}
         disabled={ctx.disabled}
         onFocus={() => setEditing(true)}
@@ -189,8 +190,10 @@ const NumberRangeInput = ({ bound, className, ...props }: NumberRangeInputProps)
                 ? ([ctx.value[0] + delta * mult, ctx.value[1]] as NumberRangeValue)
                 : ([ctx.value[0], ctx.value[1] + delta * mult] as NumberRangeValue);
             ctx.setValue(next);
+            setDraft(format(next[i]));
           }
         }}
+        data-slot="number-range-field"
         className={cn('font-mono tabular-nums', ctx.prefix && 'ps-6', ctx.suffix && 'pe-8', className)}
         {...props}
       />

--- a/registry/hirael/bases/radix/components/password-input.tsx
+++ b/registry/hirael/bases/radix/components/password-input.tsx
@@ -63,7 +63,7 @@ const usePasswordContext = () => {
   return ctx;
 };
 
-export interface PasswordInputProps {
+export interface PasswordInputProps extends React.ComponentProps<'div'> {
   id?: string;
   value?: string;
   defaultValue?: string;
@@ -80,7 +80,9 @@ const PasswordInput = ({
   onValueChange,
   disabled,
   scorer = defaultPasswordScorer,
+  className,
   children,
+  ...props
 }: PasswordInputProps) => {
   const reactId = React.useId();
   const fieldId = id ?? reactId;
@@ -112,7 +114,13 @@ const PasswordInput = ({
     [fieldId, value, setValue, visible, disabled, strength],
   );
 
-  return <PasswordContext.Provider value={ctx}>{children}</PasswordContext.Provider>;
+  return (
+    <PasswordContext.Provider value={ctx}>
+      <div data-slot="password-input" className={cn('flex flex-col gap-2', className)} {...props}>
+        {children}
+      </div>
+    </PasswordContext.Provider>
+  );
 };
 
 interface PasswordInputFieldProps extends Omit<

--- a/registry/hirael/bases/radix/components/phone-input.tsx
+++ b/registry/hirael/bases/radix/components/phone-input.tsx
@@ -108,6 +108,7 @@ export interface PhoneInputProps extends Omit<React.ComponentProps<'div'>, 'chil
   onValueChange?: (e164: string) => void;
   defaultCountry?: string;
   disabled?: boolean;
+  name?: string;
   children?: React.ReactNode;
 }
 
@@ -118,6 +119,7 @@ const PhoneInput = ({
   onValueChange,
   defaultCountry = 'US',
   disabled,
+  name,
   className,
   children,
   ...props
@@ -187,6 +189,9 @@ const PhoneInput = ({
     [fieldId, country, setCountry, national, setNational, disabled, open],
   );
 
+  const nationalDigits = digitsOnly(national);
+  const e164 = nationalDigits ? `${country.dialCode}${nationalDigits}` : '';
+
   return (
     <PhoneInputContext.Provider value={ctx}>
       <InputGroup
@@ -196,6 +201,7 @@ const PhoneInput = ({
         {...props}
       >
         {children}
+        {name && <input type="hidden" name={name} value={e164} />}
       </InputGroup>
     </PhoneInputContext.Provider>
   );
@@ -205,6 +211,7 @@ type PhoneInputCountrySelectProps = Omit<React.ComponentProps<'button'>, 'childr
 
 const PhoneInputCountrySelect = ({ className, ...props }: PhoneInputCountrySelectProps) => {
   const ctx = usePhoneInput();
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
   return (
     <InputGroupAddon align="inline-start" data-slot="phone-input-country-select" className="cursor-pointer">
@@ -235,10 +242,11 @@ const PhoneInputCountrySelect = ({ className, ...props }: PhoneInputCountrySelec
           className="w-64 p-0"
           onOpenAutoFocus={(e) => {
             e.preventDefault();
+            inputRef.current?.focus();
           }}
         >
           <Command loop>
-            <CommandInput placeholder="Search countries…" />
+            <CommandInput ref={inputRef} placeholder="Search countries…" />
             <CommandList>
               <CommandEmpty>No country found.</CommandEmpty>
               <CommandGroup>

--- a/registry/hirael/bases/radix/components/qr-code.tsx
+++ b/registry/hirael/bases/radix/components/qr-code.tsx
@@ -498,7 +498,7 @@ const encodeQR = (value: string, level: QRCodeLevel = 'M'): boolean[][] => {
   return modules;
 };
 
-export interface QRCodeProps extends Omit<React.ComponentProps<'svg'>, 'children'> {
+export interface QRCodeProps extends Omit<React.ComponentProps<'svg'>, 'children' | 'onError'> {
   /** Text encoded into the QR symbol. */
   value: string;
   /** Error correction level. */
@@ -509,10 +509,12 @@ export interface QRCodeProps extends Omit<React.ComponentProps<'svg'>, 'children
   margin?: number;
   /** Accessible title announced by screen readers. */
   title?: string;
+  /** Called when the value fails to encode; an empty svg is still rendered. */
+  onError?: (error: unknown) => void;
 }
 
-const QRCode = ({ value, level = 'M', size = 128, margin = 2, title, className, ...props }: QRCodeProps) => {
-  const { d, dim } = React.useMemo(() => {
+const QRCode = ({ value, level = 'M', size = 128, margin = 2, title, onError, className, ...props }: QRCodeProps) => {
+  const { d, dim, error } = React.useMemo(() => {
     try {
       const matrix = encodeQR(value, level);
       let path = '';
@@ -521,24 +523,34 @@ const QRCode = ({ value, level = 'M', size = 128, margin = 2, title, className, 
           if (matrix[y][x]) path += `M${x + margin} ${y + margin}h1v1h-1z`;
         }
       }
-      return { d: path, dim: matrix.length + margin * 2 };
-    } catch {
-      return { d: '', dim: margin * 2 };
+      return { d: path, dim: matrix.length + margin * 2, error: null };
+    } catch (err) {
+      return { d: '', dim: margin * 2, error: err };
     }
   }, [value, level, margin]);
+
+  // Latest-ref: an inline `onError` changes identity every parent render and
+  // must not re-report the same failure each time.
+  const onErrorRef = React.useRef(onError);
+  React.useEffect(() => {
+    onErrorRef.current = onError;
+  }, [onError]);
+  React.useEffect(() => {
+    if (error !== null) onErrorRef.current?.(error);
+  }, [error]);
 
   return (
     <svg
       data-slot="qr-code"
       role="img"
-      aria-label={title ?? value}
+      data-error={error !== null || undefined}
       viewBox={`0 0 ${dim} ${dim}`}
       width={size}
       height={size}
       className={cn('shrink-0 text-foreground', className)}
       {...props}
     >
-      {title ? <title>{title}</title> : null}
+      <title>{title ?? `QR code for ${value}`}</title>
       <path data-slot="qr-code-path" d={d} fill="currentColor" shapeRendering="crispEdges" />
     </svg>
   );

--- a/registry/hirael/bases/radix/components/resizable-panels.tsx
+++ b/registry/hirael/bases/radix/components/resizable-panels.tsx
@@ -3,18 +3,35 @@
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
+import { composeRefs } from '@/registry/hirael/bases/radix/components/compose-refs';
 
 type ResizableDirection = 'horizontal' | 'vertical';
 
-const ResizableContext = React.createContext<ResizableDirection>('horizontal');
+interface ResizableContextValue {
+  direction: ResizableDirection;
+  resizeEpoch: number;
+  notifyResize: () => void;
+}
+
+const ResizableContext = React.createContext<ResizableContextValue>({
+  direction: 'horizontal',
+  resizeEpoch: 0,
+  notifyResize: () => {},
+});
 
 interface ResizablePanelGroupProps extends React.ComponentProps<'div'> {
   direction?: ResizableDirection;
 }
 
 const ResizablePanelGroup = ({ direction = 'horizontal', className, ...props }: ResizablePanelGroupProps) => {
+  const [resizeEpoch, setResizeEpoch] = React.useState(0);
+  const notifyResize = React.useCallback(() => setResizeEpoch((epoch) => epoch + 1), []);
+  const value = React.useMemo<ResizableContextValue>(
+    () => ({ direction, resizeEpoch, notifyResize }),
+    [direction, resizeEpoch, notifyResize],
+  );
   return (
-    <ResizableContext.Provider value={direction}>
+    <ResizableContext.Provider value={value}>
       <div
         data-slot="resizable-panel-group"
         data-direction={direction}
@@ -47,26 +64,43 @@ const ResizablePanel = ({ defaultSize = 50, minSize = 10, className, style, ...p
 type ResizableHandleProps = React.ComponentProps<'div'>;
 
 const ResizableHandle = ({ className, ref, ...props }: ResizableHandleProps) => {
-  const direction = React.useContext(ResizableContext);
+  const { direction, resizeEpoch, notifyResize } = React.useContext(ResizableContext);
   const isHorizontal = direction === 'horizontal';
   const localRef = React.useRef<HTMLDivElement | null>(null);
-  const [valueNow, setValueNow] = React.useState(50);
+  const [range, setRange] = React.useState({ now: 50, min: 0, max: 100 });
 
   const measure = React.useCallback(
     (handle: HTMLElement) => {
       const prev = handle.previousElementSibling as HTMLElement | null;
       const next = handle.nextElementSibling as HTMLElement | null;
-      if (!prev || !next) return 50;
+      if (!prev || !next) return { now: 50, min: 0, max: 100 };
       const prevSize = isHorizontal ? prev.clientWidth : prev.clientHeight;
       const nextSize = isHorizontal ? next.clientWidth : next.clientHeight;
       const totalSize = prevSize + nextSize;
-      return totalSize > 0 ? Math.round((prevSize / totalSize) * 100) : 50;
+      if (totalSize <= 0) return { now: 50, min: 0, max: 100 };
+      const group = handle.parentElement;
+      const groupSize = group ? (isHorizontal ? group.clientWidth : group.clientHeight) : totalSize;
+      const prevMin = (parseFloat(prev.dataset.minSize || '0') / 100) * groupSize;
+      const nextMin = (parseFloat(next.dataset.minSize || '0') / 100) * groupSize;
+      return {
+        now: Math.round((prevSize / totalSize) * 100),
+        min: Math.round((prevMin / totalSize) * 100),
+        max: Math.round(((totalSize - nextMin) / totalSize) * 100),
+      };
     },
     [isHorizontal],
   );
 
   React.useEffect(() => {
-    if (localRef.current) setValueNow(measure(localRef.current));
+    if (localRef.current) setRange(measure(localRef.current));
+  }, [measure, resizeEpoch]);
+
+  React.useEffect(() => {
+    const onWindowResize = () => {
+      if (localRef.current) setRange(measure(localRef.current));
+    };
+    window.addEventListener('resize', onWindowResize);
+    return () => window.removeEventListener('resize', onWindowResize);
   }, [measure]);
 
   const resize = (handle: HTMLElement, deltaPx: number) => {
@@ -88,7 +122,19 @@ const ResizableHandle = ({ className, ref, ...props }: ResizableHandleProps) => 
     const newPrevGrow = (newPrev / totalSize) * totalGrow;
     prev.style.flexGrow = String(newPrevGrow);
     next.style.flexGrow = String(totalGrow - newPrevGrow);
-    if (totalSize > 0) setValueNow(Math.round((newPrev / totalSize) * 100));
+    if (totalSize <= 0) return;
+    // Derived from the numbers already in hand: re-measuring after the style
+    // writes would force a synchronous layout on every pointermove.
+    const nextRange = {
+      now: Math.round((newPrev / totalSize) * 100),
+      min: Math.round((prevMin / totalSize) * 100),
+      max: Math.round(((totalSize - nextMin) / totalSize) * 100),
+    };
+    setRange((current) =>
+      current.now === nextRange.now && current.min === nextRange.min && current.max === nextRange.max
+        ? current
+        : nextRange,
+    );
   };
 
   const onPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
@@ -105,12 +151,18 @@ const ResizableHandle = ({ className, ref, ...props }: ResizableHandleProps) => 
       resize(handle, delta);
     };
     const onUp = (ev: PointerEvent) => {
-      handle.releasePointerCapture(ev.pointerId);
+      if (handle.hasPointerCapture(ev.pointerId)) {
+        handle.releasePointerCapture(ev.pointerId);
+      }
       handle.removeEventListener('pointermove', onMove);
       handle.removeEventListener('pointerup', onUp);
+      handle.removeEventListener('pointercancel', onUp);
+      // Siblings share the space that moved; they re-measure once, not per pointermove.
+      notifyResize();
     };
     handle.addEventListener('pointermove', onMove);
     handle.addEventListener('pointerup', onUp);
+    handle.addEventListener('pointercancel', onUp);
   };
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -132,22 +184,21 @@ const ResizableHandle = ({ className, ref, ...props }: ResizableHandleProps) => 
     if (dir !== 0) {
       event.preventDefault();
       resize(handle, dir * step * groupSize);
+      notifyResize();
     }
   };
 
+  const composedRef = React.useMemo(() => composeRefs(localRef, ref), [ref]);
+
   return (
     <div
-      ref={(node) => {
-        localRef.current = node;
-        if (typeof ref === 'function') ref(node);
-        else if (ref) ref.current = node;
-      }}
+      ref={composedRef}
       role="separator"
       tabIndex={0}
       aria-orientation={isHorizontal ? 'vertical' : 'horizontal'}
-      aria-valuenow={valueNow}
-      aria-valuemin={0}
-      aria-valuemax={100}
+      aria-valuenow={range.now}
+      aria-valuemin={range.min}
+      aria-valuemax={range.max}
       data-slot="resizable-handle"
       onPointerDown={onPointerDown}
       onKeyDown={onKeyDown}

--- a/registry/hirael/bases/radix/components/rich-text-editor.tsx
+++ b/registry/hirael/bases/radix/components/rich-text-editor.tsx
@@ -121,7 +121,7 @@ const contentClassName = cn(
   '[&_.ProseMirror_p.is-editor-empty:first-child]:before:pointer-events-none [&_.ProseMirror_p.is-editor-empty:first-child]:before:float-start [&_.ProseMirror_p.is-editor-empty:first-child]:before:h-0 [&_.ProseMirror_p.is-editor-empty:first-child]:before:text-muted-foreground [&_.ProseMirror_p.is-editor-empty:first-child]:before:content-[attr(data-placeholder)]',
 );
 
-export interface RichTextEditorProps {
+export interface RichTextEditorProps extends Omit<React.ComponentProps<'div'>, 'onChange'> {
   value?: string;
   onChange?: (value: string) => void;
   defaultValue?: string;
@@ -145,6 +145,7 @@ const RichTextEditor = ({
   onBlur,
   className,
   children,
+  ...props
 }: RichTextEditorProps) => {
   const isEditable = editable && !disabled;
 
@@ -241,6 +242,7 @@ const RichTextEditor = ({
           disabled && 'cursor-not-allowed opacity-50',
           className,
         )}
+        {...props}
       >
         {children ?? (
           <>
@@ -303,6 +305,7 @@ const RichTextEditorButton = ({
           pressed={pressed}
           onPressedChange={onPressedChange}
           disabled={disabled}
+          aria-label={tooltip}
           className={className}
         >
           {children}
@@ -372,6 +375,7 @@ const RichTextEditorLinkPopover = () => {
               size="sm"
               pressed={isLink}
               onPressedChange={() => handleOpen(!open)}
+              aria-label="Link"
             >
               <LinkIcon className="size-4" />
             </Toggle>
@@ -516,11 +520,17 @@ const RichTextEditorLinkBubble = () => {
 
   React.useEffect(() => {
     if (!target) return;
-    window.addEventListener('scroll', reposition, true);
-    window.addEventListener('resize', reposition);
+    let raf = 0;
+    const scheduleReposition = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(reposition);
+    };
+    window.addEventListener('scroll', scheduleReposition, true);
+    window.addEventListener('resize', scheduleReposition);
     return () => {
-      window.removeEventListener('scroll', reposition, true);
-      window.removeEventListener('resize', reposition);
+      cancelAnimationFrame(raf);
+      window.removeEventListener('scroll', scheduleReposition, true);
+      window.removeEventListener('resize', scheduleReposition);
     };
   }, [target]);
 

--- a/registry/hirael/bases/radix/components/signature-pad.tsx
+++ b/registry/hirael/bases/radix/components/signature-pad.tsx
@@ -89,6 +89,7 @@ const SignaturePad = ({
   className,
   children,
   ref,
+  'aria-label': ariaLabel,
   ...props
 }: SignaturePadProps) => {
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
@@ -289,7 +290,8 @@ const SignaturePad = ({
           ref={canvasRef}
           data-slot="signature-pad-canvas"
           role="img"
-          aria-label="Signature pad"
+          aria-roledescription="signature pad"
+          aria-label={ariaLabel ?? 'Signature pad. Draw using a mouse or touch.'}
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={endStroke}
@@ -335,7 +337,7 @@ const SignaturePadClear = ({ className, children, ...props }: React.ComponentPro
       data-slot="signature-pad-clear"
       disabled={ctx.disabled || ctx.empty}
       onClick={() => ctx.clear()}
-      className={cn(className)}
+      className={className}
       {...props}
     >
       <Eraser aria-hidden />
@@ -354,7 +356,7 @@ const SignaturePadUndo = ({ className, children, ...props }: React.ComponentProp
       data-slot="signature-pad-undo"
       disabled={ctx.disabled || ctx.empty}
       onClick={() => ctx.undo()}
-      className={cn(className)}
+      className={className}
       {...props}
     >
       <Undo2 aria-hidden />

--- a/registry/hirael/bases/radix/components/sortable.tsx
+++ b/registry/hirael/bases/radix/components/sortable.tsx
@@ -103,9 +103,11 @@ const Sortable = ({
   const order = preview ?? committed;
 
   const orderRef = React.useRef(order);
-  orderRef.current = order;
   const committedRef = React.useRef(committed);
-  committedRef.current = committed;
+  React.useLayoutEffect(() => {
+    orderRef.current = order;
+    committedRef.current = committed;
+  }, [order, committed]);
 
   const itemsRef = React.useRef(new Map<string, ItemEntry>());
   const pressRef = React.useRef<{

--- a/registry/hirael/bases/radix/components/sparkles.tsx
+++ b/registry/hirael/bases/radix/components/sparkles.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
+import { composeRefs } from '@/registry/hirael/bases/radix/components/compose-refs';
 
 interface SparklesProps extends React.ComponentProps<'div'> {
   /**
@@ -43,19 +44,21 @@ const Sparkles = ({
   color = 'var(--foreground)',
   opacity = 1,
   className,
+  ref,
   ...props
 }: SparklesProps) => {
   const containerRef = React.useRef<HTMLDivElement>(null);
+  const composedRef = React.useMemo(() => composeRefs(containerRef, ref), [ref]);
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
 
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     const container = containerRef.current;
     const canvas = canvasRef.current;
     const ctx = canvas?.getContext('2d');
     if (!container || !canvas || !ctx) return;
 
     const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    const fill = resolveColor(container, color);
+    let fill = resolveColor(container, color);
     let particles: Particle[] = [];
     let width = 0;
     let height = 0;
@@ -119,6 +122,7 @@ const Sparkles = ({
     };
 
     const resize = () => {
+      fill = resolveColor(container, color);
       const rect = container.getBoundingClientRect();
       const dpr = window.devicePixelRatio || 1;
       width = rect.width;
@@ -133,6 +137,14 @@ const Sparkles = ({
     resize();
     const ro = new ResizeObserver(resize);
     ro.observe(container);
+    const mo = new MutationObserver(() => {
+      fill = resolveColor(container, color);
+      if (reduced) draw(0, 0);
+    });
+    mo.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'style'],
+    });
     const io = new IntersectionObserver(([entry]) => {
       isVisible = entry.isIntersecting;
       sync();
@@ -144,6 +156,7 @@ const Sparkles = ({
     return () => {
       stop();
       ro.disconnect();
+      mo.disconnect();
       io.disconnect();
       document.removeEventListener('visibilitychange', sync);
     };
@@ -151,7 +164,7 @@ const Sparkles = ({
 
   return (
     <div
-      ref={containerRef}
+      ref={composedRef}
       data-slot="sparkles"
       aria-hidden
       className={cn('pointer-events-none absolute inset-0', className)}

--- a/registry/hirael/bases/radix/components/split-view.tsx
+++ b/registry/hirael/bases/radix/components/split-view.tsx
@@ -3,12 +3,15 @@
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
+import { composeRefs } from '@/registry/hirael/bases/radix/components/compose-refs';
 
 type SplitOrientation = 'horizontal' | 'vertical';
 
 interface SplitViewContextValue {
   orientation: SplitOrientation;
   size: number;
+  minSize: number;
+  maxSize: number;
   dragging: boolean;
   onResizerPointerDown: (event: React.PointerEvent) => void;
   onResizerKeyDown: (event: React.KeyboardEvent) => void;
@@ -46,9 +49,11 @@ const SplitView = ({
   className,
   style,
   children,
+  ref: consumerRef,
   ...props
 }: SplitViewProps) => {
   const ref = React.useRef<HTMLDivElement>(null);
+  const composedRef = React.useMemo(() => composeRefs(ref, consumerRef), [consumerRef]);
   const [size, setSize] = React.useState(defaultSize);
   const [dragging, setDragging] = React.useState(false);
 
@@ -82,10 +87,12 @@ const SplitView = ({
         }
         handle.removeEventListener('pointermove', onMove);
         handle.removeEventListener('pointerup', onUp);
+        handle.removeEventListener('pointercancel', onUp);
         setDragging(false);
       };
       handle.addEventListener('pointermove', onMove);
       handle.addEventListener('pointerup', onUp);
+      handle.addEventListener('pointercancel', onUp);
     },
     [resizeToPointer],
   );
@@ -114,17 +121,19 @@ const SplitView = ({
     () => ({
       orientation,
       size,
+      minSize,
+      maxSize,
       dragging,
       onResizerPointerDown,
       onResizerKeyDown,
     }),
-    [orientation, size, dragging, onResizerPointerDown, onResizerKeyDown],
+    [orientation, size, minSize, maxSize, dragging, onResizerPointerDown, onResizerKeyDown],
   );
 
   return (
     <SplitViewContext.Provider value={value}>
       <div
-        ref={ref}
+        ref={composedRef}
         data-slot="split-view"
         data-orientation={orientation}
         className={cn(
@@ -153,15 +162,15 @@ const SplitViewPanel = ({ className, ...props }: SplitViewPanelProps) => {
 type SplitViewResizerProps = React.ComponentProps<'div'>;
 
 const SplitViewResizer = ({ className, ...props }: SplitViewResizerProps) => {
-  const { orientation, size, dragging, onResizerPointerDown, onResizerKeyDown } = useSplitView();
+  const { orientation, size, minSize, maxSize, dragging, onResizerPointerDown, onResizerKeyDown } = useSplitView();
   return (
     <div
       role="separator"
       tabIndex={0}
       aria-orientation={orientation === 'horizontal' ? 'vertical' : 'horizontal'}
       aria-valuenow={Math.round(size)}
-      aria-valuemin={0}
-      aria-valuemax={100}
+      aria-valuemin={minSize}
+      aria-valuemax={maxSize}
       data-slot="split-view-resizer"
       data-dragging={dragging ? '' : undefined}
       onPointerDown={onResizerPointerDown}

--- a/registry/hirael/bases/radix/components/spotlight-card.tsx
+++ b/registry/hirael/bases/radix/components/spotlight-card.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { motion, useMotionTemplate, useMotionValue } from 'motion/react';
+import { motion, useMotionTemplate, useMotionValue, useReducedMotion } from 'motion/react';
 
 import { cn } from '@/lib/utils';
 
@@ -11,11 +11,13 @@ interface SpotlightCardProps extends React.ComponentProps<'div'> {
 }
 
 const SpotlightCard = ({ className, children, size = 350, ...props }: SpotlightCardProps) => {
+  const reduced = useReducedMotion();
   const x = useMotionValue(0);
   const y = useMotionValue(0);
   const background = useMotionTemplate`radial-gradient(${size}px circle at ${x}px ${y}px, color-mix(in oklch, var(--foreground) 10%, transparent), transparent 70%)`;
 
   const onPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (reduced) return;
     const rect = event.currentTarget.getBoundingClientRect();
     x.set(event.clientX - rect.left);
     y.set(event.clientY - rect.top);

--- a/registry/hirael/bases/radix/components/stepper.tsx
+++ b/registry/hirael/bases/radix/components/stepper.tsx
@@ -72,6 +72,7 @@ const Stepper = ({
   return (
     <StepperContext.Provider value={ctx}>
       <div
+        role="list"
         data-slot="stepper"
         data-orientation={orientation}
         className={cn(
@@ -103,6 +104,7 @@ const StepperItem = ({ step, completed, disabled = false, className, ...props }:
   return (
     <StepperItemContext.Provider value={ctx}>
       <div
+        role="listitem"
         data-slot="stepper-item"
         data-state={state}
         className={cn(

--- a/registry/hirael/bases/radix/components/tag-input.tsx
+++ b/registry/hirael/bases/radix/components/tag-input.tsx
@@ -38,7 +38,7 @@ const useTagInput = () => {
   return ctx;
 };
 
-export interface TagInputProps {
+export interface TagInputProps extends Omit<React.ComponentProps<'div'>, 'defaultValue'> {
   value?: string[];
   defaultValue?: string[];
   onValueChange?: (value: string[]) => void;
@@ -65,7 +65,9 @@ const TagInput = ({
   validate,
   commitKeys = ['Enter', ','],
   splitOn = /[,\n\t]+/,
+  className,
   children,
+  ...props
 }: TagInputProps) => {
   const [internalValue, setInternalValue] = React.useState<string[]>(defaultValue ?? []);
   const value = valueProp ?? internalValue;
@@ -171,7 +173,13 @@ const TagInput = ({
     ],
   );
 
-  return <TagInputContext.Provider value={ctx}>{children}</TagInputContext.Provider>;
+  return (
+    <TagInputContext.Provider value={ctx}>
+      <div data-slot="tag-input" className={cn('flex flex-col gap-2', className)} {...props}>
+        {children}
+      </div>
+    </TagInputContext.Provider>
+  );
 };
 
 type TagInputContainerProps = React.ComponentProps<'div'>;

--- a/registry/hirael/bases/radix/components/text-reveal.tsx
+++ b/registry/hirael/bases/radix/components/text-reveal.tsx
@@ -61,9 +61,12 @@ const TextReveal = ({
 
   return (
     <Tag ref={ref} data-slot="text-reveal" className={cn(by === 'line' && 'flex flex-col', className)} {...props}>
+      {/* The split units are decorative, and a role-less element ignores aria-label. */}
+      <span className="sr-only">{children}</span>
       {units.map((unit, i) => (
         <React.Fragment key={i}>
           <span
+            aria-hidden
             data-slot="text-reveal-unit"
             className={cn('overflow-hidden pb-[0.12em]', by === 'line' ? 'flex' : 'inline-flex align-bottom')}
           >

--- a/registry/hirael/bases/radix/components/time-picker.tsx
+++ b/registry/hirael/bases/radix/components/time-picker.tsx
@@ -52,7 +52,9 @@ const clampStep = (value: number, step: number, max: number) => {
 export interface TimePickerProps {
   value?: TimeValue | null;
   defaultValue?: TimeValue;
-  onValueChange?: (v: TimeValue) => void;
+  /** Reports every change, including `null` when the value is cleared. */
+  onValueChange?: (v: TimeValue | null) => void;
+  /** Side-effect hook for the clear button. State still arrives via `onValueChange`. */
   onClear?: () => void;
   clearable?: boolean;
   format?: TimeFormat;
@@ -83,7 +85,7 @@ const TimePicker = ({
   children,
 }: TimePickerProps) => {
   const [openInternal, setOpenInternal] = React.useState(defaultOpen);
-  const open = openProp ?? openInternal;
+  const open = openProp !== undefined ? openProp : openInternal;
   const setOpen = React.useCallback(
     (next: boolean) => {
       if (openProp === undefined) setOpenInternal(next);
@@ -105,8 +107,9 @@ const TimePicker = ({
 
   const clearValue = React.useCallback(() => {
     if (valueProp === undefined) setInternal(null);
+    onValueChange?.(null);
     onClear?.();
-  }, [valueProp, onClear]);
+  }, [valueProp, onValueChange, onClear]);
 
   const ctx = React.useMemo<TimePickerContextValue>(
     () => ({
@@ -172,7 +175,9 @@ const TimePickerTrigger = ({
         {...props}
       >
         <Clock className="size-3.5 shrink-0 text-muted-foreground" />
-        <span className="flex-1 truncate">{children ?? label ?? placeholder}</span>
+        <span data-slot="time-picker-trigger-label" className="flex-1 truncate">
+          {children ?? label ?? placeholder}
+        </span>
       </button>
     </PopoverTrigger>
   );
@@ -332,7 +337,7 @@ const TimePickerContent = ({ className, ...props }: React.ComponentProps<typeof 
 
   return (
     <PopoverContent align="start" data-slot="time-picker-content" className={cn('w-auto p-3', className)} {...props}>
-      <div className="flex items-stretch gap-2">
+      <div data-slot="time-picker-columns" className="flex items-stretch gap-2">
         <ScrollColumn values={hourValues} selected={displayHour} onSelect={setHour} ariaLabel="Hour" />
         <span aria-hidden className="flex items-center font-mono text-sm text-muted-foreground">
           :
@@ -365,7 +370,7 @@ const TimePickerContent = ({ className, ...props }: React.ComponentProps<typeof 
         </Tabs>
       )}
       {ctx.clearable && ctx.value && (
-        <div className="mt-3 flex justify-end">
+        <div data-slot="time-picker-content-footer" className="mt-3 flex justify-end">
           <Button
             type="button"
             variant="ghost"

--- a/registry/hirael/bases/radix/components/toc.tsx
+++ b/registry/hirael/bases/radix/components/toc.tsx
@@ -66,10 +66,11 @@ const prefersReducedMotion = () => {
 
 const TOP_OFFSET = 56;
 
-const useActiveHeading = (items: TocItem[]) => {
+const useActiveHeading = (items: TocItem[], enabled: boolean) => {
   const [activeId, setActiveId] = React.useState<string | null>(null);
 
   React.useEffect(() => {
+    if (!enabled) return;
     const headings = flattenTocItems(items);
 
     const update = () => {
@@ -106,7 +107,7 @@ const useActiveHeading = (items: TocItem[]) => {
       window.removeEventListener('scroll', onScroll);
       window.removeEventListener('resize', onScroll);
     };
-  }, [items]);
+  }, [items, enabled]);
 
   return activeId;
 };
@@ -141,8 +142,9 @@ const TableOfContents = ({
   'aria-label': ariaLabel,
   ...props
 }: TableOfContentsProps) => {
-  const trackedActiveId = useActiveHeading(controlledActiveId ? [] : (items ?? []));
+  const trackedActiveId = useActiveHeading(items ?? [], controlledActiveId === undefined);
   const activeId = controlledActiveId !== undefined ? controlledActiveId : trackedActiveId;
+  const contextValue = React.useMemo(() => ({ activeId }), [activeId]);
 
   const content =
     children ??
@@ -156,7 +158,7 @@ const TableOfContents = ({
   if (!content) return null;
 
   return (
-    <TocContext.Provider value={{ activeId }}>
+    <TocContext.Provider value={contextValue}>
       <nav
         data-slot="toc"
         aria-label={ariaLabel ?? 'On this page'}
@@ -256,7 +258,7 @@ const TableOfContentsLink = ({
       data-slot="toc-link"
       data-active={isActive ? '' : undefined}
       href={href}
-      aria-current={isActive ? 'true' : undefined}
+      aria-current={isActive ? 'location' : undefined}
       onClick={handleClick}
       className={cn(
         '-ms-px block border-s py-1 ps-4 text-sm transition-colors duration-150 ease-out',

--- a/registry/hirael/bases/radix/components/tour.tsx
+++ b/registry/hirael/bases/radix/components/tour.tsx
@@ -348,10 +348,11 @@ const TourOverlay = ({ steps, step, stop, next, back, scrollIntoView, padding, l
     const first = focusables[0];
     const last = focusables[focusables.length - 1];
     const active = document.activeElement;
-    if (e.shiftKey && (active === first || active === card)) {
+    const outside = active === null || !Array.from(focusables).includes(active as HTMLElement);
+    if (e.shiftKey && (active === first || outside)) {
       e.preventDefault();
       last.focus();
-    } else if (!e.shiftKey && active === last) {
+    } else if (!e.shiftKey && (active === last || outside)) {
       e.preventDefault();
       first.focus();
     }

--- a/registry/hirael/bases/radix/components/tree-view.tsx
+++ b/registry/hirael/bases/radix/components/tree-view.tsx
@@ -118,7 +118,10 @@ export interface TreeItemProps extends Omit<React.ComponentProps<'div'>, 'title'
   label: React.ReactNode;
   /** Override the leading icon. Pass `null` to hide it entirely. */
   icon?: React.ReactNode;
+  /** Controlled expanded state. Pair with `onExpandedChange`. */
+  expanded?: boolean;
   defaultExpanded?: boolean;
+  onExpandedChange?: (expanded: boolean) => void;
   disabled?: boolean;
 }
 
@@ -126,7 +129,9 @@ const TreeItem = ({
   value,
   label,
   icon,
+  expanded: expandedProp,
   defaultExpanded = false,
+  onExpandedChange,
   disabled = false,
   className,
   children,
@@ -136,7 +141,16 @@ const TreeItem = ({
   const depth = React.useContext(TreeDepthContext);
   const parentTriggerRef = React.useContext(TreeParentContext);
   const triggerRef = React.useRef<HTMLButtonElement>(null);
-  const [open, setOpen] = React.useState(defaultExpanded);
+  const [internalOpen, setInternalOpen] = React.useState(defaultExpanded);
+  const open = expandedProp ?? internalOpen;
+
+  const setOpen = React.useCallback(
+    (next: boolean) => {
+      if (expandedProp === undefined) setInternalOpen(next);
+      onExpandedChange?.(next);
+    },
+    [expandedProp, onExpandedChange],
+  );
 
   const hasChildren = React.Children.count(children) > 0;
   const isSelected = !hasChildren && selected === value;
@@ -146,6 +160,18 @@ const TreeItem = ({
     if (!el) return;
     return registerItem(value, el);
   }, [registerItem, value]);
+
+  // An unmounting item that holds focus (e.g. an ancestor collapsed) hands it
+  // to the parent trigger instead of dropping it to <body>. Kept apart from the
+  // registration effect, which re-runs on `value` changes while the item stays mounted.
+  React.useLayoutEffect(() => {
+    const el = triggerRef.current;
+    const parentTrigger = parentTriggerRef?.current ?? null;
+    return () => {
+      const holdsFocus = el?.closest('[data-slot="tree-item"]')?.contains(document.activeElement) ?? false;
+      if (holdsFocus) parentTrigger?.focus();
+    };
+  }, [parentTriggerRef]);
 
   const onTriggerKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
     const { key } = event;
@@ -237,7 +263,14 @@ const TreeItem = ({
   if (hasChildren) {
     return (
       <Collapsible asChild open={open} onOpenChange={setOpen}>
-        <div data-slot="tree-item" role="treeitem" aria-selected={isSelected} aria-expanded={open} {...props}>
+        <div
+          data-slot="tree-item"
+          role="treeitem"
+          aria-selected={isSelected}
+          aria-expanded={open}
+          aria-level={depth + 1}
+          {...props}
+        >
           <CollapsibleTrigger asChild>
             <button {...triggerProps}>{labelRow}</button>
           </CollapsibleTrigger>
@@ -254,7 +287,7 @@ const TreeItem = ({
   }
 
   return (
-    <div data-slot="tree-item" role="treeitem" aria-selected={isSelected} {...props}>
+    <div data-slot="tree-item" role="treeitem" aria-selected={isSelected} aria-level={depth + 1} {...props}>
       <button {...triggerProps} data-state={isSelected ? 'selected' : undefined} onClick={() => setSelected(value)}>
         {labelRow}
       </button>

--- a/registry/hirael/bases/radix/components/yaml-editor.tsx
+++ b/registry/hirael/bases/radix/components/yaml-editor.tsx
@@ -80,7 +80,7 @@ const tokenizeLine = (line: string): Token[] => {
   return tokens;
 };
 
-const HighlightLine = ({ line }: { line: string }) => {
+const HighlightLine = React.memo(function HighlightLine({ line }: { line: string }) {
   const tokens = tokenizeLine(line);
   return (
     <span className="block min-h-[1.25rem]">
@@ -93,7 +93,7 @@ const HighlightLine = ({ line }: { line: string }) => {
           ))}
     </span>
   );
-};
+});
 
 interface YamlEditorProps extends Omit<React.ComponentProps<'div'>, 'onChange' | 'defaultValue'> {
   value?: string;
@@ -121,6 +121,9 @@ const YamlEditor = ({
 
   const preRef = React.useRef<HTMLPreElement>(null);
   const gutterRef = React.useRef<HTMLDivElement>(null);
+  const caretRafRef = React.useRef(0);
+
+  React.useEffect(() => () => cancelAnimationFrame(caretRafRef.current), []);
 
   const lines = text.split('\n');
 
@@ -148,7 +151,7 @@ const YamlEditor = ({
     const next = text.slice(0, start) + '  ' + text.slice(end);
     if (!isControlled) setInternal(next);
     onValueChange?.(next);
-    requestAnimationFrame(() => {
+    caretRafRef.current = requestAnimationFrame(() => {
       el.selectionStart = el.selectionEnd = start + 2;
     });
   };
@@ -190,6 +193,7 @@ const YamlEditor = ({
         </pre>
         <textarea
           data-slot="yaml-editor-input"
+          aria-label="YAML editor"
           spellCheck={false}
           autoComplete="off"
           autoCapitalize="off"

--- a/registry/hirael/bases/radix/components/year-picker.tsx
+++ b/registry/hirael/bases/radix/components/year-picker.tsx
@@ -121,8 +121,9 @@ const YearPicker = (props: YearPickerProps) => {
   const [singleInternal, setSingleInternal] = React.useState<number | undefined>(singleDefaultValue);
   const [rangeInternal, setRangeInternal] = React.useState<YearRange | undefined>(rangeDefaultValue);
 
-  const singleValue = mode === 'single' ? (singleValueProp ?? singleInternal) : undefined;
-  const rangeValue = mode === 'range' ? (rangeValueProp ?? rangeInternal) : undefined;
+  const singleValue =
+    mode === 'single' ? (singleValueProp !== undefined ? singleValueProp : singleInternal) : undefined;
+  const rangeValue = mode === 'range' ? (rangeValueProp !== undefined ? rangeValueProp : rangeInternal) : undefined;
 
   const anchorYear = (mode === 'single' ? singleValue : rangeValue?.from) ?? new Date().getFullYear();
   const [decadeStart, setDecadeStart] = React.useState<number>(viewStartFor(anchorYear));
@@ -315,10 +316,10 @@ const YearPickerContent = ({ className, ...props }: React.ComponentProps<typeof 
         next = year + (3 - ((year - ctx.decadeStart) % 4));
         break;
       case 'PageUp':
-        ctx.setDecadeStart(ctx.decadeStart - YEARS_PER_VIEW);
+        ctx.setDecadeStart(Math.max(ctx.minYear - 1, ctx.decadeStart - YEARS_PER_VIEW));
         return;
       case 'PageDown':
-        ctx.setDecadeStart(ctx.decadeStart + YEARS_PER_VIEW);
+        ctx.setDecadeStart(Math.min(ctx.maxYear + 1 - YEARS_PER_VIEW, ctx.decadeStart + YEARS_PER_VIEW));
         return;
       default:
         return;

--- a/registry/hirael/bases/radix/examples/time-picker-demo.tsx
+++ b/registry/hirael/bases/radix/examples/time-picker-demo.tsx
@@ -13,8 +13,8 @@ import {
 
 const TimePickerDemo = () => {
   const t = useT();
-  const [t24, setT24] = React.useState<TimeValue>({ hour: 14, minute: 30 });
-  const [t12, setT12] = React.useState<TimeValue>({
+  const [t24, setT24] = React.useState<TimeValue | null>({ hour: 14, minute: 30 });
+  const [t12, setT12] = React.useState<TimeValue | null>({
     hour: 9,
     minute: 15,
     second: 0,
@@ -29,7 +29,7 @@ const TimePickerDemo = () => {
           <TimePickerContent />
         </TimePicker>
         <p className="font-mono text-[10px] tracking-[0.08em] text-muted-foreground uppercase">
-          {`${t24.hour}:${t24.minute.toString().padStart(2, '0')}`}
+          {t24 ? `${t24.hour}:${t24.minute.toString().padStart(2, '0')}` : t({ en: 'Not set', ar: 'غير محدد' })}
         </p>
       </Field>
 
@@ -42,7 +42,9 @@ const TimePickerDemo = () => {
           <TimePickerContent />
         </TimePicker>
         <p className="font-mono text-[10px] tracking-[0.08em] text-muted-foreground uppercase">
-          {`${t12.hour}:${t12.minute.toString().padStart(2, '0')}:${(t12.second ?? 0).toString().padStart(2, '0')}`}
+          {t12
+            ? `${t12.hour}:${t12.minute.toString().padStart(2, '0')}:${(t12.second ?? 0).toString().padStart(2, '0')}`
+            : t({ en: 'Not set', ar: 'غير محدد' })}
         </p>
       </Field>
     </FieldGroup>

--- a/registry/hirael/registry-meta.ts
+++ b/registry/hirael/registry-meta.ts
@@ -794,7 +794,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
       'SV gradient + hue slider with HEX / RGB / HSL tabs, eyedropper (where supported) and recent swatches.',
     category: 'pickers',
     files: [{ path: 'components/color-picker.tsx' }],
-    registryDependencies: ['button', 'input', 'popover', 'tabs'],
+    registryDependencies: ['button', 'input', 'popover', 'tabs', 'compose-refs'],
     dependencies: ['lucide-react'],
   },
   {
@@ -1199,7 +1199,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
       'Single-date picker with month grid, keyboard nav, min/max bounds and disabled dates. Includes an inline DateCalendar, no date library.',
     category: 'pickers',
     files: [{ path: 'components/date-picker.tsx' }],
-    registryDependencies: ['button', 'popover', 'calendar-utils'],
+    registryDependencies: ['button', 'popover', 'calendar-utils', 'compose-refs'],
     dependencies: ['lucide-react'],
   },
   {
@@ -1209,7 +1209,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
       'Dual-month range picker with hover preview, presets, min/max bounds and keyboard nav. Includes an inline DateRangeCalendar, no date library.',
     category: 'pickers',
     files: [{ path: 'components/date-range-picker.tsx' }],
-    registryDependencies: ['button', 'popover', 'separator', 'calendar-utils'],
+    registryDependencies: ['button', 'popover', 'separator', 'calendar-utils', 'compose-refs'],
     dependencies: ['lucide-react'],
   },
   {
@@ -1219,7 +1219,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
       '@-mention textarea with caret-anchored autocomplete, highlighted mention chips, async search and multiple trigger characters.',
     category: 'inputs',
     files: [{ path: 'components/mention-input.tsx' }],
-    registryDependencies: ['spinner'],
+    registryDependencies: ['spinner', 'compose-refs'],
     dependencies: [],
   },
   {
@@ -1249,7 +1249,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
       'Click-to-edit text with preview, validation, async submit and confirm/cancel controls. Input and textarea modes.',
     category: 'inputs',
     files: [{ path: 'components/inline-edit.tsx' }],
-    registryDependencies: ['button', 'input', 'spinner', 'textarea'],
+    registryDependencies: ['button', 'input', 'spinner', 'textarea', 'compose-refs'],
     dependencies: ['lucide-react'],
   },
   {
@@ -1279,7 +1279,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
       'Before/after comparison slider with a draggable, keyboard-accessible divider, horizontal or vertical orientation and hover-follow mode.',
     category: 'display',
     files: [{ path: 'components/image-compare.tsx' }],
-    registryDependencies: [],
+    registryDependencies: ['compose-refs'],
     dependencies: ['lucide-react'],
   },
   {
@@ -1473,7 +1473,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
       'Canvas particle field that drifts and twinkles behind any container. Density scales with size, colors resolve from tokens, and it pauses offscreen and under reduced-motion. No dependencies.',
     category: 'animation',
     files: [{ path: 'components/sparkles.tsx' }],
-    registryDependencies: [],
+    registryDependencies: ['compose-refs'],
     dependencies: [],
   },
   {
@@ -1503,7 +1503,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
       'macOS-style dock with cursor magnification: icons scale and spring as the pointer passes, with hover and focus labels. Built on motion.',
     category: 'navigation',
     files: [{ path: 'components/dock.tsx' }],
-    registryDependencies: [],
+    registryDependencies: ['compose-refs'],
     dependencies: ['motion'],
   },
   {
@@ -1533,7 +1533,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
       'Two-pane master/detail layout with a draggable divider, keyboard resize, min/max bounds and horizontal or vertical orientation. RTL-aware.',
     category: 'navigation',
     files: [{ path: 'components/split-view.tsx' }],
-    registryDependencies: [],
+    registryDependencies: ['compose-refs'],
     dependencies: [],
   },
   {
@@ -1543,7 +1543,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
       'Composable resizable panel groups with draggable, keyboard-accessible handles, per-panel minimums and nestable horizontal or vertical groups. RTL-aware.',
     category: 'navigation',
     files: [{ path: 'components/resizable-panels.tsx' }],
-    registryDependencies: [],
+    registryDependencies: ['compose-refs'],
     dependencies: [],
   },
   {
@@ -3295,7 +3295,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
       'Self-contained emoji grid with 560+ emoji in 8 categories, keyword search, recents, skin tones, and arrow-key navigation. No dependencies.',
     category: 'pickers',
     files: [{ path: 'components/emoji-picker.tsx' }],
-    registryDependencies: ['input'],
+    registryDependencies: ['input', 'compose-refs'],
     dependencies: ['lucide-react'],
   },
   {
@@ -3305,7 +3305,7 @@ export const REGISTRY: RegistryEntryMeta[] = [
       'Click or drop an image, crop it to a circle or square with zoom, and preview the result. Initials fallback, size and type limits, remove control.',
     category: 'files',
     files: [{ path: 'components/avatar-upload.tsx' }],
-    registryDependencies: ['button', 'dialog', 'image-cropper'],
+    registryDependencies: ['button', 'dialog', 'image-cropper', 'compose-refs'],
     dependencies: ['lucide-react'],
   },
   {
@@ -3706,6 +3706,17 @@ export const DISTRIBUTION_ONLY: DistributionOnlyEntry[] = [
     files: [{ path: 'ui/accordion.tsx' }],
     registryDependencies: [],
     dependencies: ['radix-ui', 'lucide-react'],
+  },
+  {
+    name: 'compose-refs',
+    title: 'Compose Refs',
+    description:
+      'Fans one node out to several refs, so a part can keep its own internal ref while still forwarding the element to the consumer.',
+    type: 'registry:component',
+    categories: ['primitives'],
+    files: [{ path: 'components/compose-refs.ts' }],
+    registryDependencies: [],
+    dependencies: [],
   },
   {
     name: 'calendar-utils',


### PR DESCRIPTION

<!--
  Thanks for contributing to Hirael! Please give your PR a title in
  Conventional Commit format, e.g. `feat(multi-select): add async loader prop`.
  Keep the PR focused — one component, one fix, or one refactor.
-->

## Summary

<!-- What does this change and why? Link any related issue (e.g. Closes #123). -->

## Type of change

- [ ] New component / block / template (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Docs (`docs`)
- [ ] Refactor / internal (`refactor` / `chore`)
- [ ] Build / CI / tooling (`build` / `ci`)

## Checklist

- [ ] `pnpm lint && pnpm typecheck && pnpm registry:build && pnpm build` pass locally
- [ ] Edited `registry/hirael/registry-meta.ts` and ran `pnpm registry:gen` (never hand-edited `registry.json`)
- [ ] Registered a preview loader in `registry-demos.tsx` for any new showcased item
- [ ] Works under `dir="rtl"` (checked the preview RTL toggle) using CSS logical properties

## Test plan

<!-- How did you verify this? Add screenshots or short clips for any UI work. -->
